### PR TITLE
[hotfix] 전 모듈 기동 실패 수정 — @EnableJpaRepositories 중복 제거 및 SeatHoldMetricsRecorder 비활성화

### DIFF
--- a/Queue/src/main/java/com/goormgb/be/queue/QueueApplication.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/QueueApplication.java
@@ -2,14 +2,10 @@ package com.goormgb.be.queue;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.goormgb.be")
 @ConfigurationPropertiesScan(basePackages = "com.goormgb.be")
-@EnableJpaRepositories(basePackages = "com.goormgb.be")
-@EntityScan(basePackages = "com.goormgb.be")
 public class QueueApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(QueueApplication.class, args);

--- a/Recommendation/src/main/java/com/goormgb/be/recommendation/RecommendationApplication.java
+++ b/Recommendation/src/main/java/com/goormgb/be/recommendation/RecommendationApplication.java
@@ -2,14 +2,10 @@ package com.goormgb.be.recommendation;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.goormgb.be")
 @ConfigurationPropertiesScan(basePackages = "com.goormgb.be")
-@EnableJpaRepositories(basePackages = "com.goormgb.be")
-@EntityScan(basePackages = "com.goormgb.be")
 public class RecommendationApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(RecommendationApplication.class, args);

--- a/Seat/src/main/java/com/goormgb/be/seat/SeatApplication.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/SeatApplication.java
@@ -2,14 +2,10 @@ package com.goormgb.be.seat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.goormgb.be")
 @ConfigurationPropertiesScan(basePackages = "com.goormgb.be")
-@EnableJpaRepositories(basePackages = "com.goormgb.be")
-@EntityScan(basePackages = "com.goormgb.be")
 public class SeatApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SeatApplication.class, args);

--- a/Seat/src/main/java/com/goormgb/be/seat/metrics/SeatHoldMetricsRecorder.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/metrics/SeatHoldMetricsRecorder.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.function.Supplier;
 
-@Component
+// @Component // TODO: seat hold 기능 구현 후 활성화
 @RequiredArgsConstructor
 public class SeatHoldMetricsRecorder {
 


### PR DESCRIPTION
## 🔧 작업 내용
**문제: 서비스 모듈(Queue, Recommendation, Seat, Order-Core) 기동 시 Bean 중복 등록 에러 발생**

- 원인 1: common-core의 JpaConfig에 @EnableJpaRepositories(basePackages = "com.goormgb.be") 선언이 있는데, 각 모듈 Application 클래스에도 동일한
  어노테이션이 중복 선언되어 있었음
  - 해결 1: @SpringBootApplication(scanBasePackages = "com.goormgb.be")가 JpaConfig를 자동 스캔하므로, Application 클래스의 @EnableJpaRepositories
  / @EntityScan 제거

- 원인 2: Seat 모듈의 SeatHoldMetricsRecorder가 Supplier<Number> 빈을 생성자 주입으로 요구하나, 해당 빈이 등록되어 있지 않아 기동 실패
  - 해결 2: seat hold 기능 미구현 상태이므로 @Component 주석 처리로 임시 비활성화


## 🧩 구현 상세 (선택)
- JPA 설정 일원화 위치: common-core/src/main/java/com/goormgb/be/global/config/JpaConfig.java
  - 제거 대상 어노테이션: @EnableJpaRepositories, @EntityScan, 관련 import 2개
  - SeatHoldMetricsRecorder는 삭제하지 않고 // @Component 주석 처리로 코드 보존 — 이후 Supplier<Number> 구현 시 주석만 풀면 바로 활성화 가능

### 📌 관련 Jira Issue
- GRBG-159

## 🧪 테스트 방법(선택)
- 각 모듈 로컬 기동 후 Started XxxApplication in N seconds 로그 확인
- 대상 모듈: Auth-Guard, Queue, Recommendation, Seat, Order-Core
- 체크 포인트: APPLICATION FAILED TO START 미발생, Bean 중복 에러 미발생


## ❗ 참고 사항
- 후속 작업: SeatHoldMetricsRecorder — seat hold 기능 구현 시 @Component 주석 해제 및 SeatMetricsConfig에 Supplier<Number> 빈 등록 필요
- 배포 시 주의: Order-Core의 spring.jpa.hibernate.ddl-auto 설정이 create로 확인됨 → dev 배포 전 validate 또는 none으로 변경 필요 (별도 이슈 등록 예정)

fixes #54 