### PR TITLE
chore(config): dev/prod 환경변수 기반 설정 전환 및 서비스별 포트·이름 통일

### DIFF
--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8080
+
 spring:
   application:
-    name: goormgb
+    name: auth-guard
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -51,3 +54,12 @@ springdoc:
         url: http://localhost:8083/v3/api-docs
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -9,9 +9,9 @@ spring:
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -25,19 +25,19 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
-  secret-key: ${JWT_SECRET_KEY:kt-techup-groomgb-pyogo-20260205151046}
+  secret-key: ${JWT_SECRET_KEY}
 
-  issuer: ${JWT_ISSUER:goormgb-auth-service}
+  issuer: ${JWT_ISSUER}
   access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE:goormgb-api}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION:15} # 15분
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
+    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
   refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE:goormgb-auth-service}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION:7} # 7일
+    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
+    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
   cookie:
     secure: false
 

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8083
+
 spring:
   application:
-    name: goormgb
+    name: order-core
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -51,3 +54,12 @@ springdoc:
         url: http://localhost:8083/v3/api-docs
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8083
+
 spring:
   application:
-    name: goormgb
+    name: order-core
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,21 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+
+  issuer: ${JWT_ISSUER}
+  access-token:
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
+    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token:
+    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
+    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  cookie:
+    secure: false
 
 springdoc:
   swagger-ui:
@@ -39,13 +55,11 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
 
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8081
+
 spring:
   application:
-    name: goormgb
+    name: queue
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -51,3 +54,12 @@ springdoc:
         url: http://localhost:8083/v3/api-docs
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8081
+
 spring:
   application:
-    name: goormgb
+    name: queue
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,21 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+
+  issuer: ${JWT_ISSUER}
+  access-token:
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
+    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token:
+    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
+    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  cookie:
+    secure: false
 
 springdoc:
   swagger-ui:
@@ -39,13 +55,11 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
 
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8084
+
 spring:
   application:
-    name: goormgb
+    name: recommendation
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -51,3 +54,12 @@ springdoc:
         url: http://localhost:8083/v3/api-docs
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Recommendation/src/main/resources/application.yaml
+++ b/Recommendation/src/main/resources/application.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8084
+
 spring:
   application:
-    name: goormgb
+    name: recommendation
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,21 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+
+  issuer: ${JWT_ISSUER}
+  access-token:
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
+    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token:
+    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
+    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  cookie:
+    secure: false
 
 springdoc:
   swagger-ui:
@@ -39,13 +55,11 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
 
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8082
+
 spring:
   application:
-    name: goormgb
+    name: seat
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}
@@ -51,3 +54,12 @@ springdoc:
         url: http://localhost:8083/v3/api-docs
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -1,14 +1,17 @@
+server:
+  port: 8082
+
 spring:
   application:
-    name: goormgb
+    name: seat
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/goormgb
-    username: goormgb
-    password: 1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   jpa:
@@ -22,8 +25,21 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+
+  issuer: ${JWT_ISSUER}
+  access-token:
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
+    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token:
+    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
+    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  cookie:
+    secure: false
 
 springdoc:
   swagger-ui:
@@ -39,13 +55,11 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/v3/api-docs
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
 
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  auth-url: https://kauth.kakao.com/oauth/authorize
+  token-url: https://kauth.kakao.com/oauth/token
+  user-info-url: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 🔧 작업 내용
- 5개 서비스(Auth-Guard, Queue, Seat, Order-Core, Recommendation)의 dev/prod 환경 설정을 환경변수 기반으로 전환
- 하드코딩된 DB, Redis, JWT, Kakao OAuth 값을 ${ENV} 참조로 변경하여 .env 파일만으로 환경 구성 가능하도록 개선
- 서비스별 server.port와 spring.application.name 누락분 추가 및 통일

## 🧩 구현 상세
- DB: url, username, password → ${DB_URL}, ${DB_USERNAME}, ${DB_PASSWORD}
- Redis: host, port → ${REDIS_HOST}, ${REDIS_PORT}
- JWT: 기본값 제거하고 ${JWT_SECRET_KEY}, ${JWT_ISSUER} 등으로 통일, cookie.secure 추가
- Kakao OAuth: 누락된 서비스에 kakao 섹션 추가 (${KAKAO_CLIENT_ID}, ${KAKAO_CLIENT_SECRET}, ${KAKAO_REDIRECT_URI})
- 서비스 식별: 각 서비스에 고유 server.port(8080~8084)와 spring.application.name 설정

### 📌 관련 Jira Issue
  - GRGB-139

## ❗ 참고 사항
- .env 파일 없이 dev/prod 프로필로 실행하면 환경변수 미설정 오류 발생
- 클라우드 배포 시 해당 환경변수를 인프라 레벨에서 주입 필요