### PR TITLE
feat(auth): GRGB-121 로그아웃 API 엔드포인트 추가

### DIFF
--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -48,4 +48,25 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, cookie)
                 .body(ApiResult.ok("토큰 재발급 성공", TokenRefreshResponse.of(result.accessToken())));
     }
+
+    @Operation(summary = "로그아웃", description = "Refresh Token을 삭제하고 로그아웃합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResult<Void>> logout(HttpServletRequest request) {
+        // 1. Cookie에서 Refresh Token 추출
+        String refreshToken = cookieUtils.extractRefreshToken(request);
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        // 2. 로그아웃 처리 (Redis에서 Refresh Token 삭제)
+        authService.logout(refreshToken);
+
+        // 3. Refresh Token Cookie 삭제
+        String cookie = cookieUtils.deleteRefreshTokenCookie().toString();
+
+        // 4. 응답
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie)
+                .body(ApiResult.ok("로그아웃 성공"));
+    }
 }

--- a/src/main/java/com/goormgb/be/global/response/ApiResult.java
+++ b/src/main/java/com/goormgb/be/global/response/ApiResult.java
@@ -18,6 +18,10 @@ public class ApiResult<T> {
 		return of("OK", "성공", null);
 	}
 
+	public static ApiResult<Void> ok(String message) {
+		return of("OK", message, null);
+	}
+
 	public static <T> ApiResult<T> ok(T data) {
 		return of("OK", "성공", data);
 	}


### PR DESCRIPTION
- POST /auth/logout 엔드포인트 구현
- ApiResult에 메시지만 받는 ok(String message) 메서드 추가

## 🔧 작업 내용
- 로그아웃 API 엔드포인트 구현


## 🧩 구현 상세 (선택)
### AuthController - POST /auth/logout
  1. Cookie에서 Refresh Token 추출
  2. AuthService.logout() 호출하여 Redis에서 Refresh Token 삭제
  3. 응답 시 Refresh Token Cookie 삭제 (maxAge=0)
 ### ApiResult
  - 데이터 없이 메시지만 반환하는 `ok(String message)` 메서드 추가


### 📌 관련 Jira Issue
- GRBG-121
---

## ❗ 참고 사항
- 이전 #26 PR이 반영 되어야 해당 로그아웃 API 엔드포인트가 작동합니다