### PR TITLE
feat(onboarding): 온보딩 도메인

### DIFF
--- a/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
+++ b/src/main/java/com/goormgb/be/onboarding/entity/OnboardingPreference.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "onboarding_preferences", uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"user_id", "rank"}),
+		@UniqueConstraint(columnNames = {"user_id", "priority"}),
 		@UniqueConstraint(columnNames = {"user_id", "viewpoint"})
 }, indexes = {
 		@Index(name = "idx_onboarding_preferences_user_id", columnList = "user_id"),
@@ -28,8 +28,8 @@ public class OnboardingPreference extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(name = "rank", nullable = false)
-	private Integer rank;
+	@Column(name = "priority", nullable = false)
+	private Integer priority;
 
 	// 필수 항목
 	@Enumerated(EnumType.STRING)
@@ -75,7 +75,7 @@ public class OnboardingPreference extends BaseEntity {
 	@Builder
 	public OnboardingPreference(
 			User user,
-			Integer rank,
+			Integer priority,
 			Viewpoint viewpoint,
 			SeatHeight seatHeight,
 			Section section,
@@ -88,7 +88,7 @@ public class OnboardingPreference extends BaseEntity {
 			Integer priceMax
 	) {
 		this.user = user;
-		this.rank = rank;
+		this.priority = priority;
 		update(
 				viewpoint,
 				seatHeight,

--- a/src/main/java/com/goormgb/be/onboarding/repository/OnboardingPreferenceRepository.java
+++ b/src/main/java/com/goormgb/be/onboarding/repository/OnboardingPreferenceRepository.java
@@ -1,0 +1,29 @@
+package com.goormgb.be.onboarding.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.onboarding.enums.Viewpoint;
+
+public interface OnboardingPreferenceRepository extends JpaRepository<OnboardingPreference, Long> {
+	List<OnboardingPreference> findAllByUserId(Long userId);
+
+	List<OnboardingPreference> findAllByUserIdOrderByPriorityAsc(Long userId);
+
+	Optional<OnboardingPreference> findByUserIdAndPriority(Long userId, Integer priority);
+
+	Optional<OnboardingPreference> findByUserIdAndViewpoint(Long userId, Viewpoint viewpoint);
+
+	boolean existsByUserIdAndPriority(Long userId, Integer priority);
+
+	boolean existsByUserIdAndViewpoint(Long userId, Viewpoint viewpoint);
+
+	default OnboardingPreference findByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- `Onboarding`의 `entity` 수정
- `Onboarding`의 `reposirity` 생성


## 🧩 구현 상세 (선택)
**entity**
- `rank` 컬럼을 `priority`로 변경했습니다.
- `GPT`의 의견으로 컬럼 이름을 `rank`로 하면 `sql`의 `rank()` 함수와 혼동될 수 있다고 합니다.


**repository**
- `repository`에서 기본적으로 들어가야될 것 같은 내용만 작성했습니다.


## 📌 관련 Jira Issue
- GRGB-55


## ❗ 참고 사항
- PR 단위를 도메인, service, api로 나눠본건 처음이라 도메인 작업에 어디까지 해야될지가 고민입니다.
- 저는 entity, repository로 생각했습니다.