### PR TITLE
refactor(auth-guard,common): GRGB-158 JWT 클래스 common-core에서 Auth-Guard로 이동                                                                

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -13,14 +13,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import com.goormgb.be.global.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
 
 import io.jsonwebtoken.Claims;
 
 import com.goormgb.be.authguard.auth.dto.RefreshTokenInfo;
-import com.goormgb.be.global.jwt.enums.TokenType;
-import com.goormgb.be.global.jwt.provider.JwtTokenProvider;
-import com.goormgb.be.global.jwt.repository.AccessTokenBlacklistRepository;
+import com.goormgb.be.authguard.jwt.enums.TokenType;
+import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.authguard.jwt.repository.AccessTokenBlacklistRepository;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
@@ -8,9 +8,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.goormgb.be.global.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
 import com.goormgb.be.authguard.auth.dto.RefreshTokenInfo;
-import com.goormgb.be.global.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.authguard.jwt.filter.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.global.jwt.config;
+package com.goormgb.be.authguard.jwt.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/enums/TokenType.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/enums/TokenType.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.global.jwt.enums;
+package com.goormgb.be.authguard.jwt.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/filter/JwtAuthenticationFilter.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/filter/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.global.jwt.filter;
+package com.goormgb.be.authguard.jwt.filter;
 
 import java.io.IOException;
 import java.util.List;
@@ -10,9 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.goormgb.be.global.jwt.enums.TokenType;
-import com.goormgb.be.global.jwt.provider.JwtTokenProvider;
-import com.goormgb.be.global.jwt.repository.AccessTokenBlacklistRepository;
+import com.goormgb.be.authguard.jwt.enums.TokenType;
+import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.authguard.jwt.repository.AccessTokenBlacklistRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.global.jwt.provider;
+package com.goormgb.be.authguard.jwt.provider;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -9,8 +9,8 @@ import javax.crypto.SecretKey;
 
 import org.springframework.stereotype.Component;
 
-import com.goormgb.be.global.jwt.config.JwtProperties;
-import com.goormgb.be.global.jwt.enums.TokenType;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.enums.TokenType;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/AccessTokenBlacklistRepository.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/AccessTokenBlacklistRepository.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.global.jwt.repository;
+package com.goormgb.be.authguard.jwt.repository;
 
 import java.time.Duration;
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.goormgb.be.global.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
 import com.goormgb.be.authguard.auth.dto.RefreshTokenInfo;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.WebUtils;
 
-import com.goormgb.be.global.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -1,12 +1,12 @@
 package com.goormgb.be.authguard.kakao.service;
 
-import com.goormgb.be.global.jwt.config.JwtProperties;
+import com.goormgb.be.authguard.jwt.config.JwtProperties;
 import com.goormgb.be.authguard.auth.dto.RefreshTokenInfo;
 import com.goormgb.be.authguard.kakao.client.KakaoOAuthClient;
 import com.goormgb.be.authguard.kakao.dto.KakaoLoginResponse;
 import com.goormgb.be.authguard.kakao.dto.KakaoTokenResponse;
 import com.goormgb.be.authguard.kakao.dto.KakaoUserResponse;
-import com.goormgb.be.global.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/support/WebMvcTestSupport.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/support/WebMvcTestSupport.java
@@ -7,7 +7,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import tools.jackson.databind.ObjectMapper;
 import com.goormgb.be.authguard.jwt.util.CookieUtils;
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.authguard.jwt.filter.JwtAuthenticationFilter;
 
 @ActiveProfiles("test")
 public abstract class WebMvcTestSupport {

--- a/common-core/build.gradle
+++ b/common-core/build.gradle
@@ -12,11 +12,6 @@ dependencies {
 	api 'org.springframework.boot:spring-boot-starter-webmvc'
 	api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 
-	// JWT
-	api 'io.jsonwebtoken:jjwt-api:0.13.0'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
-
 	runtimeOnly 'org.postgresql:postgresql'
 
 	// 필수: Actuator & Prometheus


### PR DESCRIPTION
## 🔧 작업 내용
- JWT 관련 클래스 5개를 `common-core`에서 `Auth-Guard`로 이동
- Auth-Guard 내부 import 경로를 `global.jwt.*` → `authguard.jwt.*`로 수정
- common-core에서 JWT 파일 및 jjwt 의존성 제거

**[멘토링 피드백 반영 작업]**
JWT는 Auth-Guard(인증/인가 서버)의 책임이며, 공통 라이브러리에 위치할 이유가 없음.                                                             
추후 API Gateway에서 JWT 검증을 담당하게 되면 다른 서비스들은 JWT 의존성이 완전히 불필요해지므로, 이번 작업으로 분리 기반을 마련함.

## 🧩 구현 상세

### 이동된 클래스 (common-core → Auth-Guard)
| 클래스 | 변경 전 패키지 | 변경 후 패키지 |
|--------|--------------|--------------|
| `JwtProperties` | `global.jwt.config` | `authguard.jwt.config` |
| `TokenType` | `global.jwt.enums` | `authguard.jwt.enums` |
| `JwtTokenProvider` | `global.jwt.provider` | `authguard.jwt.provider` |
| `JwtAuthenticationFilter` | `global.jwt.filter` | `authguard.jwt.filter` |
| `AccessTokenBlacklistRepository` | `global.jwt.repository` | `authguard.jwt.repository` |

### import 수정 대상 (Auth-Guard 내부)
- `AuthService`, `DevAuthService`, `KakaoAuthService`
- `CookieUtils`, `RefreshTokenRepository`
- `AuthGuardSecurityConfig`, `WebMvcTestSupport`

### 📌 관련 Jira Issue
- GRGB-158

## ❗ 참고 사항
### ⚠️ 이 PR 머지 후 일시적으로 빌드가 깨집니다 (의도된 상태)
**그래서 이번 #52 PR은 `dev`가 아닌 `feat/api-gateway`로 Merge 요청.**
Order-Core, Queue, Seat, Recommendation의 `SecurityConfig`가 `JwtAuthenticationFilter`를 참조하고 있는데, 해당 클래스가 common-core에서 삭제되었기 때문입니다.

이는 API Gateway 도입 작업의 일부로 **의도적으로 허용된 상태**입니다.
`feat/api-gateway` 브랜치 내 후속 PR에서 아래 작업을 통해 해결됩니다.

[ ] `common-core`에 `XUserIdAuthenticationFilter` 추가
[ ] 4개 서비스 `SecurityConfig`에서 JWT 필터 → `XUserIdAuthenticationFilter` 교체
[ ] 4개 서비스 `application.yaml`에서 `jwt:` 설정 제거
[ ] `API-Gateway` 모듈 신규 생성 및 JWT GlobalFilter 구현

  > API Gateway 전체 도입 배경 및 작업 계획은 [`API Gateway 도입 배경 및 개념 정리`](https://www.notion.so/API-Gateway-3109e3e335cc803a89f8f559fa8c2bef?source=copy_link) 참고