### PR TITLE
feat(auth): GRGB-123 [BE] 개발용 ID/PW 인증 시스템 구현

### DIFF
--- a/src/main/java/com/goormgb/be/auth/controller/DevAuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/DevAuthController.java
@@ -1,0 +1,67 @@
+package com.goormgb.be.auth.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.auth.dto.DevLoginRequest;
+import com.goormgb.be.auth.dto.DevSignupRequest;
+import com.goormgb.be.auth.dto.TokenRefreshResponse;
+import com.goormgb.be.auth.service.DevAuthService;
+import com.goormgb.be.auth.util.CookieUtils;
+import com.goormgb.be.global.response.ApiResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Dev Auth", description = "개발용 인증 API (local/dev 프로필 전용)")
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/dev/auth")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+	private final DevAuthService devAuthService;
+	private final CookieUtils cookieUtils;
+
+	@Operation(summary = "개발용 회원가입", description = "ID/PW 기반 개발용 계정을 생성합니다.")
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResult<Void>> signup(@Valid @RequestBody DevSignupRequest request) {
+		devAuthService.signup(
+				request.getLoginId(),
+				request.getPassword(),
+				request.getNickname(),
+				request.getEmail()
+		);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(ApiResult.ok("회원가입 성공", null));
+	}
+
+	@Operation(summary = "개발용 로그인", description = "ID/PW 기반 개발용 로그인 후 JWT를 발급합니다.")
+	@PostMapping("/login")
+	public ResponseEntity<ApiResult<TokenRefreshResponse>> login(
+			@Valid @RequestBody DevLoginRequest request,
+			HttpServletRequest httpRequest
+	) {
+		DevAuthService.DevLoginResult result = devAuthService.login(
+				request.getLoginId(),
+				request.getPassword(),
+				httpRequest
+		);
+
+		String cookie = cookieUtils.createRefreshTokenCookie(result.refreshToken()).toString();
+
+		return ResponseEntity.ok()
+				.header(HttpHeaders.SET_COOKIE, cookie)
+				.body(ApiResult.ok("로그인 성공", TokenRefreshResponse.of(result.accessToken())));
+	}
+}

--- a/src/main/java/com/goormgb/be/auth/dto/DevLoginRequest.java
+++ b/src/main/java/com/goormgb/be/auth/dto/DevLoginRequest.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DevLoginRequest {
+
+	@Schema(example = "dev")
+	@NotBlank(message = "로그인 ID는 필수입니다.")
+	private String loginId;
+
+	@Schema(example = "1234")
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	private String password;
+}

--- a/src/main/java/com/goormgb/be/auth/dto/DevSignupRequest.java
+++ b/src/main/java/com/goormgb/be/auth/dto/DevSignupRequest.java
@@ -1,0 +1,20 @@
+package com.goormgb.be.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DevSignupRequest {
+
+	@NotBlank(message = "로그인 ID는 필수입니다.")
+	private String loginId;
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	private String password;
+
+	private String nickname;
+
+	private String email;
+}

--- a/src/main/java/com/goormgb/be/auth/init/DevUserSeeder.java
+++ b/src/main/java/com/goormgb/be/auth/init/DevUserSeeder.java
@@ -1,0 +1,31 @@
+package com.goormgb.be.auth.init;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.auth.service.DevAuthService;
+import com.goormgb.be.user.repository.DevUserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile({"local", "dev"})
+@RequiredArgsConstructor
+public class DevUserSeeder implements CommandLineRunner {
+
+	private final DevUserRepository devUserRepository;
+	private final DevAuthService devAuthService;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		if (!devUserRepository.existsByLoginId("dev")) {
+			devAuthService.signup("dev", "1234", "개발자", "dev@test.com");
+			log.info("Dev seed user created - loginId: dev, password: 1234");
+		}
+	}
+}

