### PR TITLE
test(order): GRGB-154 온보딩 Unit 테스트 작성 및 JpaConfig 공통화

### DIFF
--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
@@ -31,7 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class AuthControllerTest extends WebMvcTestSupport {
+class ㅏㄴ그AuthControllerTest extends WebMvcTestSupport {
 
 	@MockitoBean
 	private AuthService authService;
@@ -44,7 +44,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/token/refresh - 토큰 재발급 성공")
-	void tokenRefresh_성공() throws Exception {
+	void 토큰_재발급_성공() throws Exception {
 		// given
 		String oldRefreshToken = "old-refresh-token";
 		AuthService.TokenRefreshResult result =
@@ -68,7 +68,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/token/refresh - 쿠키 없으면 401")
-	void tokenRefresh_쿠키없음() throws Exception {
+	void 토큰_재발급_리프레시_쿠키_없음() throws Exception {
 		// given
 		given(cookieUtils.extractRefreshToken(any(HttpServletRequest.class))).willReturn(null);
 
@@ -80,7 +80,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/logout - 로그아웃 성공")
-	void logout_성공() throws Exception {
+	void 로그아웃_성공() throws Exception {
 		// given
 		String refreshToken = "refresh-token";
 
@@ -102,7 +102,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/logout - 쿠키 없으면 401")
-	void logout_쿠키없음() throws Exception {
+	void 로그아웃_리프레시_쿠키_없음() throws Exception {
 		// given
 		given(cookieUtils.extractRefreshToken(any(HttpServletRequest.class))).willReturn(null);
 
@@ -114,7 +114,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/withdraw - 회원 탈퇴 성공")
-	void withdraw_성공() throws Exception {
+	void 회원_탈퇴_성공() throws Exception {
 		// given
 		Long userId = 1L;
 		setAuthentication(userId);

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
@@ -31,7 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class ㅏㄴ그AuthControllerTest extends WebMvcTestSupport {
+class AuthControllerTest extends WebMvcTestSupport {
 
 	@MockitoBean
 	private AuthService authService;

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/DevAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/DevAuthControllerTest.java
@@ -42,7 +42,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /dev/auth/signup - 회원가입 성공")
-	void signup_성공() throws Exception {
+	void 회원가입_성공() throws Exception {
 		// given
 		DevSignupRequest request = DevSignupRequestFixture.createDefault();
 
@@ -64,7 +64,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /dev/auth/signup - loginId 누락 시 400")
-	void signup_loginId_누락() throws Exception {
+	void 회원가입_로그인아이디_누락() throws Exception {
 		// given
 		DevSignupRequest request = DevSignupRequestFixture.createDefault();
 		org.springframework.test.util.ReflectionTestUtils.setField(request, "loginId", null);
@@ -78,7 +78,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /dev/auth/signup - password 누락 시 400")
-	void signup_password_누락() throws Exception {
+	void 회원가입_패스워드_누락() throws Exception {
 		// given
 		DevSignupRequest request = DevSignupRequestFixture.createDefault();
 		org.springframework.test.util.ReflectionTestUtils.setField(request, "password", null);
@@ -92,7 +92,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /dev/auth/login - 로그인 성공")
-	void login_성공() throws Exception {
+	void 로그인_성공() throws Exception {
 		// given
 		DevLoginRequest request = DevLoginRequestFixture.createDefault();
 		DevAuthService.DevLoginResult loginResult =
@@ -118,7 +118,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /dev/auth/login - 잘못된 인증 정보 시 401")
-	void login_잘못된_인증() throws Exception {
+	void 로그인_잘못된_인증_정보() throws Exception {
 		// given
 		DevLoginRequest request = DevLoginRequestFixture.createDefault();
 

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
@@ -41,7 +41,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("GET /auth/kakao/login-url - 카카오 로그인 URL 조회 성공")
-	void getLoginUrl_성공() throws Exception {
+	void 카카오_로그인_URL_조회_성공() throws Exception {
 		// given
 		String expectedUrl = "https://kauth.kakao.com/oauth/authorize?client_id=test&redirect_uri=http://localhost&response_type=code";
 		given(kakaoOAuthClient.createLoginUrl(isNull())).willReturn(expectedUrl);
@@ -55,7 +55,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/kakao/login - 카카오 로그인 성공")
-	void kakaoLogin_성공() throws Exception {
+	void 카카오_로그인_성공() throws Exception {
 		// given
 		KakaoLoginRequest request = KakaoLoginRequestFixture.createDefault();
 
@@ -95,7 +95,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 
 	@Test
 	@DisplayName("POST /auth/kakao/login - 인가 코드 없으면 400")
-	void kakaoLogin_코드없음() throws Exception {
+	void 카카오_로그인_인가코드_없음() throws Exception {
 		// given
 		KakaoLoginRequest request = new KakaoLoginRequest();
 

--- a/Order-Core/build.gradle
+++ b/Order-Core/build.gradle
@@ -13,4 +13,7 @@ dependencies {
 	implementation "net.logstash.logback:logstash-logback-encoder:7.4"
 
 	runtimeOnly 'org.postgresql:postgresql'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/OrderCoreApplication.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/OrderCoreApplication.java
@@ -2,14 +2,10 @@ package com.goormgb.be.ordercore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.goormgb.be")
 @ConfigurationPropertiesScan(basePackages = "com.goormgb.be")
-@EnableJpaRepositories(basePackages = "com.goormgb.be")
-@EntityScan(basePackages = "com.goormgb.be")
 public class OrderCoreApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(OrderCoreApplication.class, args);

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceControllerTest.java
@@ -1,0 +1,227 @@
+package com.goormgb.be.ordercore.onboarding.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.fixture.OnboardingPreferenceDtoFixture;
+import com.goormgb.be.ordercore.fixture.OnboardingPreferenceRequestFixture;
+import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceCreateRequest;
+import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceUpdateRequest;
+import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceCreateResponse;
+import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceGetResponse;
+import com.goormgb.be.ordercore.onboarding.service.OnboardingPreferenceService;
+import com.goormgb.be.ordercore.support.WebMvcTestSupport;
+
+@WebMvcTest(controllers = OnboardingPreferenceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
+
+	@MockitoBean
+	private OnboardingPreferenceService onboardingPreferenceService;
+
+	private void setAuthentication(Long userId) {
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userId, null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+	}
+
+	@Test
+	@DisplayName("GET /onboarding/preferences - 선호도 조회 성공")
+	void 선호도_조회_성공() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceGetResponse response = new OnboardingPreferenceGetResponse(
+			List.of(
+				OnboardingPreferenceDtoFixture.createFirst(),
+				OnboardingPreferenceDtoFixture.createSecond(),
+				OnboardingPreferenceDtoFixture.createThird()
+			)
+		);
+
+		given(onboardingPreferenceService.getPreferences(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/onboarding/preferences"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.preferences").isArray())
+			.andExpect(jsonPath("$.data.preferences.length()").value(3))
+			.andExpect(jsonPath("$.data.preferences[0].priority").value(1))
+			.andExpect(jsonPath("$.data.preferences[0].viewpoint").value("CENTER"));
+	}
+
+	@Test
+	@DisplayName("GET /onboarding/preferences - 존재하지 않는 사용자 404")
+	void 선호도_조회_존재하지않는_사용자() throws Exception {
+		// given
+		Long userId = 999L;
+		setAuthentication(userId);
+
+		given(onboardingPreferenceService.getPreferences(userId))
+			.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(get("/onboarding/preferences"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("POST /onboarding/preferences - 선호도 생성 성공")
+	void 선호도_생성_성공() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceCreateRequest request = OnboardingPreferenceRequestFixture.createCreateRequest();
+
+		LocalDateTime now = LocalDateTime.of(2026, 2, 22, 12, 0, 0);
+		OnboardingPreferenceCreateResponse response = new OnboardingPreferenceCreateResponse(
+			true, now, true, now
+		);
+
+		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
+			.willReturn(response);
+
+		// when & then
+		mockMvc.perform(post("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.onboardingStatus").value(true))
+			.andExpect(jsonPath("$.data.marketingConsent").value(true))
+			.andExpect(jsonPath("$.data.onboardingCompletedAt").exists())
+			.andExpect(jsonPath("$.data.marketingConsentedAt").exists());
+	}
+
+	@Test
+	@DisplayName("POST /onboarding/preferences - 이미 온보딩이 완료된 경우 409")
+	void 선호도_생성_이미_온보딩_완료() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceCreateRequest request = OnboardingPreferenceRequestFixture.createCreateRequest();
+
+		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
+			.willThrow(new CustomException(ErrorCode.ONBOARDING_ALREADY_COMPLETED));
+
+		// when & then
+		mockMvc.perform(post("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.message").value("이미 온보딩이 완료되었습니다."));
+	}
+
+	@Test
+	@DisplayName("POST /onboarding/preferences - 존재하지 않는 사용자 404")
+	void 선호도_생성_존재하지않는_사용자() throws Exception {
+		// given
+		Long userId = 999L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceCreateRequest request = OnboardingPreferenceRequestFixture.createCreateRequest();
+
+		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
+			.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(post("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("PUT /onboarding/preferences - 선호도 수정 성공")
+	void 선호도_수정_성공() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
+
+		willDoNothing().given(onboardingPreferenceService)
+			.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
+
+		// when & then
+		mockMvc.perform(put("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"));
+	}
+
+	@Test
+	@DisplayName("PUT /onboarding/preferences - 수정할 선호도를 찾을 수 없음 404")
+	void 선호도_수정_수정할_선호도_없음() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
+
+		willThrow(new CustomException(ErrorCode.PREFERENCE_NOT_FOUND_FOR_UPDATE))
+			.given(onboardingPreferenceService)
+			.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
+
+		// when & then
+		mockMvc.perform(put("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("수정할 선호도 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("PUT /onboarding/preferences - 존재하지 않는 사용자 404")
+	void 선호도_수정_존재하지않는_사용자() throws Exception {
+		// given
+		Long userId = 999L;
+		setAuthentication(userId);
+
+		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
+
+		willThrow(new CustomException(ErrorCode.USER_NOT_FOUND))
+			.given(onboardingPreferenceService)
+			.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
+
+		// when & then
+		mockMvc.perform(put("/onboarding/preferences")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.ordercore.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import tools.jackson.databind.ObjectMapper;
+import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+
+@ActiveProfiles("test")
+public abstract class WebMvcTestSupport {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@MockitoBean
+	protected JwtAuthenticationFilter jwtAuthenticationFilter;
+}

--- a/common-core/src/main/java/com/goormgb/be/global/config/JpaConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.authguard.config;
+package com.goormgb.be.global.config;
 
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
 ## 🔧 작업 내용
- Order-Core 온보딩 API 테스트코드 작성
- 모든 모듈에서 `JpaConfig`를 사용하기에 `common-core`로 통합.
- 전체 컨트롤러 테스트 메서드명 컨벤션을 한글로 통일

### 어떤 문제를 해결했는지
- `@WebMvcTest` 실행 시 `OrderCoreApplication`에 직접 선언된 `@EnableJpaRepositories`가 로드되면서 `entityManagerFactory` 빈을 찾지 못해 컨텍스트 로드 실패 → `JpaConfig` 분리로 해결 -> `common-core`로 통합

### 왜 이런 방식으로 구현했는지
- `@WebMvcTest`는 Web 레이어 슬라이스만 로드하므로, 별도 `@Configuration` 클래스로 분리된 `JpaConfig`는 필터에 의해 자동 제외됨
- `JwtAuthenticationFilter`가 `common-core`에 위치하는 것과 동일하게, 전 모듈 공통으로 사용되는 JPA 설정도 `common-core`에 두는 것이 일관성 있음

## 🧩 구현 상세

### JpaConfig 공통화
- `Auth-Guard`, `Order-Core` 각각에 존재하던 동일한 `JpaConfig` 삭제
- `common-core/src/main/java/com/goormgb/be/global/config/JpaConfig.java`로 통합
- 기존 `JpaAuditingConfiguration`이 위치한 경로와 동일하게 배치

### 온보딩 Unit 테스트 작성
- `WebMvcTestSupport` 추상 클래스 구성 (`MockMvc`, `ObjectMapper`, `JwtAuthenticationFilter` mock)
- `@AuthenticationPrincipal`은 `SecurityContextHolder`에 직접 인증 객체 주입으로 처리
- GET, POST, PUT 각 엔드포인트에 대해 성공 / 예외 시나리오 포함, 총 8개 테스트

### 테스트 메서드명 컨벤션 통일
- 기존: `동사_상황()` (영문 동사 + 한글 혼용, ex. `tokenRefresh_성공`)
- 변경: 전체 한글 (ex. `토큰_재발급_성공`)
- 대상: `AuthControllerTest`, `DevAuthControllerTest`, `KakaoAuthControllerTest`

### 📌 관련 Jira Issue
- GRBG-154

## 🧪 테스트 방법

<img width="1233" height="613" alt="스크린샷 2026-02-22 오후 10 11 40" src="https://github.com/user-attachments/assets/f3a270c6-50f7-4d89-9f07-19bf344b16f2" />

- `OnboardingPreferenceController` 단위 테스트 실행
`./gradlew :Order-Core:test --tests "*.OnboardingPreferenceControllerTest"`

- 테스트 시나리오
  - `GET /onboarding/preferences` — 조회 성공 / 존재하지 않는 사용자 404
  - `POST /onboarding/preferences` — 생성 성공 / 이미 온보딩 완료 409 / 존재하지 않는 사용자 404
  - `PUT /onboarding/preferences` — 수정 성공 / 선호도 없음 404 / 존재하지 않는 사용자 404

## ❗ 참고 사항
- `Order-Core`의 `OrderCoreApplication`에서 `@EnableJpaRepositories`, `@EntityScan`이 제거되었으나, `common-core`의 `JpaConfig`가 컴포넌트 스캔으로 자동 픽업되므로 동작 변경 없음