### PR TITLE
refactor(entity): 시간 타입 UTC 기준으로 통일

### DIFF
--- a/src/main/java/com/goormgb/be/global/entity/BaseEntity.java
+++ b/src/main/java/com/goormgb/be/global/entity/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -24,9 +24,9 @@ public abstract class BaseEntity {
 
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
-	private OffsetDateTime createdAt;
+	protected LocalDateTime createdAt;
 
 	@LastModifiedDate
 	@Column(name = "updated_at", nullable = false)
-	private OffsetDateTime updatedAt;
+	protected LocalDateTime updatedAt;
 }

--- a/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/src/main/java/com/goormgb/be/user/entity/User.java
@@ -9,7 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 @Entity
 @Table(name = "users")
@@ -31,16 +32,16 @@ public class User extends BaseEntity {
 	private Boolean onboardingCompleted = false;
 
 	@Column(name = "onboarding_completed_at")
-	private OffsetDateTime onboardingCompletedAt;
+	private LocalDateTime onboardingCompletedAt;
 
 	@Column(name = "last_login_at")
-	private OffsetDateTime lastLoginAt;
+	private LocalDateTime lastLoginAt;
 
 	@Column(name = "marketing_consent", nullable = false)
 	private Boolean marketingConsent = false;
 
 	@Column(name = "marketing_consented_at")
-	private OffsetDateTime marketingConsentedAt;
+	private LocalDateTime marketingConsentedAt;
 
 	@Builder
 	public User(String email, String nickname) {
@@ -52,17 +53,17 @@ public class User extends BaseEntity {
 
 	public void completeOnboarding() {
 		this.onboardingCompleted = true;
-		this.onboardingCompletedAt = OffsetDateTime.now();
+		this.onboardingCompletedAt = LocalDateTime.now(ZoneOffset.UTC);
 	}
 
 	public void updateLastLoginAt() {
-		this.lastLoginAt = OffsetDateTime.now();
+		this.lastLoginAt = LocalDateTime.now(ZoneOffset.UTC);
 	}
 
 	public void updateMarketingConsent(boolean consent) {
 		this.marketingConsent = consent;
 		if (consent) {
-			this.marketingConsentedAt = OffsetDateTime.now();
+			this.marketingConsentedAt = LocalDateTime.now(ZoneOffset.UTC);
 		}
 	}
 

--- a/src/main/java/com/goormgb/be/user/entity/WithdrawalRequest.java
+++ b/src/main/java/com/goormgb/be/user/entity/WithdrawalRequest.java
@@ -7,7 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 @Entity
 @Table(name = "withdrawal_requests", indexes = {
@@ -28,30 +29,30 @@ public class WithdrawalRequest {
     private User user;
 
     @Column(name = "requested_at", nullable = false)
-    private OffsetDateTime requestedAt;
+    private LocalDateTime requestedAt;
 
     @Column(name = "effective_at", nullable = false)
-    private OffsetDateTime effectiveAt;
+    private LocalDateTime effectiveAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private WithdrawStatus status = WithdrawStatus.REQUESTED;
 
     @Column(name = "cancelled_at")
-    private OffsetDateTime cancelledAt;
+    private LocalDateTime cancelledAt;
 
     @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = OffsetDateTime.now();
+        this.createdAt = LocalDateTime.now(ZoneOffset.UTC);
     }
 
     @Builder
     public WithdrawalRequest(User user) {
         this.user = user;
-        this.requestedAt = OffsetDateTime.now();
+        this.requestedAt = LocalDateTime.now(ZoneOffset.UTC);
         this.effectiveAt = this.requestedAt.plusDays(GRACE_PERIOD_DAYS);
         this.status = WithdrawStatus.REQUESTED;
     }
@@ -59,10 +60,10 @@ public class WithdrawalRequest {
     // public void cancel() {
 	// 	// 우리 서비스에서 탈퇴 취소는 없음.
     //     this.status = WithdrawStatus.CANCELLED;
-    //     this.cancelledAt = OffsetDateTime.now();
+    //     this.cancelledAt = LocalDateTime.now(ZoneOffset.UTC);
     // }
 
     public boolean isExpired() {
-        return OffsetDateTime.now().isAfter(this.effectiveAt);
+        return LocalDateTime.now(ZoneOffset.UTC).isAfter(this.effectiveAt);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: goormgb
+  jackson:
+    time-zone: UTC
+    data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
     url: jdbc:postgresql://localhost:5432/goormgb
@@ -9,9 +12,12 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
+    properties:
+      hibernate:
+        ddl-auto: update
+        jdbc:
+          time-zone: UTC
+      show-sql: true
 
   data:
     redis:


### PR DESCRIPTION
## 🔧 작업 내용
- 엔티티 시간 필드를 UTC 기준으로 통일
- application.yaml에 Jackson/Hibernate UTC 시간대 설정 추가

## 🧩 구현 상세
- `LocalDateTime.now()` → `LocalDateTime.now(ZoneOffset.UTC)` 변경
- Jackson time-zone: UTC 설정
- Hibernate jdbc.time-zone: UTC 설정

### 📌 관련 Jira Issue
- GRGB-61

## ❗ 참고 사항
- DB/API 응답 모두 UTC 기준으로 저장/반환