### PR TITLE
feat(Withdrawal of membership)

### DIFF
--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.goormgb.be.auth.controller;
 
+import com.goormgb.be.auth.dto.WithdrawlResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -65,5 +67,15 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie)
                 .body(ApiResult.ok("로그아웃 성공", null));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 신청합니다. 서비스 이용이 중단되며, 30일의 유예 기간 뒤에 최종 삭제됩니다.")
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResult<WithdrawlResponse>> withdrawl(@AuthenticationPrincipal Long userId) {
+            WithdrawlResponse response = authService.withdraw(userId);
+            return ResponseEntity.ok()
+                    .body(ApiResult.ok("탈퇴 처리 완료", response));
+
+
     }
 }

--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 신청합니다. 서비스 이용이 중단되며, 30일의 유예 기간 뒤에 최종 삭제됩니다.")
     @PostMapping("/withdraw")
-    public ResponseEntity<ApiResult<WithdrawlResponse>> withdrawl(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<ApiResult<WithdrawlResponse>> withdrawal(@AuthenticationPrincipal Long userId) {
             WithdrawlResponse response = authService.withdraw(userId);
             return ResponseEntity.ok()
                     .body(ApiResult.ok("탈퇴 처리 완료", response));

--- a/src/main/java/com/goormgb/be/auth/dto/WithdrawlResponse.java
+++ b/src/main/java/com/goormgb/be/auth/dto/WithdrawlResponse.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.auth.dto;
+
+import com.goormgb.be.user.entity.WithdrawalRequest;
+
+import java.time.LocalDateTime;
+
+public record WithdrawlResponse(
+        String status,
+        LocalDateTime withdrawnAt,
+        LocalDateTime reactivateUntil
+    ) {
+        public static WithdrawlResponse from(WithdrawalRequest request) {
+            return new WithdrawlResponse(
+                    "DEACTIVE",
+                    request.getRequestedAt(),
+                    request.getEffectiveAt()
+            );
+        }
+    }

--- a/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -41,7 +41,7 @@ public enum ErrorCode {
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "잘못된 토큰 타입입니다."),
     BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
     OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
-    OAUTH_CODE_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "인가 코드는 필수입니다."),
+    OAUTH_CODE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "인가 코드는 필수입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/goormgb/be/user/repository/WithdrawalRequestRepository.java
+++ b/src/main/java/com/goormgb/be/user/repository/WithdrawalRequestRepository.java
@@ -1,0 +1,7 @@
+package com.goormgb.be.user.repository;
+
+import com.goormgb.be.user.entity.WithdrawalRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalRequestRepository extends JpaRepository<WithdrawalRequest, Long> {
+}


### PR DESCRIPTION
## 🔧 작업 내용
회원 탈퇴 API 구현: POST /auth/withdraw 

Soft Delete 도입

## 🧩 구현 상세
Preconditions.validate를 활용하여 이미 탈퇴한 상태(ALREADY_DEACTIVATED)를 선제적으로 검증.

즉시 데이터를 삭제하지 않고 유저의 상태(UserStatus)를 DEACTIVE로 변경하여 데이터 정합성을 유지하고 30일간의 복구 유예 기간을 제공

## 📌 관련 Jira Issue
GRBG-128 [BE] 회원탈퇴 API 구현

## 🧪 테스트 방법
테스트 대상: AuthController.withdrawl

Endpoint: POST /auth/withdraw

체크 포인트:

정상 탈퇴: Authorization: Bearer <token> 전송 시 DEACTIVE 응답 및 유예 기간 데이터 확인.

중복 탈퇴: 이미 탈퇴한 유저로 요청 시 403 Forbidden 반환 확인.

<img width="469" height="171" alt="image" src="https://github.com/user-attachments/assets/18ce0e0b-86da-4b6b-bbfb-27e539cc6804" />


## ❗ 참고 사항