### PR TITLE
feat(config): 서비스별 context-path 및 liveness/readiness 헬스체크 설정

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/enums/TokenType.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/enums/TokenType.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.apigateway.jwt.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenType {
+	ACCESS("ACCESS"),
+	REFRESH("REFRESH");
+
+	private final String value;
+}

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -47,13 +47,13 @@ springdoc:
       - name: Auth-Guard
         url: http://localhost:8080/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -73,6 +73,11 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
     prometheus:
       enabled: true
   metrics:

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8080
+  servlet:
+    context-path: /auth
 
 spring:
   application:
@@ -45,15 +47,15 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/v3/api-docs
+        url: http://localhost:8080/auth/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -63,3 +65,16 @@ kakao:
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -1,7 +1,5 @@
 server:
   port: 8080
-  servlet:
-    context-path: /auth
 
 spring:
   application:
@@ -47,7 +45,7 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
+        url: http://localhost:8080/v3/api-docs
       - name: Queue
         url: http://localhost:8081/queue/v3/api-docs
       - name: Seat

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
-					"/actuator/health"
+					"/actuator/health/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8083
+  servlet:
+    context-path: /order
 
 spring:
   application:
@@ -47,13 +49,13 @@ springdoc:
       - name: Auth-Guard
         url: http://localhost:8080/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -73,6 +75,11 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
     prometheus:
       enabled: true
   metrics:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
+        url: http://localhost:8080/v3/api-docs
       - name: Queue
         url: http://localhost:8081/queue/v3/api-docs
       - name: Seat

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8083
+  servlet:
+    context-path: /order
 
 spring:
   application:
@@ -45,15 +47,15 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/v3/api-docs
+        url: http://localhost:8080/auth/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -63,3 +65,16 @@ kakao:
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
-					"/actuator/health"
+					"/actuator/health/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8081
+  servlet:
+    context-path: /queue
 
 spring:
   application:
@@ -47,13 +49,13 @@ springdoc:
       - name: Auth-Guard
         url: http://localhost:8080/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -73,6 +75,11 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
     prometheus:
       enabled: true
   metrics:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8081
+  servlet:
+    context-path: /queue
 
 spring:
   application:
@@ -45,15 +47,15 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/v3/api-docs
+        url: http://localhost:8080/auth/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -63,3 +65,16 @@ kakao:
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
+        url: http://localhost:8080/v3/api-docs
       - name: Queue
         url: http://localhost:8081/queue/v3/api-docs
       - name: Seat

--- a/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
+++ b/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
-					"/actuator/health"
+					"/actuator/health/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8084
+  servlet:
+    context-path: /recommendation
 
 spring:
   application:
@@ -47,13 +49,13 @@ springdoc:
       - name: Auth-Guard
         url: http://localhost:8080/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -73,6 +75,11 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
     prometheus:
       enabled: true
   metrics:

--- a/Recommendation/src/main/resources/application.yaml
+++ b/Recommendation/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8084
+  servlet:
+    context-path: /recommendation
 
 spring:
   application:
@@ -45,15 +47,15 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/v3/api-docs
+        url: http://localhost:8080/auth/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -63,3 +65,16 @@ kakao:
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/Recommendation/src/main/resources/application.yaml
+++ b/Recommendation/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
+        url: http://localhost:8080/v3/api-docs
       - name: Queue
         url: http://localhost:8081/queue/v3/api-docs
       - name: Seat

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 				.requestMatchers(
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
-					"/actuator/health"
+					"/actuator/health/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8082
+  servlet:
+    context-path: /seat
 
 spring:
   application:
@@ -47,13 +49,13 @@ springdoc:
       - name: Auth-Guard
         url: http://localhost:8080/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -73,6 +75,11 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
     prometheus:
       enabled: true
   metrics:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
+        url: http://localhost:8080/v3/api-docs
       - name: Queue
         url: http://localhost:8081/queue/v3/api-docs
       - name: Seat

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8082
+  servlet:
+    context-path: /seat
 
 spring:
   application:
@@ -45,15 +47,15 @@ springdoc:
   swagger-ui:
     urls:
       - name: Auth-Guard
-        url: http://localhost:8080/v3/api-docs
+        url: http://localhost:8080/auth/v3/api-docs
       - name: Queue
-        url: http://localhost:8081/v3/api-docs
+        url: http://localhost:8081/queue/v3/api-docs
       - name: Seat
-        url: http://localhost:8082/v3/api-docs
+        url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
-        url: http://localhost:8083/v3/api-docs
+        url: http://localhost:8083/order/v3/api-docs
       - name: Recommendation
-        url: http://localhost:8084/v3/api-docs
+        url: http://localhost:8084/recommendation/v3/api-docs
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
@@ -63,3 +65,16 @@ kakao:
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
   user-info-url: https://kapi.kakao.com/v2/user/me
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+  endpoints:
+    web:
+      exposure:
+        include: health


### PR DESCRIPTION
## 🔧 작업 내용
- 각 서비스에 servlet context-path 추가 (dev.yaml 도 추가)
- Spring Boot Actuator liveness/readiness 헬스체크 설정 추가
- Auth-Guard context-path 이중 경로 버그 수정

## 🧩 구현 상세
- 서비스별 context-path 설정
  -Queue: `/queue` / Seat: `/seat` Order-Core: `/order` / Recommendation: `/recommendation`
  - Auth-Guard는 컨트롤러에 `/auth` 매핑이 이미 존재하여 context-path 미적용
- `management.endpoint.health.probes.enabled: true` 로 헬스 프로브 활성화
- readiness 그룹에 `db` 포함하여 DB 연결 상태를 readiness 체크에 반영
- context-path 변경에 따라 swagger-ui API docs URL 일괄 업데이트
- SecurityConfig 헬스체크 경로 `/actuator/health` → `/actuator/health/**` 수정
- 
  ### 📌 관련 Jira Issue
  - GRGB-173

## ❗ 참고 사항
- API Gateway 라우팅 설정은 별도 브랜치에서 진행 예정
- Liveness: `GET /{context-path}/actuator/health/liveness`
- Readiness: `GET /{context-path}/actuator/health/readiness`

**[추후 리팩토링 예정]** 
Auth-Guard는 현재 컨트롤러 매핑에 `/auth`가 하드코딩되어 있어 context-path 적용 시 `/auth/auth/**` 이중 경로가 발생함. 다른 서비스와 통일성을 맞추려면 컨트롤러 매핑에서 `/auth` prefix 제거 + context-path 적용이 필요하나, 변경 범위가 크므로 별도 이슈로 처리 예정입니다