### PR TITLE
feat(auth): GRGB-106 [BE] Access Token 블랙리스트 도메인 구현

### DIFF
--- a/src/main/java/com/goormgb/be/auth/repository/AccessTokenBlacklistRepository.java
+++ b/src/main/java/com/goormgb/be/auth/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,54 @@
+package com.goormgb.be.auth.repository;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 로그아웃된 Access Token의 jti를 Redis에 블랙리스트로 저장하는 Repository.
+ * <p>
+ * Key 구조: {@code token_blacklist:{jti}}
+ * <p>
+ * TTL: Access Token의 남은 만료 시간만큼만 저장하여 불필요한 메모리 사용을 방지한다.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AccessTokenBlacklistRepository {
+
+	private static final String KEY_PREFIX = "token_blacklist:";
+	private static final String BLACKLISTED_VALUE = "blacklisted";
+
+	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 * Access Token의 jti를 블랙리스트에 등록한다.
+	 *
+	 * @param jti Access Token의 고유 식별자
+	 * @param ttl 남은 만료 시간
+	 */
+	public void save(String jti, Duration ttl) {
+		String key = generateKey(jti);
+		redisTemplate.opsForValue().set(key, BLACKLISTED_VALUE, ttl);
+		log.debug("Access token blacklisted - jti: {}", jti);
+	}
+
+	/**
+	 * jti가 블랙리스트에 존재하는지 확인한다.
+	 *
+	 * @param jti Access Token의 고유 식별자
+	 * @return 블랙리스트 존재 여부
+	 */
+	public boolean existsByJti(String jti) {
+		String key = generateKey(jti);
+		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+	}
+
+	private String generateKey(String jti) {
+		return KEY_PREFIX + jti;
+	}
+}

--- a/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token이 존재하지 않거나 만료, 유효하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "잘못된 토큰 타입입니다."),
+    BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
     OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
     ;
 


### PR DESCRIPTION
- Redis 기반 AccessTokenBlacklistRepository 구현 (token_blacklist:{jti})
- BLACKLISTED_TOKEN 에러코드 추가

## 🔧 작업 내용
- 로그아웃 시 Access Token을 즉시 무효화하기 위한 Redis 블랙리스트 저장소 구현
- 블랙리스트된 토큰 접근 시 사용할 에러코드 추가

## 🧩 구현 상세
- `AccessTokenBlacklistRepository`: Redis에 `token_blacklist:{jti}` 키로 블랙리스트 저장
  - `save(jti, ttl)`: Access Token 남은 만료 시간만큼만 TTL 설정하여 메모리 낭비 방지
  - `existsByJti(jti)`: 블랙리스트 존재 여부 확인
- `BLACKLISTED_TOKEN` 에러코드 추가 (401 UNAUTHORIZED)
- 기존 `RefreshTokenRepository`와 동일한 패턴으로 구현

### 📌 관련 Jira Issue
- GRGB-106

## ❗ 참고 사항
- 본 PR은 도메인(저장소 + 에러코드)만 포함하며, Filter/Service/Controller 연동은 후속 PR에서 진행 예정