### PR TITLE
fix(auth): 회원탈퇴 API 코드리뷰 반영 및 auth 와일드 카드 경로 변경

### DIFF
--- a/src/main/java/com/goormgb/be/auth/controller/AuthController.java
+++ b/src/main/java/com/goormgb/be/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.goormgb.be.auth.controller;
 
-import com.goormgb.be.auth.dto.WithdrawlResponse;
+import com.goormgb.be.auth.dto.WithdrawalResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -71,8 +71,8 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 신청합니다. 서비스 이용이 중단되며, 30일의 유예 기간 뒤에 최종 삭제됩니다.")
     @PostMapping("/withdraw")
-    public ResponseEntity<ApiResult<WithdrawlResponse>> withdrawal(@AuthenticationPrincipal Long userId) {
-            WithdrawlResponse response = authService.withdraw(userId);
+    public ResponseEntity<ApiResult<WithdrawalResponse>> withdraw(@AuthenticationPrincipal Long userId) {
+            WithdrawalResponse response = authService.withdraw(userId);
             return ResponseEntity.ok()
                     .body(ApiResult.ok("탈퇴 처리 완료", response));
 

--- a/src/main/java/com/goormgb/be/auth/dto/WithdrawalResponse.java
+++ b/src/main/java/com/goormgb/be/auth/dto/WithdrawalResponse.java
@@ -1,17 +1,18 @@
 package com.goormgb.be.auth.dto;
 
 import com.goormgb.be.user.entity.WithdrawalRequest;
+import com.goormgb.be.user.enums.UserStatus;
 
 import java.time.LocalDateTime;
 
-public record WithdrawlResponse(
+public record WithdrawalResponse(
         String status,
         LocalDateTime withdrawnAt,
         LocalDateTime reactivateUntil
     ) {
-        public static WithdrawlResponse from(WithdrawalRequest request) {
-            return new WithdrawlResponse(
-                    "DEACTIVE",
+        public static WithdrawalResponse from(WithdrawalRequest request) {
+            return new WithdrawalResponse(
+                    UserStatus.DEACTIVATE.name(),
                     request.getRequestedAt(),
                     request.getEffectiveAt()
             );

--- a/src/main/java/com/goormgb/be/auth/service/AuthService.java
+++ b/src/main/java/com/goormgb/be/auth/service/AuthService.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 
-import com.goormgb.be.auth.dto.WithdrawlResponse;
+import com.goormgb.be.auth.dto.WithdrawalResponse;
 import com.goormgb.be.user.entity.WithdrawalRequest;
 import com.goormgb.be.user.repository.WithdrawalRequestRepository;
 import org.springframework.http.HttpHeaders;
@@ -161,7 +161,8 @@ public class AuthService {
     /**
      * 회원 탈퇴
      */
-    public WithdrawlResponse withdraw(Long userId) {
+    @Transactional
+    public WithdrawalResponse withdraw(Long userId) {
         User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 
         // 1. 이미 탈퇴 처리된 유저인지 확인
@@ -178,7 +179,7 @@ public class AuthService {
                 .build();
         withdrawalRequestRepository.save(withdrawalRequest);
 
-        return WithdrawlResponse.from(withdrawalRequest);
+        return WithdrawalResponse.from(withdrawalRequest);
 
     }
 }

--- a/src/main/java/com/goormgb/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/goormgb/be/global/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
     private static final String[] PUBLIC_URIS = {
             "/v3/api-docs/**",
             "/swagger-ui/**",
-            "/auth/**",
+            "/auth/token/refresh",
+            "/auth/kakao/**",
             "/dev/**"
     };
 


### PR DESCRIPTION
## 🔧 작업 내용
- 회원탈퇴 API 코드리뷰(Gemini) 피드백 반영
- SecurityConfig에서 `/auth/**` 와일드카드를 개별 경로로 변경하여 인증 필요 API 보호

## 🧩 구현 상세
- **SecurityConfig 접근 제어 강화**: `/auth/**` permitAll → `/auth/token/refresh`, `/auth/kakao/**`만 허용
  - `/auth/logout`, `/auth/withdraw`는 인증 필수로 변경
  - 기존에는 토큰 없이 호출 시 `@AuthenticationPrincipal`이 null → 500 에러 발생
  - 변경 후 Spring Security가 401 Unauthorized 반환
- **`@Transactional` 추가**: `withdraw()` 메서드에서 User 상태 변경 + WithdrawalRequest 저장이 단일 트랜잭션으로 실행되도록 보장
- **오타 수정**: `WithdrawlResponse` → `WithdrawalResponse` (클래스명, 파일명, 메서드명)
- **매직 스트링 제거**: 하드코딩된 `"DEACTIVE"` → `UserStatus.DEACTIVATE.name()`

## 🧪 테스트 방법
- Swagger에서 토큰 없이 `POST /auth/withdraw` 호출 → 401 반환 확인
- Swagger에서 토큰 포함 `POST /auth/withdraw` 호출 → 정상 탈퇴 처리 확인
- 응답 body의 `status` 필드가 `"DEACTIVATE"`인지 확인
<img width="163" height="162" alt="스크린샷 2026-02-09 오후 8 19 28" src="https://github.com/user-attachments/assets/43671839-2902-4f98-8daa-6991d4e807dc" />

  ## ❗ 참고 사항
- SecurityConfig PUBLIC_URIS 변경으로 `/auth/logout`, `/auth/withdraw`는 반드시 Authorization 헤더 필요
- 향후 `/auth/` 하위에 새 API 추가 시 인증 필요 여부에 따라 PUBLIC_URIS 업데이트 필요