### PR TITLE
feat(entity): [GRGB-61] 도메인 베이스 엔티티 및 Enum 구조 설계

### DIFF
--- a/src/main/java/com/goormgb/be/global/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/goormgb/be/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/goormgb/be/global/entity/BaseEntity.java
+++ b/src/main/java/com/goormgb/be/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private OffsetDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at", nullable = false)
+	private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
+++ b/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
@@ -89,17 +89,18 @@ public class OnboardingPreference extends BaseEntity {
 	) {
 		this.user = user;
 		this.rank = rank;
-		this.viewpoint = viewpoint;
-		this.seatHeight = seatHeight;
-		this.section = section;
-		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
-		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
-		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
-		this.obstructionSensitivity =
-				obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
-		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
-		this.priceMin = priceMin;
-		this.priceMax = priceMax;
+		update(
+				viewpoint,
+				seatHeight,
+				section,
+				seatPositionPref,
+				environmentPref,
+				moodPref,
+				obstructionSensitivity,
+				priceMode,
+				priceMin,
+				priceMax
+		);
 	}
 
 	public void update(

--- a/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
+++ b/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
@@ -1,0 +1,129 @@
+package com.goormgb.be.onboarding.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.onboarding.enums.*;
+import com.goormgb.be.user.entity.User;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "onboarding_preferences", uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"user_id", "rank"}),
+		@UniqueConstraint(columnNames = {"user_id", "viewpoint"})
+}, indexes = {
+		@Index(name = "idx_onboarding_preferences_user_id", columnList = "user_id"),
+		@Index(name = "idx_onboarding_preferences_price_mode", columnList = "price_mode"),
+		@Index(name = "idx_onboarding_preferences_price_min", columnList = "price_min"),
+		@Index(name = "idx_onboarding_preferences_price_max", columnList = "price_max")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OnboardingPreference extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "rank", nullable = false)
+	private Integer rank;
+
+	// 필수 항목
+	@Enumerated(EnumType.STRING)
+	@Column(name = "viewpoint", nullable = false, length = 30)
+	private Viewpoint viewpoint;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "seat_height", nullable = false, length = 20)
+	private SeatHeight seatHeight;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "section", nullable = false, length = 20)
+	private Section section;
+
+	// 선택 항목 (기본값 ANY)
+	@Enumerated(EnumType.STRING)
+	@Column(name = "seat_position_pref", nullable = false, length = 20)
+	private SeatPositionPref seatPositionPref = SeatPositionPref.ANY;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "environment_pref", nullable = false, length = 20)
+	private EnvironmentPref environmentPref = EnvironmentPref.ANY;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "mood_pref", nullable = false, length = 20)
+	private MoodPref moodPref = MoodPref.ANY;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "obstruction_sensitivity", nullable = false, length = 30)
+	private ObstructionSensitivity obstructionSensitivity = ObstructionSensitivity.NORMAL;
+
+	// 가격
+	@Enumerated(EnumType.STRING)
+	@Column(name = "price_mode", nullable = false, length = 20)
+	private PriceMode priceMode = PriceMode.ANY;
+
+	@Column(name = "price_min")
+	private Integer priceMin;
+
+	@Column(name = "price_max")
+	private Integer priceMax;
+
+	@Builder
+	public OnboardingPreference(
+			User user,
+			Integer rank,
+			Viewpoint viewpoint,
+			SeatHeight seatHeight,
+			Section section,
+			SeatPositionPref seatPositionPref,
+			EnvironmentPref environmentPref,
+			MoodPref moodPref,
+			ObstructionSensitivity obstructionSensitivity,
+			PriceMode priceMode,
+			Integer priceMin,
+			Integer priceMax
+	) {
+		this.user = user;
+		this.rank = rank;
+		this.viewpoint = viewpoint;
+		this.seatHeight = seatHeight;
+		this.section = section;
+		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
+		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
+		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
+		this.obstructionSensitivity =
+				obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
+		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
+		this.priceMin = priceMin;
+		this.priceMax = priceMax;
+	}
+
+	public void update(
+			Viewpoint viewpoint,
+			SeatHeight seatHeight,
+			Section section,
+			SeatPositionPref seatPositionPref,
+			EnvironmentPref environmentPref,
+			MoodPref moodPref,
+			ObstructionSensitivity obstructionSensitivity,
+			PriceMode priceMode,
+			Integer priceMin,
+			Integer priceMax
+	) {
+		this.viewpoint = viewpoint;
+		this.seatHeight = seatHeight;
+		this.section = section;
+		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
+		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
+		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
+		this.obstructionSensitivity =
+				obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
+		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
+		this.priceMin = priceMin;
+		this.priceMax = priceMax;
+	}
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/EnvironmentPref.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/EnvironmentPref.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EnvironmentPref {
+    SHADE("그늘 선호"),
+    SUN_OK("햇빛 무관"),
+    ANY("무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/MoodPref.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/MoodPref.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MoodPref {
+    CHEERFUL("열정적인 응원"),
+    QUIET("조용한 관람"),
+    ANY("무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/ObstructionSensitivity.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/ObstructionSensitivity.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ObstructionSensitivity {
+    NET_SENSITIVE("안전망 민감"),
+    RAIL_PILLAR_SENSITIVE("난간/기둥 민감"),
+    NORMAL("보통"),
+    ANY("둔감/ 무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/PriceMode.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/PriceMode.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PriceMode {
+    ANY("무관"),
+    RANGE("범위 지정");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/SeatHeight.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/SeatHeight.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatHeight {
+    LOW("하단"),
+    MID("중단"),
+    HIGH("상단"),
+    ANY("무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/SeatPositionPref.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/SeatPositionPref.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatPositionPref {
+    AISLE("통로석 선호"),
+    MIDDLE("중앙석 선호"),
+    ANY("무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/Section.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/Section.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Section {
+    CENTER_SIDE("중앙 쪽"),
+    MIDDLE("중간"),
+    CORNER("코너(파울라인)"),
+    ANY("무관");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/onboarding/enums/Viewpoint.java
+++ b/src/main/java/com/goormgb/be/onboarding/enums/Viewpoint.java
@@ -1,0 +1,17 @@
+package com.goormgb.be.onboarding.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Viewpoint {
+    CENTER("중앙"),
+    INFIELD_1B("1루 내야"),
+    INFIELD_3B("3루 내야"),
+    OUTFIELD_L("외야(좌)"),
+    OUTFIELD_C("외야 (중)"),
+    OUTFIELD_R("외야 (우)");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/user/entity/DevUser.java
+++ b/src/main/java/com/goormgb/be/user/entity/DevUser.java
@@ -1,0 +1,33 @@
+package com.goormgb.be.user.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "dev_users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DevUser extends BaseEntity {
+
+	@Column(name = "login_id", nullable = false, unique = true, length = 50)
+	private String loginId;
+
+	@Column(name = "password_hash", nullable = false, length = 255)
+	private String passwordHash;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
+	private User user;
+
+	@Builder
+	public DevUser(String loginId, String passwordHash, User user) {
+		this.loginId = loginId;
+		this.passwordHash = passwordHash;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/src/main/java/com/goormgb/be/user/entity/User.java
@@ -1,0 +1,77 @@
+package com.goormgb.be.user.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.user.enums.UserStatus;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private UserStatus status = UserStatus.ACTIVATE;
+
+	@Column(name = "email", length = 255)
+	private String email;
+
+	@Column(name = "nickname", length = 100)
+	private String nickname;
+
+	@Column(name = "onboarding_completed", nullable = false)
+	private Boolean onboardingCompleted = false;
+
+	@Column(name = "onboarding_completed_at")
+	private OffsetDateTime onboardingCompletedAt;
+
+	@Column(name = "last_login_at")
+	private OffsetDateTime lastLoginAt;
+
+	@Column(name = "marketing_consent", nullable = false)
+	private Boolean marketingConsent = false;
+
+	@Column(name = "marketing_consented_at")
+	private OffsetDateTime marketingConsentedAt;
+
+	@Builder
+	public User(String email, String nickname) {
+		this.email = email;
+		this.nickname = nickname;
+		this.status = UserStatus.ACTIVATE;
+		this.onboardingCompleted = false;
+		this.marketingConsent = false;
+	}
+
+	public void completeOnboarding() {
+		this.onboardingCompleted = true;
+		this.onboardingCompletedAt = OffsetDateTime.now();
+	}
+
+	public void updateLastLoginAt() {
+		this.lastLoginAt = OffsetDateTime.now();
+	}
+
+	public void updateMarketingConsent(boolean consent) {
+		this.marketingConsent = consent;
+		if (consent) {
+			this.marketingConsentedAt = OffsetDateTime.now();
+		}
+	}
+
+	public void deactivate() {
+		this.status = UserStatus.DEACTIVATE;
+	}
+
+	public void activate() {
+		this.status = UserStatus.ACTIVATE;
+	}
+}

--- a/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/src/main/java/com/goormgb/be/user/entity/User.java
@@ -46,7 +46,6 @@ public class User extends BaseEntity {
 	public User(String email, String nickname) {
 		this.email = email;
 		this.nickname = nickname;
-		this.status = UserStatus.ACTIVATE;
 		this.onboardingCompleted = false;
 		this.marketingConsent = false;
 	}

--- a/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -25,7 +25,7 @@ public class UserSns extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "provider", nullable = false, length = 20)
-	private SocialProvider provider = SocialProvider.KAKAO;
+	private SocialProvider provider;
 
 	@Column(name = "provider_user_id", nullable = false, length = 128)
 	private String providerUserId;

--- a/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -1,0 +1,39 @@
+package com.goormgb.be.user.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.user.enums.SocialProvider;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_sns", uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"provider", "provider_user_id"})
+}, indexes = {
+		@Index(name = "idx_user_sns_user_id", columnList = "user_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSns extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "provider", nullable = false, length = 20)
+	private SocialProvider provider = SocialProvider.KAKAO;
+
+	@Column(name = "provider_user_id", nullable = false, length = 128)
+	private String providerUserId;
+
+	@Builder
+	public UserSns(User user, SocialProvider provider, String providerUserId) {
+		this.user = user;
+		this.provider = provider != null ? provider : SocialProvider.KAKAO;
+		this.providerUserId = providerUserId;
+	}
+}

--- a/src/main/java/com/goormgb/be/user/entity/WithdrawalRequest.java
+++ b/src/main/java/com/goormgb/be/user/entity/WithdrawalRequest.java
@@ -1,0 +1,68 @@
+package com.goormgb.be.user.entity;
+
+import com.goormgb.be.user.enums.WithdrawStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "withdrawal_requests", indexes = {
+        @Index(name = "idx_withdrawal_requests_effective_at", columnList = "effective_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WithdrawalRequest {
+
+    private static final int GRACE_PERIOD_DAYS = 30;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "requested_at", nullable = false)
+    private OffsetDateTime requestedAt;
+
+    @Column(name = "effective_at", nullable = false)
+    private OffsetDateTime effectiveAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private WithdrawStatus status = WithdrawStatus.REQUESTED;
+
+    @Column(name = "cancelled_at")
+    private OffsetDateTime cancelledAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    @Builder
+    public WithdrawalRequest(User user) {
+        this.user = user;
+        this.requestedAt = OffsetDateTime.now();
+        this.effectiveAt = this.requestedAt.plusDays(GRACE_PERIOD_DAYS);
+        this.status = WithdrawStatus.REQUESTED;
+    }
+
+    // public void cancel() {
+	// 	// 우리 서비스에서 탈퇴 취소는 없음.
+    //     this.status = WithdrawStatus.CANCELLED;
+    //     this.cancelledAt = OffsetDateTime.now();
+    // }
+
+    public boolean isExpired() {
+        return OffsetDateTime.now().isAfter(this.effectiveAt);
+    }
+}

--- a/src/main/java/com/goormgb/be/user/enums/SocialProvider.java
+++ b/src/main/java/com/goormgb/be/user/enums/SocialProvider.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialProvider {
+    KAKAO("카카오");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/user/enums/UserStatus.java
+++ b/src/main/java/com/goormgb/be/user/enums/UserStatus.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserStatus {
+	ACTIVATE("활성"),
+    DEACTIVATE("비활성");
+
+    private final String description;
+}

--- a/src/main/java/com/goormgb/be/user/enums/WithdrawStatus.java
+++ b/src/main/java/com/goormgb/be/user/enums/WithdrawStatus.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithdrawStatus {
+    REQUESTED("탈퇴 요청");
+    // CANCELLED("요청 취소"); // 우리 서비스에서 탈퇴 취소 요청은 없음
+
+    private final String description;
+}


### PR DESCRIPTION
## 🔧 작업 내용
- 도메인별 협업을 위한 베이스 엔티티 구조 설계
- User, Onboarding 도메인 엔티티 및 Enum 정의
- 프로젝트 초기 패키지 구조 정리 (demo 패키지 삭제)

## 🧩 구현 상세
- **BaseEntity**: id, createdAt, updatedAt 공통 필드 정의 (JPA Auditing 적용)
- **User 도메인**
  - User, UserSns, WithdrawalRequest, DevUser 엔티티
  - UserStatus, SocialProvider, WithdrawStatus Enum
- **Onboarding 도메인**
  - OnboardingPreference 엔티티 (1~3순위 선호 좌석)
  - Viewpoint, SeatHeight, Section, SeatPositionPref 등 8개 Enum
- 모든 Enum에 한글 description 추가

### 📌 관련 Jira Issue
- GRGB-61

## ❗ 참고 사항
- JWT, OAuth, 온보딩 담당자가 각자 도메인 작업 시 해당 엔티티 기반으로 개발 진행                                                                 
- WithdrawalRequest는 updated_at이 없어 BaseEntity 미상속 (DB 설계 반영)