### PR TITLE
feat(auth): GRGB-125 [BE] 로그아웃 Service 구현

### DIFF
--- a/src/main/java/com/goormgb/be/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/com/goormgb/be/auth/provider/JwtTokenProvider.java
@@ -22,110 +22,129 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 // TODO: JwtTokenProvider 구현
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private static final String CLAIM_TOKEN_TYPE = "tokenType";
-    private static final String CLAIM_AUTH = "auth";
+	private static final String CLAIM_TOKEN_TYPE = "tokenType";
+	private static final String CLAIM_AUTH = "auth";
 
-    private final JwtProperties jwtProperties;
-    private SecretKey secretKey;
+	private final JwtProperties jwtProperties;
+	private SecretKey secretKey;
 
-    @PostConstruct
-    public void init() {
-        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
-    }
+	@PostConstruct
+	public void init() {
+		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+	}
 
-    public String createAccessToken(Long userId, String authority) {
-        Instant now = Instant.now();
-        Instant expiration = now.plus(jwtProperties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
+	public String createAccessToken(Long userId, String authority) {
+		Instant now = Instant.now();
+		Instant expiration = now.plus(jwtProperties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
 
-        return Jwts.builder()
-                .header()
-                    .type("JWT")
-                    .and()
-                .issuer(jwtProperties.getIssuer())
-                .subject(String.valueOf(userId))
-                .audience()
-                    .add(jwtProperties.getAccessToken().getAudience())
-                    .and()
-                .issuedAt(Date.from(now))
-                .expiration(Date.from(expiration))
-                .id(UUID.randomUUID().toString())
-                .claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
-                .claim(CLAIM_AUTH, authority)
-                .signWith(secretKey)
-                .compact();
-    }
+		return Jwts.builder()
+				.header()
+				.type("JWT")
+				.and()
+				.issuer(jwtProperties.getIssuer())
+				.subject(String.valueOf(userId))
+				.audience()
+				.add(jwtProperties.getAccessToken().getAudience())
+				.and()
+				.issuedAt(Date.from(now))
+				.expiration(Date.from(expiration))
+				.id(UUID.randomUUID().toString())
+				.claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
+				.claim(CLAIM_AUTH, authority)
+				.signWith(secretKey)
+				.compact();
+	}
 
-    public String createRefreshToken(Long userId) {
-        Instant now = Instant.now();
-        Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationDays(), ChronoUnit.DAYS);
+	public String createRefreshToken(Long userId) {
+		Instant now = Instant.now();
+		Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationDays(), ChronoUnit.DAYS);
 
-        return Jwts.builder()
-                .header()
-                    .type("JWT")
-                    .and()
-                .issuer(jwtProperties.getIssuer())
-                .subject(String.valueOf(userId))
-                .audience()
-                    .add(jwtProperties.getRefreshToken().getAudience())
-                    .and()
-                .issuedAt(Date.from(now))
-                .expiration(Date.from(expiration))
-                .id(UUID.randomUUID().toString())
-                .claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
-                .signWith(secretKey)
-                .compact();
-    }
+		return Jwts.builder()
+				.header()
+				.type("JWT")
+				.and()
+				.issuer(jwtProperties.getIssuer())
+				.subject(String.valueOf(userId))
+				.audience()
+				.add(jwtProperties.getRefreshToken().getAudience())
+				.and()
+				.issuedAt(Date.from(now))
+				.expiration(Date.from(expiration))
+				.id(UUID.randomUUID().toString())
+				.claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
+				.signWith(secretKey)
+				.compact();
+	}
 
-    public boolean validateToken(String token) {
-        try {
-            parseClaimsFromToken(token);
-            return true;
-        } catch (ExpiredJwtException e) {
-            log.warn("Expired JWT token: {}", e.getMessage());
-            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("Invalid JWT token: {}", e.getMessage());
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
-    }
+	public boolean validateToken(String token) {
+		try {
+			parseClaimsFromToken(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.warn("Expired JWT token: {}", e.getMessage());
+			throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("Invalid JWT token: {}", e.getMessage());
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
+		}
+	}
 
-    public Long getUserIdFromToken(String token) {
-        Claims claims = parseClaimsFromToken(token);
-        return Long.parseLong(claims.getSubject());
-    }
+	public Long getUserIdFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		return Long.parseLong(claims.getSubject());
+	}
 
-    public String getAuthorityFromToken(String token) {
-        Claims claims = parseClaimsFromToken(token);
-        return claims.get(CLAIM_AUTH, String.class);
-    }
+	public String getAuthorityFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		return claims.get(CLAIM_AUTH, String.class);
+	}
 
-    public TokenType getTokenTypeFromToken(String token) {
-        Claims claims = parseClaimsFromToken(token);
-        String tokenTypeValue = claims.get(CLAIM_TOKEN_TYPE, String.class);
-        return TokenType.valueOf(tokenTypeValue);
-    }
+	public TokenType getTokenTypeFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		String tokenTypeValue = claims.get(CLAIM_TOKEN_TYPE, String.class);
+		return TokenType.valueOf(tokenTypeValue);
+	}
 
-    public String getJtiFromToken(String token) {
-        Claims claims = parseClaimsFromToken(token);
-        return claims.getId();
-    }
+	public String getJtiFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		return claims.getId();
+	}
 
-    public Date getExpirationFromToken(String token) {
-        Claims claims = parseClaimsFromToken(token);
-        return claims.getExpiration();
-    }
+	public Date getExpirationFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		return claims.getExpiration();
+	}
 
-    private Claims parseClaimsFromToken(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
-    }
+	private Claims parseClaimsFromToken(String token) {
+		return Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+	}
+
+	/**
+	 * 만료된 토큰도 허용하여 Claims를 반환한다.
+	 * 서명이 유효하지 않거나 토큰 형식이 잘못된 경우에는 예외를 발생시킨다.
+	 *
+	 * @param token JWT 토큰
+	 * @return Claims
+	 */
+	public Claims parseClaimsAllowExpired(String token) {
+		try {
+			return parseClaimsFromToken(token);
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("Invalid JWT token: {}", e.getMessage());
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
+		}
+	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 로그아웃 시 Redis에서 Refresh Token 삭제하는 서비스 로직 구현
- 만료된 Refresh Token으로도 로그아웃 가능하도록 개선
- 토큰 파싱 반복 호출 제거 (3회 → 1회)

## 🧩 구현 상세
### AuthService.logout()
 1. parseClaimsAllowExpired()로 Refresh Token을 1회 파싱 (만료 토큰 허용)
  2. Claims에서 토큰 타입 확인 (REFRESH 타입인지)
  3. Claims에서 jti 추출 후 Redis에서 해당 토큰 삭제

### JwtTokenProvider.parseClaimsAllowExpired()
- 만료된 토큰의 경우 ExpiredJwtException.getClaims()로 Claims 반환
  - 서명 불일치 등 유효하지 않은 토큰은 기존과 동일하게 예외 발생

### 📌 관련 Jira Issue
- GRGB-125: 로그아웃 Service 구현