### PR TITLE
feat(global): GRGB-67 공통 예외 처리 및 응답 구조

### DIFF
--- a/src/main/java/com/goormgb/be/global/exception/CustomException.java
+++ b/src/main/java/com/goormgb/be/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.goormgb.be.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 백엔드팀에 문의하세요."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+    USER_DEACTIVATED(HttpStatus.FORBIDDEN, "비활성화된 사용자입니다."),
+
+    // Onboarding
+    ONBOARDING_NOT_COMPLETED(HttpStatus.FORBIDDEN, "온보딩이 완료되지 않았습니다."),
+    ONBOARDING_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 온보딩이 완료되었습니다."),
+    INVALID_PREFERENCE_RANK(HttpStatus.BAD_REQUEST, "선호 순위는 1~3이어야 합니다."),
+    DUPLICATE_VIEWPOINT(HttpStatus.BAD_REQUEST, "동일한 시야로 여러 순위를 등록할 수 없습니다."),
+
+    // Auth
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/goormgb/be/global/exception/ExceptionHandler.java
+++ b/src/main/java/com/goormgb/be/global/exception/ExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.goormgb.be.global.exception;
+
+import java.util.Arrays;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.goormgb.be.global.response.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse.ErrorData> handleException(Exception e) {
+        log.error(e.getMessage(), e);
+        return ErrorResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 백엔드팀에 문의하세요.");
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse.ErrorData> handleCustomException(CustomException e) {
+        return ErrorResponse.error(e.getErrorCode().getStatus(), e.getErrorCode().getMessage());
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse.ErrorData> handleValidationException(MethodArgumentNotValidException e) {
+        var details = Arrays.toString(e.getDetailMessageArguments());
+        var message = details.split(",", 2)[1].replace("]", "").trim();
+        return ErrorResponse.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ErrorResponse.ErrorData> handleAuthorizationDenied(AuthorizationDeniedException e) {
+        return ErrorResponse.error(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.goormgb.be.global.response.ErrorResponse;
 
@@ -14,27 +15,27 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
-public class ExceptionHandler {
+public class GlobalExceptionHandler {
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(Exception.class)
+    @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse.ErrorData> handleException(Exception e) {
         log.error(e.getMessage(), e);
         return ErrorResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 백엔드팀에 문의하세요.");
     }
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(CustomException.class)
+    @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse.ErrorData> handleCustomException(CustomException e) {
         return ErrorResponse.error(e.getErrorCode().getStatus(), e.getErrorCode().getMessage());
     }
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse.ErrorData> handleValidationException(MethodArgumentNotValidException e) {
         var details = Arrays.toString(e.getDetailMessageArguments());
         var message = details.split(",", 2)[1].replace("]", "").trim();
         return ErrorResponse.error(HttpStatus.BAD_REQUEST, message);
     }
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(AuthorizationDeniedException.class)
+    @ExceptionHandler(AuthorizationDeniedException.class)
     public ResponseEntity<ErrorResponse.ErrorData> handleAuthorizationDenied(AuthorizationDeniedException e) {
         return ErrorResponse.error(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
     }

--- a/src/main/java/com/goormgb/be/global/request/Paging.java
+++ b/src/main/java/com/goormgb/be/global/request/Paging.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.global.request;
+
+import org.springframework.data.domain.PageRequest;
+
+public record Paging(
+		// TODO: 페이징 정렬기능 나중에 추가해도 될듯? 작업자:seulgi
+    Integer page,
+    Integer size
+) {
+    public Paging {
+        if (page == null || page < 1) {
+            page = 1;
+        }
+        if (size == null || size < 1) {
+            size = 10;
+        }
+    }
+
+    public PageRequest toPageable() {
+        return PageRequest.of(page - 1, size);
+    }
+}

--- a/src/main/java/com/goormgb/be/global/response/ApiResult.java
+++ b/src/main/java/com/goormgb/be/global/response/ApiResult.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResult<T> {
+	private String code;
+	private String message;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private T data;
+
+	public static ApiResult<Void> ok() {
+		return of("OK", "성공", null);
+	}
+
+	public static <T> ApiResult<T> ok(T data) {
+		return of("OK", "성공", data);
+	}
+
+	public static <T> ApiResult<T> ok(String message, T data) {
+		return of("OK", message, data);
+	}
+
+	private static <T> ApiResult<T> of(String code, String message, T data) {
+		return new ApiResult<>(code, message, data);
+	}
+}

--- a/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
+++ b/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.goormgb.be.global.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private HttpStatus status;
+    private String message;
+
+    public static ResponseEntity<ErrorData> error(HttpStatus status, String message) {
+        return ResponseEntity.status(status).body(ErrorData.of(status.series().name(), message));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ErrorData {
+        private String code;
+        private String message;
+
+        public static ErrorData of(String code, String message) {
+            return new ErrorData(code, message);
+        }
+    }
+}

--- a/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
+++ b/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
@@ -3,6 +3,8 @@ package com.goormgb.be.global.response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.goormgb.be.global.exception.ErrorCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,6 +16,10 @@ public class ErrorResponse {
 
     public static ResponseEntity<ErrorData> error(HttpStatus status, String message) {
         return ResponseEntity.status(status).body(ErrorData.of(status.series().name(), message));
+    }
+
+    public static ResponseEntity<ErrorData> error(ErrorCode errorCode) {
+        return error(errorCode.getStatus(), errorCode.getMessage());
     }
 
     @Getter

--- a/src/main/java/com/goormgb/be/global/support/Preconditions.java
+++ b/src/main/java/com/goormgb/be/global/support/Preconditions.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.global.support;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+
+public class Preconditions {
+
+	public static void validate(boolean expression, ErrorCode errorCode) {
+		if (!expression) {
+			throw new CustomException(errorCode);
+		}
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,12 +12,13 @@ spring:
     driver-class-name: org.postgresql.Driver
 
   jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
     properties:
       hibernate:
-        ddl-auto: update
         jdbc:
           time-zone: UTC
-      show-sql: true
 
   data:
     redis:


### PR DESCRIPTION
## 🔧 작업 내용
- 전역 예외 처리 구조 설계 및 구현
- API 응답 표준화 (ApiResult, ErrorResponse)
- 공통 유틸리티 클래스 추가

## 🧩 구현 상세
- **exception**
  - `ErrorCode`: 도메인별 에러 코드 enum 정의
  - `CustomException`: 커스텀 예외 클래스
  - `ExceptionHandler`: 전역 예외 처리 (@RestControllerAdvice)
- **response**
  - `ApiResult<T>`: 성공 응답 표준화 (code, message, data)
  - `ErrorResponse`: 에러 응답 표준화
- **request**
  - `Paging`: 페이지네이션 요청 처리
- **support**
  - `Preconditions`: 검증 유틸 (validate 메서드)
- **config**
  - application.yaml JPA 설정 위치 수정 (show-sql, ddl-auto)

### 📌 관련 Jira Issue
- GRGB-67

## ❗ 참고 사항
- 각 도메인 개발 시 ErrorCode에 에러 코드 추가하여 사용. 기본 ErrorCode 세팅해두었으나, 구현 상황에 따라 수정하시어 사용하셔도 됩니다
- API 응답은 `ApiResult.ok(data)` 형태로 통일

fixes: #4 