### PR TITLE
feat(club): 구단 전체 조회, 상세 조회

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubDetailGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubDetailGetResponse.java
@@ -1,0 +1,61 @@
+package com.goormgb.be.ordercore.club.dto.response;
+
+import com.goormgb.be.ordercore.club.entity.Club;
+import com.goormgb.be.ordercore.stadium.entity.Stadium;
+import com.goormgb.be.ordercore.state.entity.TeamSeasonStats;
+
+import java.math.BigDecimal;
+
+public record ClubDetailGetResponse(
+        Long clubId,
+        String koName,
+        String logoImg,
+        String clubColor,
+        StadiumDto stadium,
+        String homepageRedirectUrl,
+        CurrentSeasonStatsDto currentSeasonStats
+) {
+    public static ClubDetailGetResponse of(Club club, TeamSeasonStats stats) {
+        return new ClubDetailGetResponse(
+                club.getId(),
+                club.getKoName(),
+                club.getLogoImg(),
+                club.getClubColor(),
+                StadiumDto.from(club.getStadium()),
+                club.getHomepageRedirectUrl(),
+                stats == null ? null : CurrentSeasonStatsDto.from(stats)
+        );
+    }
+
+    public record StadiumDto(Long stadiumId, String koName) {
+        public static StadiumDto from(Stadium stadium) {
+            return new StadiumDto(stadium.getId(), stadium.getKoName());
+        }
+    }
+
+    public record CurrentSeasonStatsDto(
+            int seasonYear,
+            Integer seasonRanking,
+            Integer wins,
+            Integer draws,
+            Integer losses,
+            BigDecimal winRate,
+            BigDecimal battingAverage,
+            BigDecimal era,
+            BigDecimal gamesBehind
+    ) {
+        public static CurrentSeasonStatsDto from(TeamSeasonStats stats) {
+            return new CurrentSeasonStatsDto(
+                    stats.getSeasonYear(),
+                    stats.getSeasonRanking(),
+                    stats.getWins(),
+                    stats.getDraws(),
+                    stats.getLosses(),
+                    stats.getWinRate(),
+                    stats.getBattingAverage(),
+                    stats.getEra(),
+                    stats.getGamesBehind()
+            );
+        }
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubGetResponse.java
@@ -1,0 +1,21 @@
+package com.goormgb.be.ordercore.club.dto.response;
+
+import com.goormgb.be.ordercore.club.entity.Club;
+
+public record ClubGetResponse(
+        Long clubId,
+        String koName,
+        String enName,
+        String logoImg,
+        String clubColor
+) {
+    public static ClubGetResponse from(Club club) {
+        return new ClubGetResponse(
+               club.getId(),
+               club.getKoName(),
+               club.getEnName(),
+               club.getLogoImg(),
+               club.getClubColor()
+        );
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/repository/ClubRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/repository/ClubRepository.java
@@ -13,12 +13,15 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
-
     // TODO: service 레이어 구현할 때 필요한 부분 수정
 //    List<ClubListItemResponse> findAllClubList();
 //
-//    @EntityGraph(attributePaths = {"stadium"})
-//    Optional<Club> findWithStadiumById(Long id);
+    @EntityGraph(attributePaths = {"stadium"})
+    Optional<Club> findWithStadiumById(Long id);
+
+    default Club findWithStadiumByIdOrThrow(Long id, ErrorCode errorCode){
+        return findWithStadiumById(id).orElseThrow(() -> new CustomException(errorCode));
+    }
 
     /**
      * FR-C02 구단 상세 기본 정보 조회용 쿼리.

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
@@ -30,7 +30,7 @@ public class ClubService {
                 .toList();
     }
 
-    public ClubDetailGetResponse GetClubDetail(Long id) {
+    public ClubDetailGetResponse getClubDetail(Long id) {
         var club = clubRepository.findWithStadiumByIdOrThrow(id, ErrorCode.CLUB_NOT_FOUND);
 
         int currentYear = LocalDate.now().getYear();

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
@@ -1,0 +1,44 @@
+package com.goormgb.be.ordercore.club.service;
+
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.club.dto.response.ClubDetailGetResponse;
+import com.goormgb.be.ordercore.club.dto.response.ClubGetResponse;
+import com.goormgb.be.ordercore.club.repository.ClubRepository;
+import com.goormgb.be.ordercore.state.repository.TeamSeasonStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubService {
+    final private ClubRepository clubRepository;
+    final private TeamSeasonStatsRepository teamSeasonStatsRepository;
+
+    public List<ClubGetResponse> getAllClubs(){
+        var clubs = clubRepository.findAll();
+
+        Preconditions.validate(!clubs.isEmpty(), ErrorCode.CLUB_NOT_FOUND);
+
+        return clubs.stream()
+                .map(ClubGetResponse::from)
+                .toList();
+    }
+
+    public ClubDetailGetResponse GetClubDetail(Long id) {
+        var club = clubRepository.findWithStadiumByIdOrThrow(id, ErrorCode.CLUB_NOT_FOUND);
+
+        int currentYear = LocalDate.now().getYear();
+        var stats = teamSeasonStatsRepository
+                .findByClubIdAndSeasonYear(id, currentYear)
+                .orElse(null);
+
+        return ClubDetailGetResponse.of(club, stats);
+    }
+
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/state/repository/TeamSeasonStatsRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/state/repository/TeamSeasonStatsRepository.java
@@ -13,7 +13,7 @@ public interface TeamSeasonStatsRepository extends JpaRepository<TeamSeasonStats
 //
     Optional<TeamSeasonStats> findByClubIdAndSeasonYear(Long clubId, int seasonYear);
 
-    default TeamSeasonStats findByIdOtThrow(Long id, ErrorCode errorCode) {
+    default TeamSeasonStats findByIdOrThrow(Long id, ErrorCode errorCode) {
         return findById(id).orElseThrow(() -> new CustomException(errorCode));
     }
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/state/repository/TeamSeasonStatsRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/state/repository/TeamSeasonStatsRepository.java
@@ -1,5 +1,7 @@
 package com.goormgb.be.ordercore.state.repository;
 
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.state.entity.TeamSeasonStats;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,8 +9,12 @@ import java.util.Optional;
 
 public interface TeamSeasonStatsRepository extends JpaRepository<TeamSeasonStats, Long> {
 
-    Optional<TeamSeasonStats> findFirstByClubIdOrderBySeasonYearDesc(Long clubId);
-
+//    Optional<TeamSeasonStats> findFirstByClubIdOrderBySeasonYearDesc(Long clubId);
+//
     Optional<TeamSeasonStats> findByClubIdAndSeasonYear(Long clubId, int seasonYear);
+
+    default TeamSeasonStats findByIdOtThrow(Long id, ErrorCode errorCode) {
+        return findById(id).orElseThrow(() -> new CustomException(errorCode));
+    }
 
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -42,6 +42,10 @@ public enum ErrorCode {
 	BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
 	OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
 	OAUTH_CODE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "인가 코드는 필수입니다."),
+
+	// Club
+	CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "구단을 찾을 수 없습니다."),
+
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔧 작업 내용
- 구단 Service 레이어 구현


## 🧩 구현 상세 (선택)
**구단 전체 조회**
- DB에 존재하는 구단 정보를 전체 조회
- List로 반환

**구단 상세 조회**
- `clubId`를 기준으로 구단 상세 조회
- `repository`에 `findWithStadiumByIdOrThrow` 추가하여 clubId로 연관된 stadium까지 같이 조회
- `ClubDetaulGetResponse`에서 정적 팩토리 메소드 패턴기반으로 내부에서 dto 내부에서 처리할 수 있도록 했습니다

### 📌 관련 Jira Issue
- GRBG-160


## ❗ 참고 사항
- controller 작업하면서 오류 발생하면 수정하면서 진행해보겠습니다