### PR TITLE
feat(user): 카카오 OAuth 로그인 시 사용자 프로필 이미지 수집

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
@@ -17,10 +17,10 @@ public class KakaoLoginResponse {
     @Getter
     @Builder
     public static class UserInfo {
-        // TODO: 카카오 프로필 url 추가 profile_image_url << private String profileImageUrl; 추가해야함. 작업자: 시연
         private Long userId;
         private String email;
         private String nickname;
+        private String profileImageUrl;
         private UserStatus status;
     }
 
@@ -35,7 +35,7 @@ public class KakaoLoginResponse {
                         .userId(user.getId())
                         .email(user.getEmail())
                         .nickname(user.getNickname())
-                        // TODO: .profileImageUrl(user.getProfileImageUrl()) 추가. 작업자: 시연
+                        .profileImageUrl(user.getProfileImageUrl())
                         .status(user.getStatus())
                         .build())
                 .onboardingRequired(!user.getOnboardingCompleted())

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoUserResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoUserResponse.java
@@ -39,9 +39,8 @@ public class KakaoUserResponse {
         static class Profile {
             private String nickname;
 
-            // TODO: 카카오 프로필 이미지 URL 필드 추가. 작업자: 시연
-            // @JsonProperty("profile_image_url")
-            // private String profileImageUrl;
+            @JsonProperty("profile_image_url")
+            private String profileImageUrl;;
         }
 
         public String getEmail() {
@@ -55,11 +54,10 @@ public class KakaoUserResponse {
                 .orElse(null);
     }
 
-    // TODO: getProfileImageUrl() 추가 - getNickname()과 동일한 Optional 체인 패턴, 작업자: 시연
-    // public String getProfileImageUrl() {
-    //     return Optional.ofNullable(kakaoAccount)
-    //             .map(KakaoAccount::getProfile)
-    //             .map(Profile::getProfileImageUrl)
-    //             .orElse(null);
-    // }
+     public String getProfileImageUrl() {
+         return Optional.ofNullable(kakaoAccount)
+                 .map(KakaoAccount::getProfile)
+                 .map(Profile::getProfileImageUrl)
+                 .orElse(null);
+     }
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoUserResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoUserResponse.java
@@ -40,7 +40,7 @@ public class KakaoUserResponse {
             private String nickname;
 
             @JsonProperty("profile_image_url")
-            private String profileImageUrl;;
+            private String profileImageUrl;
         }
 
         public String getEmail() {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -52,16 +52,14 @@ public class KakaoAuthService {
         String providerUserId = String.valueOf(userResponse.getId());
         String email = userResponse.getEmail();
         String nickname = userResponse.getNickname();
-        // TODO: 카카오 응답에서 프로필 이미지 URL 추출. 작업자: 시연
-        // String profileImageUrl = userResponse.getProfileImageUrl();
+        String profileImageUrl = userResponse.getProfileImageUrl();
 
         // 3. user_sns 기준으로 기존 사용자 조회
         User user = userSnsRepository.findByProviderAndProviderUserId(
                 SocialProvider.KAKAO,
                 providerUserId
         ).map(UserSns::getUser)
-                // TODO: signUp()에 profileImageUrl 파라미터 추가 전달. 작업자: 시연
-                .orElseGet(() -> signUp(email, nickname, providerUserId));
+                .orElseGet(() -> signUp(email, nickname, profileImageUrl, providerUserId));
 
         // 4. 상태 체크
         Preconditions.validate(
@@ -110,14 +108,13 @@ public class KakaoAuthService {
     /**
      * 신규 사용자 회원가입 처리
      */
-    // TODO: signUp 파라미터에 String profileImageUrl 추가. 작업자: 시연
     private User signUp(
             String email,
             String nickname,
+            String profileImageUrl,
             String providerUserId
     ) {
-        // TODO: createOAuthUser()에 profileImageUrl 전달. 작업자: 시연
-        User user = User.createOAuthUser(email, nickname);
+        User user = User.createOAuthUser(email, nickname, profileImageUrl);
         userRepository.save(user);
 
         UserSns userSns = UserSns.create(

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -50,7 +50,7 @@ public class User extends BaseEntity {
 	public User(String email, String nickname, String profileImageUrl) {
 		this.email = email;
 		this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
+		this.profileImageUrl = profileImageUrl;
 		this.onboardingCompleted = false;
 		this.marketingConsent = false;
 	}

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -28,9 +28,8 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", length = 100)
 	private String nickname;
 
-	// TODO: 프로필 이미지 URL 필드 추가. 작업자: 시연
-	// @Column(name = "profile_image_url")
-	// private String profileImageUrl;
+	 @Column(name = "profile_image_url")
+	 private String profileImageUrl;
 
 	@Column(name = "onboarding_completed", nullable = false)
 	private Boolean onboardingCompleted = false;
@@ -47,11 +46,11 @@ public class User extends BaseEntity {
 	@Column(name = "marketing_consented_at")
 	private LocalDateTime marketingConsentedAt;
 
-	// TODO: Builder 생성자에 profileImageUrl 파라미터 추가. 작업자: 시연
 	@Builder
-	public User(String email, String nickname) {
+	public User(String email, String nickname, String profileImageUrl) {
 		this.email = email;
 		this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
 		this.onboardingCompleted = false;
 		this.marketingConsent = false;
 	}
@@ -84,11 +83,11 @@ public class User extends BaseEntity {
 		this.status = UserStatus.ACTIVATE;
 	}
 
-	// TODO: profileImageUrl 파라미터 추가 → .profileImageUrl(profileImageUrl). 작업자: 시연
-	public static User createOAuthUser(String email, String nickname) {
+	public static User createOAuthUser(String email, String nickname, String profileImageUrl) {
 		return User.builder()
 				.email(email)
 				.nickname(nickname)
+                .profileImageUrl(profileImageUrl)
 				.build();
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", length = 100)
 	private String nickname;
 
-	 @Column(name = "profile_image_url")
+	@Column(name = "profile_image_url")
 	 private String profileImageUrl;
 
 	@Column(name = "onboarding_completed", nullable = false)

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -87,7 +87,7 @@ public class User extends BaseEntity {
 		return User.builder()
 				.email(email)
 				.nickname(nickname)
-                .profileImageUrl(profileImageUrl)
+				.profileImageUrl(profileImageUrl)
 				.build();
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 카카오 OAuth 로그인 시 사용자 프로필 이미지(profile_image_url)를 함께 수집하도록 DTO 수정
- KakaoUserResponse에 프로필 이미지 필드 매핑 추가
- 로그인/회원가입 시 프로필 이미지 URL을 User 엔티티에 저장하도록 로직 보완


## 🧩 구현 상세 (선택)
- kakao_account → profile → profile_image_url 경로를 안전하게 탐색
- 필드명은 camelCase로 유지하고 @JsonProperty("profile_image_url")로 매핑
- 카카오 응답 스펙 변경에 유연하게 대응 가능
- DTO 내부 구조를 실제 응답 JSON 구조와 동일하게 유지하여 가독성 확보


### 📌 관련 Jira Issue
- GRBG-147


## 🧪 테스트 방법(선택)
- 신규 회원 가입 시 DB에 profileImageUrl 저장 여부 확인


## ❗ 참고 사항
- 카카오 디벨로퍼스 콘솔에서 프로필 사진 동의 항목 활성화 필요
- 프로필 사진 설정 X -> 카카오 기본 이미지 저장