### PR TITLE
feat(auth): 토큰 재발급 API 엔드포인트 및 CookieUtils 개선

### DIFF
--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.goormgb.be.auth.controller;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.auth.dto.TokenRefreshResponse;
+import com.goormgb.be.auth.service.AuthService;
+import com.goormgb.be.auth.util.CookieUtils;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.response.ApiResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final CookieUtils cookieUtils;
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급합니다.")
+    @PostMapping("/token/refresh")
+    public ResponseEntity<ApiResult<TokenRefreshResponse>> refresh(HttpServletRequest request) {
+        // 1. Cookie에서 Refresh Token 추출
+        String refreshToken = cookieUtils.extractRefreshToken(request);
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // 2. 토큰 재발급
+        AuthService.TokenRefreshResult result = authService.refresh(refreshToken, request);
+
+        // 3. 새 Refresh Token을 HttpOnly Cookie로 설정
+        String cookie = cookieUtils.createRefreshTokenCookie(result.refreshToken()).toString();
+
+        // 4. 응답
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie)
+                .body(ApiResult.ok("토큰 재발급 성공", TokenRefreshResponse.of(result.accessToken())));
+    }
+}

--- a/src/main/java/com/goormgb/be/auth/util/CookieUtils.java
+++ b/src/main/java/com/goormgb/be/auth/util/CookieUtils.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
 
 import com.goormgb.be.auth.config.JwtProperties;
 
@@ -51,16 +52,7 @@ public class CookieUtils {
 	 * Request에서 Refresh Token 추출 (API 요청 시)
 	 */
 	public String extractRefreshToken(HttpServletRequest request) {
-		Cookie[] cookies = request.getCookies();
-		if (cookies == null) {
-			return null;
-		}
-
-		for (Cookie cookie : cookies) {
-			if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-				return cookie.getValue();
-			}
-		}
-		return null;
+		Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
+		return cookie != null ? cookie.getValue() : null;
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 토큰 재발급 API 엔드포인트 구현 (POST /auth/token/refresh)
 - CookieUtils에서 Spring WebUtils 활용으로 코드 간소화

## 🧩 구현 상세
- Cookie에서 Refresh Token 추출 → AuthService로 재발급 처리
- 새 Access Token은 응답 Body, 새 Refresh Token은 HttpOnly Cookie로 전달
- WebUtils.getCookie() 사용하여 쿠키 추출 로직 단순화

### 📌 관련 Jira Issue
- GRGB-124: [BE] 토큰 재발급 API 구현

## ❗ 참고 사항
- RTR(Refresh Token Rotation) 적용됨

- CookieUtils 에서 Spring 프레임워크의 WebUtils를 사용하여 코드 간소화를 했습니다!
_사실 refactor와 pr 을 따로 올렸어야 하지만, 수정된 부분이 적어서 같이 올립니닷..._
#### **WebUtils는 Spring이 제공하는 웹 관련 유틸리티 클래스**입니다.
**자주 쓰는 메서드**
```java
// 쿠키 조회
Cookie cookie = WebUtils.getCookie(request, "cookieName");
// 세션 속성 조회
Object attr = WebUtils.getSessionAttribute(request, "attrName");
// 요청 URI 조회
String uri = WebUtils.getRequestUri(request);
```
직접 for문 돌리거나 null 체크하는 보일러플레이트 코드를 줄여주는 헬퍼입니다!!!
`org.springframework.web.util` 패키지에 있고, Spring MVC 쓰면 기본으로 포함되어 있습니다~!