### PR TITLE
feat(api-gateway): GRGB-168 JWT 인증 GlobalFilter 구현

### DIFF
--- a/API-Gateway/build.gradle
+++ b/API-Gateway/build.gradle
@@ -18,6 +18,10 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	// WebFlux 기반 모듈 — WebMVC 전이 의존성 유입 차단
+	all {
+		exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
+	}
 }
 
 repositories {

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/ApiGatewayApplication.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/ApiGatewayApplication.java
@@ -2,8 +2,10 @@ package com.goormgb.be.apigateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ApiGatewayApplication {
 
 	public static void main(String[] args) {

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,112 @@
+package com.goormgb.be.apigateway.filter;
+
+import java.util.List;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.goormgb.be.apigateway.jwt.enums.TokenType;
+import com.goormgb.be.apigateway.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.apigateway.jwt.repository.AccessTokenBlacklistRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	// 인증 없이 통과시킬 경로 prefix 목록
+	private static final List<String> WHITELIST = List.of(
+			"/auth/kakao",
+			"/auth/token/refresh",
+			"/dev/auth",
+			"/swagger-ui",
+			"/v3/api-docs",
+			"/actuator"
+	);
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final AccessTokenBlacklistRepository blacklistRepository;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		String path = exchange.getRequest().getPath().value();
+
+		if (isWhitelisted(path)) {
+			return chain.filter(exchange);
+		}
+
+		String token = resolveToken(exchange.getRequest());
+		if (token == null) {
+			log.debug("No JWT token found for path: {}", path);
+			return unauthorizedResponse(exchange);
+		}
+
+		try {
+			jwtTokenProvider.validateToken(token);
+
+			if (jwtTokenProvider.getTokenTypeFromToken(token) != TokenType.ACCESS) {
+				log.debug("Token type is not ACCESS for path: {}", path);
+				return unauthorizedResponse(exchange);
+			}
+
+			String jti = jwtTokenProvider.getJtiFromToken(token);
+			Long userId = jwtTokenProvider.getUserIdFromToken(token);
+			String authority = jwtTokenProvider.getAuthorityFromToken(token);
+
+			return blacklistRepository.isBlacklisted(jti)
+					.flatMap(isBlacklisted -> {
+						if (isBlacklisted) {
+							log.debug("Blacklisted token - jti: {}", jti);
+							return unauthorizedResponse(exchange);
+						}
+
+						ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+								.header("X-User-Id", String.valueOf(userId))
+								.header("X-User-Role", authority)
+								.build();
+
+						log.debug("JWT authenticated - userId: {}, role: {}", userId, authority);
+						return chain.filter(exchange.mutate().request(mutatedRequest).build());
+					});
+
+		} catch (Exception e) {
+			log.warn("JWT validation failed for path: {} - {}", path, e.getMessage());
+			return unauthorizedResponse(exchange);
+		}
+	}
+
+	@Override
+	public int getOrder() {
+		return -1;
+	}
+
+	private boolean isWhitelisted(String path) {
+		return WHITELIST.stream().anyMatch(path::startsWith);
+	}
+
+	private String resolveToken(ServerHttpRequest request) {
+		String bearerToken = request.getHeaders().getFirst(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+
+	private Mono<Void> unauthorizedResponse(ServerWebExchange exchange) {
+		exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+		return exchange.getResponse().setComplete();
+	}
+}

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -15,6 +15,8 @@ import com.goormgb.be.apigateway.jwt.enums.TokenType;
 import com.goormgb.be.apigateway.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.apigateway.jwt.repository.AccessTokenBlacklistRepository;
 
+import io.jsonwebtoken.Claims;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -26,6 +28,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
 	private static final String AUTHORIZATION_HEADER = "Authorization";
 	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String HEADER_USER_ID = "X-User-Id";
+	private static final String HEADER_USER_ROLE = "X-User-Role";
 
 	// 인증 없이 통과시킬 경로 prefix 목록
 	private static final List<String> WHITELIST = List.of(
@@ -55,16 +59,16 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 		}
 
 		try {
-			jwtTokenProvider.validateToken(token);
+			Claims claims = jwtTokenProvider.parseClaims(token);
 
-			if (jwtTokenProvider.getTokenTypeFromToken(token) != TokenType.ACCESS) {
+			if (jwtTokenProvider.getTokenType(claims) != TokenType.ACCESS) {
 				log.debug("Token type is not ACCESS for path: {}", path);
 				return unauthorizedResponse(exchange);
 			}
 
-			String jti = jwtTokenProvider.getJtiFromToken(token);
-			Long userId = jwtTokenProvider.getUserIdFromToken(token);
-			String authority = jwtTokenProvider.getAuthorityFromToken(token);
+			String jti = jwtTokenProvider.getJti(claims);
+			Long userId = jwtTokenProvider.getUserId(claims);
+			String authority = jwtTokenProvider.getAuthority(claims);
 
 			return blacklistRepository.isBlacklisted(jti)
 					.flatMap(isBlacklisted -> {
@@ -74,8 +78,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 						}
 
 						ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
-								.header("X-User-Id", String.valueOf(userId))
-								.header("X-User-Role", authority)
+								.header(HEADER_USER_ID, String.valueOf(userId))
+								.header(HEADER_USER_ROLE, authority)
 								.build();
 
 						log.debug("JWT authenticated - userId: {}, role: {}", userId, authority);

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/config/JwtProperties.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/config/JwtProperties.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.apigateway.jwt.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+	private String secretKey;
+	private String issuer;
+	private AccessToken accessToken = new AccessToken();
+
+	@Getter
+	@Setter
+	public static class AccessToken {
+		private String audience;
+	}
+}

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.goormgb.be.apigateway.jwt.provider;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.apigateway.jwt.config.JwtProperties;
+import com.goormgb.be.apigateway.jwt.enums.TokenType;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private static final String CLAIM_TOKEN_TYPE = "tokenType";
+	private static final String CLAIM_AUTH = "auth";
+
+	private final JwtProperties jwtProperties;
+	private SecretKey secretKey;
+
+	@PostConstruct
+	public void init() {
+		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+	}
+
+	public void validateToken(String token) {
+		try {
+			parseClaimsFromToken(token);
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("Invalid JWT token: {}", e.getMessage());
+			throw new IllegalArgumentException("Invalid JWT token", e);
+		}
+	}
+
+	public Long getUserIdFromToken(String token) {
+		return Long.parseLong(parseClaimsFromToken(token).getSubject());
+	}
+
+	public String getAuthorityFromToken(String token) {
+		return parseClaimsFromToken(token).get(CLAIM_AUTH, String.class);
+	}
+
+	public TokenType getTokenTypeFromToken(String token) {
+		String tokenTypeValue = parseClaimsFromToken(token).get(CLAIM_TOKEN_TYPE, String.class);
+		return TokenType.valueOf(tokenTypeValue);
+	}
+
+	public String getJtiFromToken(String token) {
+		return parseClaimsFromToken(token).getId();
+	}
+
+	private Claims parseClaimsFromToken(String token) {
+		return Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+	}
+}

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
@@ -31,37 +31,36 @@ public class JwtTokenProvider {
 		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
 	}
 
-	public void validateToken(String token) {
+	/**
+	 * JWT를 한 번만 파싱하여 Claims를 반환한다.
+	 * 필터에서 이 메서드를 단 한 번 호출하고 반환된 Claims에서 필요한 정보를 추출해야 한다.
+	 */
+	public Claims parseClaims(String token) {
 		try {
-			parseClaimsFromToken(token);
+			return Jwts.parser()
+					.verifyWith(secretKey)
+					.build()
+					.parseSignedClaims(token)
+					.getPayload();
 		} catch (JwtException | IllegalArgumentException e) {
 			log.warn("Invalid JWT token: {}", e.getMessage());
 			throw new IllegalArgumentException("Invalid JWT token", e);
 		}
 	}
 
-	public Long getUserIdFromToken(String token) {
-		return Long.parseLong(parseClaimsFromToken(token).getSubject());
+	public TokenType getTokenType(Claims claims) {
+		return TokenType.valueOf(claims.get(CLAIM_TOKEN_TYPE, String.class));
 	}
 
-	public String getAuthorityFromToken(String token) {
-		return parseClaimsFromToken(token).get(CLAIM_AUTH, String.class);
+	public Long getUserId(Claims claims) {
+		return Long.parseLong(claims.getSubject());
 	}
 
-	public TokenType getTokenTypeFromToken(String token) {
-		String tokenTypeValue = parseClaimsFromToken(token).get(CLAIM_TOKEN_TYPE, String.class);
-		return TokenType.valueOf(tokenTypeValue);
+	public String getAuthority(Claims claims) {
+		return claims.get(CLAIM_AUTH, String.class);
 	}
 
-	public String getJtiFromToken(String token) {
-		return parseClaimsFromToken(token).getId();
-	}
-
-	private Claims parseClaimsFromToken(String token) {
-		return Jwts.parser()
-				.verifyWith(secretKey)
-				.build()
-				.parseSignedClaims(token)
-				.getPayload();
+	public String getJti(Claims claims) {
+		return claims.getId();
 	}
 }

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/repository/AccessTokenBlacklistRepository.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,27 @@
+package com.goormgb.be.apigateway.jwt.repository;
+
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+/**
+ * Auth-Guard에서 등록한 블랙리스트 jti를 Redis에서 조회하는 Repository.
+ * Key 구조: token_blacklist:{jti}
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AccessTokenBlacklistRepository {
+
+	private static final String KEY_PREFIX = "token_blacklist:";
+
+	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+	public Mono<Boolean> isBlacklisted(String jti) {
+		return reactiveRedisTemplate.hasKey(KEY_PREFIX + jti)
+				.doOnNext(result -> log.debug("Blacklist check - jti: {}, blacklisted: {}", jti, result));
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- API Gateway에서 JWT를 검증하고 downstream 서비스에 사용자 정보를 헤더로 주입하는 GlobalFilter 구현
- 각 서비스가 JWT를 직접 검증하던 방식에서 Gateway 단일 검증으로 전환하는 작업의 핵심 필터 

## 🧩 구현 상세
- **JwtAuthenticationFilter** (`GlobalFilter`, `Ordered(-1)`)
  - `Authorization: Bearer {JWT}` 헤더 파싱 및 서명 검증
  - Redis 블랙리스트(`token_blacklist:{jti}`) 확인 — `ReactiveRedisTemplate` 사용
  - 검증 성공 시 downstream 헤더 주입: `X-User-Id`, `X-User-Role`
  - 검증 실패 시 `401 Unauthorized` 즉시 반환
  - 화이트리스트 경로는 필터 건너뜀 (`/auth/kakao`, `/auth/token/refresh`, `/dev/auth`, `/swagger-ui`, `/v3/api-docs`, `/actuator`)

- **JwtTokenProvider** — Gateway 전용 (토큰 검증/파싱만, 발급 없음)
- **AccessTokenBlacklistRepository** — Auth-Guard와 동일한 Redis Key(`token_blacklist:{jti}`) 조회, Reactive 구현
- **JwtProperties** — `@ConfigurationProperties(prefix = "jwt")` Gateway 전용 설정

> Auth-Guard와 JWT 로직이 유사하나, Gateway는 WebFlux 기반으로 common-core(WebMVC/JPA) 의존 불가하여 Gateway 내 별도 구현

### 📌 관련 Jira Issue
  - GRGB-168 (JWT GlobalFilter 구현)

  ## ❗ 참고 사항
- PR 대상 브랜치: `feat/api-gateway` (dev 아님)
- Auth-Guard의 `JwtAuthenticationFilter`는 GRGB-170 에서 `XUserIdAuthenticationFilter`로 교체 예정
- 라우팅 설정 미완료로 현재 모든 경로 404 응답 (다음작업에서 추가예정)