### PR TITLE
refactor(login-domain): 카카오 OAuth 자잘한 수정들

### DIFF
--- a/src/main/java/com/goormgb/be/GoormgbApplication.java
+++ b/src/main/java/com/goormgb/be/GoormgbApplication.java
@@ -2,8 +2,10 @@ package com.goormgb.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class GoormgbApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/goormgb/be/auth/kakao/client/KakaoOAuthClient.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/client/KakaoOAuthClient.java
@@ -14,11 +14,10 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.Map;
 
 
 /**
-  * 카카오 OAuth 서버와 통신만 담당
+ * 카카오 OAuth 서버와 통신만 담당
  * 인가 코드 → Access Token
  * Access Token → 사용자 정보
  */
@@ -44,7 +43,7 @@ public class KakaoOAuthClient {
     }
 
     /**
-     * 2.인가 코드 → 카카오 Access Token 요청
+     * 2. 인가 코드 → 카카오 Access Token 요청
      *
      * @param authorizationCode 카카오 로그인 성공 후 받은 code
      * @return 카카오 Access Token
@@ -63,16 +62,14 @@ public class KakaoOAuthClient {
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-        KakaoTokenResponse response = restTemplate.postForObject(
+        return restTemplate.postForObject(
                 properties.getTokenUrl(),
                 request,
                 KakaoTokenResponse.class);
-
-        return response;
     }
 
     /**
-     * 3.카카오 Access Token으로 사용자 정보 조회
+     * 3. 카카오 Access Token으로 사용자 정보 조회
      *
      * id (카카오 고유 ID)
      * profile_nickname
@@ -83,11 +80,11 @@ public class KakaoOAuthClient {
         headers.setBearerAuth(accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<Void> requset = new HttpEntity<>(headers);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
         return restTemplate.postForObject(
                 properties.getUserInfoUrl(),
-                requset,
+                request,
                 KakaoUserResponse.class
         );
 

--- a/src/main/java/com/goormgb/be/auth/kakao/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/config/KakaoOAuthProperties.java
@@ -2,13 +2,10 @@ package com.goormgb.be.auth.kakao.config;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 @Getter
 @RequiredArgsConstructor
-@Configuration
 @ConfigurationProperties(prefix = "kakao")
 public class KakaoOAuthProperties {
     private final String clientId;

--- a/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoUserResponse.java
@@ -28,7 +28,7 @@ public class KakaoUserResponse {
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class KakaoAccount {
+    static class KakaoAccount {
         private String email;
         private Profile profile;
     }
@@ -36,7 +36,7 @@ public class KakaoUserResponse {
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class Profile {
+    static class Profile {
         private String nickname;
     }
 
@@ -45,7 +45,7 @@ public class KakaoUserResponse {
     }
 
     public String getNickname() {
-        return java.util.Optional.ofNullable(kakaoAccount) // 1단계: 계정 확인
+        return Optional.ofNullable(kakaoAccount)         // 1단계: 계정 확인
                 .map(KakaoAccount::getProfile)           // 2단계: 프로필 확인
                 .map(Profile::getNickname)               // 3단계: 닉네임 확인
                 .orElse(null);


### PR DESCRIPTION
## 🔧 작업 내용
- #13 카카오 OAuth PR 코드 리뷰 반영
- `@Configuration` + 생성자 바인딩 충돌, Jackson 역직렬화 접근 제한 이슈 해결
- 오타 및 코드 스타일 정리

## 🧩 구현 상세 (선택)
- **KakaoOAuthProperties**: `@Configuration` 제거, `@ConfigurationPropertiesScan`으로 변경 (CGLIB 프록시와 final 필드 생성자 바인딩 충돌 해결)
- **KakaoUserResponse**: `private static` 내부 클래스를 package-private으로 변경 (Jackson 역직렬화 호환)
- **KakaoOAuthClient**: 미사용 import 제거, Javadoc 오타 수정, 불필요한 지역변수 제거                                                           
- **KakaoUserResponse**: FQCN 대신 import된 Optional 사용으로 통일

### 📌 관련 PR 
 #13 

## ❗ 참고 사항
- 기능 변경 없이 리팩터링만 진행했습니당