### PR TITLE
feat(auth): GRGB-126 로그아웃 시에 Access Token 블랙리스트 Service구현

### DIFF
--- a/src/main/java/com/goormgb/be/auth/config/JwtConfig.java
+++ b/src/main/java/com/goormgb/be/auth/config/JwtConfig.java
@@ -7,4 +7,3 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(JwtProperties.class)
 public class JwtConfig {
 }
-// 크아악ㅇㄹㅇㄹㄴㄹㄴㄹㄴ 요깅에여

--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.goormgb.be.auth.controller;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +12,7 @@ import com.goormgb.be.auth.util.CookieUtils;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.global.support.Preconditions;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,23 +52,14 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "Access Token을 블랙리스트에 등록하고 Refresh Token을 삭제합니다.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResult<Void>> logout(HttpServletRequest request) {
-        // 1. Authorization 헤더에서 Access Token 추출
-        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith("Bearer ")) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
-        String accessToken = bearerToken.substring(7);
-
-        // 2. Cookie에서 Refresh Token 추출
+        // 1. Refresh Token 추출
         String refreshToken = cookieUtils.extractRefreshToken(request);
-        if (refreshToken == null) {
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
+        Preconditions.validate(refreshToken != null, ErrorCode.REFRESH_TOKEN_NOT_FOUND);
 
-        // 3. 로그아웃 처리
-        authService.logout(accessToken, refreshToken);
+        // 2. 로그아웃 처리 (Access Token 블랙리스트 등록 + Refresh Token 삭제)
+        authService.logout(request, refreshToken);
 
-        // 4. Refresh Token Cookie 삭제
+        // 3. Refresh Token Cookie 삭제
         String cookie = cookieUtils.deleteRefreshTokenCookie().toString();
 
         return ResponseEntity.ok()

--- a/src/main/java/com/goormgb/be/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/goormgb/be/auth/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,8 @@ import com.goormgb.be.auth.enums.TokenType;
 import com.goormgb.be.auth.provider.JwtTokenProvider;
 import com.goormgb.be.auth.repository.AccessTokenBlacklistRepository;
 import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -49,22 +51,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     if (tokenType == TokenType.ACCESS) {
                         String jti = jwtTokenProvider.getJtiFromToken(token);
 
-                        if (accessTokenBlacklistRepository.existsByJti(jti)) {
-                            log.debug("Blacklisted token used - jti: {}", jti);
-                        } else {
-                            Long userId = jwtTokenProvider.getUserIdFromToken(token);
-                            String authority = jwtTokenProvider.getAuthorityFromToken(token);
+                        Preconditions.validate(
+                                !accessTokenBlacklistRepository.existsByJti(jti),
+                                ErrorCode.BLACKLISTED_TOKEN
+                        );
 
-                            UsernamePasswordAuthenticationToken authentication =
-                                    new UsernamePasswordAuthenticationToken(
-                                            userId,
-                                            null,
-                                            List.of(new SimpleGrantedAuthority(authority))
-                                    );
+                        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+                        String authority = jwtTokenProvider.getAuthorityFromToken(token);
 
-                            SecurityContextHolder.getContext().setAuthentication(authentication);
-                            log.debug("Set authentication for user: {}", userId);
-                        }
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        List.of(new SimpleGrantedAuthority(authority))
+                                );
+
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                        log.debug("Set authentication for user: {}", userId);
                     }
                 }
             } catch (CustomException e) {

--- a/src/main/java/com/goormgb/be/auth/service/AuthService.java
+++ b/src/main/java/com/goormgb/be/auth/service/AuthService.java
@@ -122,7 +122,7 @@ public class AuthService {
 
 		// 3. 토큰 타입 확인
 		String tokenTypeValue = refreshClaims.get("tokenType", String.class);
-		Preconditions.validate(TokenType.valueOf(tokenTypeValue) == TokenType.REFRESH, ErrorCode.INVALID_TOKEN_TYPE);
+		Preconditions.validate(TokenType.REFRESH.getValue().equals(tokenTypeValue), ErrorCode.INVALID_TOKEN_TYPE);
 
 		// 4. jti 추출 후 Redis에서 삭제
 		String refreshJti = refreshClaims.getId();


### PR DESCRIPTION
- AuthController: 로그아웃 API에 Access Token 추출 및 블랙리스트 등록 추가
- AuthService: logout()에 Access Token 블랙리스트 저장 로직 반영
- JwtAuthenticationFilter: 블랙리스트 토큰 인증 차단 처리
- 미사용 import 및 주석 정리

## 🔧 작업 내용
- 로그아웃 시 Access Token을 Redis 블랙리스트에 등록하여 즉시 무효화 처리
- JwtAuthenticationFilter에서 블랙리스트 토큰 인증 차단 로직 추가
- 기존 로그아웃 API가 Refresh Token만 삭제하던 방식에서 Access Token까지 무효화하도록 개선

## 🧩 구현 상세 (선택)
- AuthController: Authorization 헤더에서 Access Token 추출 후 서비스에 전달
- AuthService: logout(accessToken, refreshToken) — Access Token의 jti를 블랙리스트에 저장 (남은 만료시간만큼 TTL 설정), Refresh Token은 기존과 동일하게 Redis에서 삭제
- JwtAuthenticationFilter: 인증 시 AccessTokenBlacklistRepository.existsByJti() 체크 추가 — 블랙리스트 토큰은 인증 처리하지 않음
- 미사용 import 및 TODO 주석 정리

### 📌 관련 Jira Issue
- GRBG-126