### PR TITLE
feat(Swagger): GRGB-130 [BE] Swagger Authorization 설정(Swagger JWT 인증설정 추가)

### DIFF
--- a/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
+++ b/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.goormgb.be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		SecurityScheme securityScheme = new SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.in(SecurityScheme.In.HEADER)
+				.name("Authorization");
+
+		SecurityRequirement securityRequirement = new SecurityRequirement()
+				.addList("BearerAuth");
+
+		return new OpenAPI()
+				.info(new Info()
+						.title("표고 API")
+						.description("구름공방 백엔드 API 문서")
+						.version("v1"))
+				.addSecurityItem(securityRequirement)
+				.schemaRequirement("BearerAuth", securityScheme);
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- Swagger UI에서 JWT Bearer 인증을 사용할 수 있도록 SwaggerConfig 추가

##  🧩 구현 상세
  - SwaggerConfig: 글로벌 SecurityRequirement로 모든 API에 Bearer 인증 적용
   - 인증 불필요 API는 컨트롤러에서 @SecurityRequirements로 개별 제외 가능
    
<img width="1348" height="1423" alt="image" src="https://github.com/user-attachments/assets/20b96de5-1856-4a56-8aa9-6883a69dc6c2" />


### 📌 관련 Jira Issue
  - GRGB-130

##  🧪 테스트 방법
  - Swagger UI (http://localhost:8080/swagger-ui/index.html) 접속
    - Authorize 버튼 → Access Token 입력 → 인증 필요 API 호출 확인