### PR TITLE
GRGB-53 [BE] OAuth 카카오 로그인 Service

### DIFF
--- a/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoLoginResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class KakaoLoginResponse {
 
     private String accessToken;
+    private String refreshToken;
     private UserInfo user;
     private boolean onboardingRequired;
 
@@ -24,6 +25,7 @@ public class KakaoLoginResponse {
 
     public static KakaoLoginResponse of(
             String accessToken,
+            String refreshToken,
             User user
     ) {
         return KakaoLoginResponse.builder()

--- a/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/dto/KakaoLoginResponse.java
@@ -1,0 +1,40 @@
+package com.goormgb.be.auth.kakao.dto;
+
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.enums.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoLoginResponse {
+
+    private String accessToken;
+    private UserInfo user;
+    private boolean onboardingRequired;
+
+    @Getter
+    @Builder
+    public static class UserInfo {
+        private Long userId;
+        private String email;
+        private String nickname;
+        private UserStatus status;
+    }
+
+    public static KakaoLoginResponse of(
+            String accessToken,
+            User user
+    ) {
+        return KakaoLoginResponse.builder()
+                .accessToken(accessToken)
+                .user(UserInfo.builder()
+                        .userId(user.getId())
+                        .email(user.getEmail())
+                        .nickname(user.getNickname())
+                        .status(user.getStatus())
+                        .build())
+                .onboardingRequired(!user.getOnboardingCompleted())
+                .build();
+    }
+}

--- a/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
@@ -7,6 +7,7 @@ import com.goormgb.be.auth.kakao.dto.KakaoUserResponse;
 import com.goormgb.be.auth.provider.JwtTokenProvider;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.enums.SocialProvider;
@@ -51,16 +52,17 @@ public class KakaoAuthService {
                 .orElseGet(() -> signUp(email, nickname, providerUserId));
 
         // 4. 상태 체크
-        if (user.getStatus() == UserStatus.DEACTIVATE) {
-            throw new CustomException(ErrorCode.USER_DEACTIVATED);
-        }
+        Preconditions.validate(
+                user.getStatus() != UserStatus.DEACTIVATE,
+                ErrorCode.USER_DEACTIVATED
+        );
 
         // 5. 로그인 처리
         user.updateLastLoginAt();
 
         // 6. JWT 발급
         String accessToken =
-                jwtTokenProvider.createAccessToken(user.getId(), authorizationCode);
+                jwtTokenProvider.createAccessToken(user.getId(), "ROLE_USER");
 
         String refreshToken =
                 jwtTokenProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -30,6 +32,10 @@ public class KakaoAuthService {
 
         // 1. authorizationCode → 카카오 Access Token 요청
         KakaoTokenResponse kakaoAccessToken = kakaoOAuthClient.requestAccessToken(authorizationCode);
+
+        Optional.ofNullable(kakaoAccessToken)
+                .filter(token -> token.getAccessToken() != null)
+                .orElseThrow(() -> new CustomException(ErrorCode.OAUTH_TOKEN_REQUEST_FAILED));
 
         // 2. 카카오 사용자 정보 조회
         KakaoUserResponse userResponse = kakaoOAuthClient.requestUserInfo(kakaoAccessToken.getAccessToken());

--- a/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/goormgb/be/auth/kakao/service/KakaoAuthService.java
@@ -1,0 +1,88 @@
+package com.goormgb.be.auth.kakao.service;
+
+import com.goormgb.be.auth.kakao.client.KakaoOAuthClient;
+import com.goormgb.be.auth.kakao.dto.KakaoLoginResponse;
+import com.goormgb.be.auth.kakao.dto.KakaoTokenResponse;
+import com.goormgb.be.auth.kakao.dto.KakaoUserResponse;
+import com.goormgb.be.auth.provider.JwtTokenProvider;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.entity.UserSns;
+import com.goormgb.be.user.enums.SocialProvider;
+import com.goormgb.be.user.enums.UserStatus;
+import com.goormgb.be.user.repository.UserRepository;
+import com.goormgb.be.user.repository.UserSnsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoAuthService {
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final UserSnsRepository userSnsRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public KakaoLoginResponse kakaoLogin(String authorizationCode){
+
+        // 1. authorizationCode → 카카오 Access Token 요청
+        KakaoTokenResponse kakaoAccessToken = kakaoOAuthClient.requestAccessToken(authorizationCode);
+
+        // 2. 카카오 사용자 정보 조회
+        KakaoUserResponse userResponse = kakaoOAuthClient.requestUserInfo(kakaoAccessToken.getAccessToken());
+        String providerUserId = String.valueOf(userResponse.getId());
+        String email = userResponse.getEmail();
+        String nickname = userResponse.getNickname();
+
+        // 3. user_sns 기준으로 기존 사용자 조회
+        User user = userSnsRepository.findByProviderAndProviderUserId(
+                SocialProvider.KAKAO,
+                providerUserId
+        ).map(UserSns::getUser)
+                .orElseGet(() -> signUp(email, nickname, providerUserId));
+
+        // 4. 상태 체크
+        if (user.getStatus() == UserStatus.DEACTIVATE) {
+            throw new CustomException(ErrorCode.USER_DEACTIVATED);
+        }
+
+        // 5. 로그인 처리
+        user.updateLastLoginAt();
+
+        // 6. JWT 발급
+        String accessToken =
+                jwtTokenProvider.createAccessToken(user.getId(), authorizationCode);
+
+        String refreshToken =
+                jwtTokenProvider.createRefreshToken(user.getId());
+
+        // refreshToken 을 redis 에 저장을 여기서 해야하는지?
+
+        return KakaoLoginResponse.of(accessToken, user);
+
+    }
+
+    /**
+     * 신규 사용자 회원가입 처리
+     */
+    private User signUp(
+            String email,
+            String nickname,
+            String providerUserId
+    ) {
+        User user = User.createOAuthUser(email, nickname);
+        userRepository.save(user);
+
+        UserSns userSns = UserSns.create(
+                user,
+                SocialProvider.KAKAO,
+                providerUserId
+        );
+        userSnsRepository.save(userSns);
+
+        return user;
+    }
+}

--- a/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token이 존재하지 않거나 만료, 유효하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "잘못된 토큰 타입입니다."),
+    OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
+++ b/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
@@ -1,0 +1,30 @@
+package com.goormgb.be.user.repository;
+
+import com.goormgb.be.user.entity.UserSns;
+import com.goormgb.be.user.enums.SocialProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+public interface UserSnsRepository extends JpaRepository<UserSns, Long> {
+    /**
+     * OAuth 로그인 핵심 조회 메서드
+     *
+     * provider (KAKAO)
+     * providerUserId (카카오 고유 ID)
+     *
+     * → 기존 회원인지 판단하는 기준
+     */
+    Optional<UserSns> findByProviderAndProviderUserId(
+            SocialProvider provider,
+            String providerUserId
+    );
+
+    /**
+     * 특정 유저에 연결된 소셜 계정 조회
+     * (나중에 마이페이지, 연동 해제 등에 사용 가능)
+     */
+    Optional<UserSns> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
+++ b/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
@@ -3,8 +3,6 @@ package com.goormgb.be.user.repository;
 import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.enums.SocialProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface UserSnsRepository extends JpaRepository<UserSns, Long> {


### PR DESCRIPTION
- Service 구현
- 로그인 repository, dto 추가

## 🔧 작업 내용
카카오 OAuth 로그인 서비스 로직 구현
인가 코드를 이용한 토큰 발급부터 사용자 정보 조회, 서비스 로그인까지의 전체 플로우를 구현했습니다.

Optional 기반 예외 처리

정적 팩토리 메서드 및 빌더 패턴

## 🧩 구현 상세
안전한 토큰 검증: Optional.ofNullable().filter()를 사용하여 카카오로부터 받은 토큰 응답 객체와 실제 Access Token의 존재 여부를 동시에 검증합니다.

사용자 식별 로직: 카카오에서 제공하는 id를 provider_user_id로 활용하여 UserSns 테이블에서 기존 가입 여부를 판단합니다.

신규 가입 처리: 미가입 사용자의 경우 signUp 프라이빗 메서드를 통해 User와 UserSns 정보를 트랜잭션 내에서 함께 생성합니다.

## 📌 관련 Jira Issue
GRBG-53

## ❗참고 사항
Refresh Token 저장 위치: 현재 서비스 로직 내 주석으로 남겨둔 것처럼, auth-jwt 에서 처리할지 고민입니다...

에러 코드: OAUTH_TOKEN_REQUEST_FAILED(토큰 발급 실패) 에러 코드가 추가되었습니다.