--- a/src/main/java/com/goormgb/be/auth/service/DevAuthService.java
+++ b/src/main/java/com/goormgb/be/auth/service/DevAuthService.java
@@ -1,0 +1,109 @@
+package com.goormgb.be.auth.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.auth.config.JwtProperties;
+import com.goormgb.be.auth.dto.RefreshTokenInfo;
+import com.goormgb.be.auth.provider.JwtTokenProvider;
+import com.goormgb.be.auth.repository.RefreshTokenRepository;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.user.entity.DevUser;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.repository.DevUserRepository;
+import com.goormgb.be.user.repository.UserRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DevAuthService {
+
+	private static final String DEFAULT_AUTHORITY = "ROLE_USER";
+
+	private final UserRepository userRepository;
+	private final DevUserRepository devUserRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtProperties jwtProperties;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Transactional
+	public void signup(String loginId, String password, String nickname, String email) {
+		if (devUserRepository.existsByLoginId(loginId)) {
+			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+		}
+
+		User user = User.builder()
+				.email(email)
+				.nickname(nickname != null ? nickname : loginId)
+				.build();
+		userRepository.save(user);
+
+		DevUser devUser = DevUser.builder()
+				.loginId(loginId)
+				.passwordHash(passwordEncoder.encode(password))
+				.user(user)
+				.build();
+		devUserRepository.save(devUser);
+
+		log.info("Dev user created - loginId: {}, userId: {}", loginId, user.getId());
+	}
+
+	@Transactional
+	public DevLoginResult login(String loginId, String password, HttpServletRequest request) {
+		DevUser devUser = devUserRepository.findByLoginId(loginId)
+				.orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));
+
+		if (!passwordEncoder.matches(password, devUser.getPasswordHash())) {
+			throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+		}
+
+		User user = devUser.getUser();
+		user.updateLastLoginAt();
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY);
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
+
+		Instant now = Instant.now();
+		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
+
+		RefreshTokenInfo tokenInfo = RefreshTokenInfo.builder()
+				.userId(user.getId())
+				.token(refreshToken)
+				.jti(jti)
+				.tokenFamily(UUID.randomUUID().toString())
+				.issuedAt(now)
+				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
+				.userAgent(request.getHeader("User-Agent"))
+				.ipAddress(getClientIp(request))
+				.build();
+
+		refreshTokenRepository.save(tokenInfo);
+
+		log.info("Dev user logged in - loginId: {}, userId: {}", loginId, user.getId());
+
+		return new DevLoginResult(accessToken, refreshToken);
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		String xForwardedFor = request.getHeader("X-Forwarded-For");
+		if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+			return xForwardedFor.split(",")[0].trim();
+		}
+		return request.getRemoteAddr();
+	}
+
+	public record DevLoginResult(String accessToken, String refreshToken) {
+	}
+}

--- a/src/main/java/com/goormgb/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/goormgb/be/global/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/auth/**",
-            "/auth/kakao/**"
+            "/dev/**"
     };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/goormgb/be/user/repository/DevUserRepository.java
+++ b/src/main/java/com/goormgb/be/user/repository/DevUserRepository.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.user.entity.DevUser;
+
+public interface DevUserRepository extends JpaRepository<DevUser, Long> {
+	Optional<DevUser> findByLoginId(String loginId);
+
+	boolean existsByLoginId(String loginId);
+}


### PR DESCRIPTION
##  🔧 작업 내용
- 카카오 OAuth 없이 개발/테스트할 수 있는 ID/PW 기반 인증 시스템 추가
- 앱 기동 시 개발용 seed 계정 자동 생성
- local, dev 프로필에서만 동작하도록 제한

##  🧩 구현 상세

- DevAuthService: BCrypt 기반 회원가입/로그인, JWT 발급 및 RefreshToken Redis 저장
- DevAuthController: @Profile({"local", "dev"}) 적용
  - POST /dev/auth/signup — 개발용 계정 생성
  - POST /dev/auth/login — ID/PW 로그인 후 JWT 발급
- DevUserSeeder: CommandLineRunner로 기동 시 dev/1234 계정 자동 생성 (중복 체크)
- DevUserRepository: loginId 기반 조회/존재 확인
- SecurityConfig: /dev/** 경로 permitAll 추가

###  📌 관련 Jira Issue
  - GRGB-123

###  🧪 테스트 방법

- seed 계정으로 로그인: POST /dev/auth/login → {"loginId": "dev", "password": "1234"}
- 직접 회원가입: POST /dev/auth/signup → {"loginId": "test", "password": "1234", "nickname": "테스트", "email": "test@test.com"}
- 발급된 Access Token으로 인증 필요 API 호출 확인
- 앱 재시작 시 seed 계정 중복 생성 없이 정상 기동 확인

## ❗ 참고 사항
- DevAuthController, DevUserSeeder는 @Profile({"local", "dev"}) 적용 — 운영 환경에서 노출되지 않음
- dev 계정 쓰려면 반드시 `local` 또는 `dev` proflie로 실행해주셔야 합니당
- Swagger UI에서 POST /dev/auth/login 호출 시 기본값(dev/1234)이 자동 입력됨

**개발용 계정 기능은 빠르게 처리하기 위해 도메인/서비스/API를 나누지 않고 한 PR로 올렸습니다. 커밋 단위로 분리해두었으니 리뷰 시 커밋별로 확인해주시면 편합니다!**