### PR TITLE
feat(api-gateway): GRGB-166 API Gateway 모듈 초기 셋업

### DIFF
--- a/API-Gateway/build.gradle
+++ b/API-Gateway/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '4.0.2'
+	id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.goormgb.be'
+version = '0.0.1-SNAPSHOT'
+description = 'API Gateway - JWT 검증, 라우팅, CORS, 헤더 주입'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencyManagement {
+	imports {
+		// Spring Boot 4.0.2 호환 Spring Cloud BOM
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.1.1"
+	}
+}
+
+dependencies {
+	// Spring Cloud Gateway WebFlux (spring-boot-starter-web 절대 추가 금지)
+	// Spring Cloud 5.x부터 webflux/webmvc 분리됨
+	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
+
+	// Redis Reactive (ReactiveRedisTemplate — 블랙리스트 jti 확인용)
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+	// JWT 파싱
+	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+	// Actuator & Prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// JSON 로깅
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.projectreactor:reactor-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/ApiGatewayApplication.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/ApiGatewayApplication.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.apigateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApiGatewayApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ApiGatewayApplication.class, args);
+	}
+}

--- a/API-Gateway/src/main/resources/application-dev.yaml
+++ b/API-Gateway/src/main/resources/application-dev.yaml
@@ -1,0 +1,33 @@
+server:
+  port: 8085
+
+spring:
+  application:
+    name: api-gateway
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health, info, metrics, prometheus
+  endpoint:
+    health:
+      show-details: always
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+logging:
+  config: classpath:logback-spring.xml
+  level:
+    root: INFO
+    com.goormgb.be: DEBUG

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -1,0 +1,20 @@
+server:
+  port: 8085
+
+spring:
+  application:
+    name: api-gateway
+  jackson:
+    time-zone: UTC
+    date-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  issuer: ${JWT_ISSUER}
+  access-token:
+    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}

--- a/API-Gateway/src/main/resources/logback-spring.xml
+++ b/API-Gateway/src/main/resources/logback-spring.xml
@@ -1,4 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="logging/logback-base.xml"/>
+
+    <springProperty scope="context" name="SERVICE_NAME" source="spring.application.name"/>
+    <springProperty scope="context" name="ENVIRONMENT" source="spring.profiles.active"/>
+
+    <property name="SERVICE_NAME" value="${SERVICE_NAME:-api-gateway}"/>
+    <property name="ENVIRONMENT" value="${ENVIRONMENT:-local}"/>
+    <property name="APP_VERSION" value="1.0.0"/>
+
+    <appender name="STDOUT_JSON_ORIGIN" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>
+                {"service": "${SERVICE_NAME}", "environment": "${ENVIRONMENT}", "version": "${APP_VERSION}"}
+            </customFields>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT_JSON_ORIGIN"/>
+        <queueSize>1024</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
+    </appender>
+
+    <appender name="LOCAL_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{30}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="local">
+        <root level="WARN">
+            <appender-ref ref="LOCAL_CONSOLE"/>
+        </root>
+        <logger name="com.goormgb.be" level="DEBUG"/>
+    </springProfile>
+
+    <springProfile name="dev">
+        <appender name="FILE_DEV_ORIGIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>/var/log/backend/application.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>/var/log/backend/app-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>2GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+
+        <appender name="ASYNC_FILE_DEV" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE_DEV_ORIGIN"/>
+            <queueSize>1024</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT_JSON"/>
+            <appender-ref ref="ASYNC_FILE_DEV"/>
+        </root>
+        <logger name="com.goormgb.be" level="DEBUG"/>
+    </springProfile>
+
+    <!-- 프로파일 미설정 시 기본 콘솔 출력 -->
+    <springProfile name="!local &amp; !dev">
+        <root level="INFO">
+            <appender-ref ref="LOCAL_CONSOLE"/>
+        </root>
+        <logger name="com.goormgb.be" level="DEBUG"/>
+    </springProfile>
+
+    <logger name="io.opentelemetry" level="WARN"/>
+    <logger name="org.springframework.security" level="INFO"/>
+
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+
 </configuration>

--- a/API-Gateway/src/main/resources/logback-spring.xml
+++ b/API-Gateway/src/main/resources/logback-spring.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="logging/logback-base.xml"/>
+</configuration>

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.apigateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApiGatewayApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'goormgb'
 
-include 'Auth-Guard', 'common-core', 'Order-Core', 'Queue', 'Recommendation', 'Seat'
+include 'Auth-Guard', 'common-core', 'Order-Core', 'Queue', 'Recommendation', 'Seat', 'API-Gateway'


### PR DESCRIPTION
## 🔧 작업 내용
- MSA 구조에서 각 서비스가 직접 JWT를 검증하던 방식을 개선하기 위해 API Gateway 모듈을 신규 추가
- `settings.gradle`에 `API-Gateway` 서브모듈 등록
- Spring Cloud Gateway 5.x (WebFlux 기반) 의존성 구성 및 기본 애플리케이션 설정
- 기본 애플리케이션 설정 (포트 8085, Redis, JWT, Actuator)

## 🧩 구현 상세
- **Spring Cloud 2025.1.1 (Oakwood)** BOM 사용 — Spring Boot 4.0.2 호환 버전
- WebMVC(`spring-boot-starter-web`) 의존성 미포함 — WebFlux와 동시 사용 시 기동 불가
- ReactiveRedisTemplate 사용을 위해 `spring-boot-starter-data-redis-reactive` 추가 (다음작업 [GRGB-168-[BE] Gateway JWT 인증 GlobalFilter 구현](https://goorm-gongbang.atlassian.net/browse/GRGB-168?atlOrigin=eyJpIjoiMTY1ZjIwMzQ0OGIwNDUzNDk2Y2RlYWYzOTUzZGU4MzkiLCJwIjoiaiJ9) JWT 블랙리스트 확인에서 사용 예정)

### 📌 관련 Jira Issue
- GRGB-166

## 🧪 테스트 방법
- `./gradlew :API-Gateway:compileJava` — 컴파일 성공 확인

## ❗ 참고 사항
- 이 PR은 `feat/api-gateway` 베이스 브랜치로 머지 (dev 아님)
- 후속 작업: [GRGB-168](https://goorm-gongbang.atlassian.net/browse/GRGB-168?atlOrigin=eyJpIjoiMTY1ZjIwMzQ0OGIwNDUzNDk2Y2RlYWYzOTUzZGU4MzkiLCJwIjoiaiJ9) `feat/api-gateway-jwt-filter` — JWT GlobalFilter 구현
- 라우팅 설정, CORS, Swagger 통합은 [GRGB-167](https://goorm-gongbang.atlassian.net/browse/GRGB-167?atlOrigin=eyJpIjoiYmRmOGUxNTk4OTYwNDFhZjlhZGExNjA2YTVjMDAwNWIiLCJwIjoiaiJ9) [GRGB-165](https://goorm-gongbang.atlassian.net/browse/GRGB-169?atlOrigin=eyJpIjoiNWE5MDNhNzljNWZmNDlkMmIyNWRkNjczNWFkMzg4MzUiLCJwIjoiaiJ9)에서 진행 예정

[GRGB-168]: https://goorm-gongbang.atlassian.net/browse/GRGB-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRGB-167]: https://goorm-gongbang.atlassian.net/browse/GRGB-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