### PR TITLE
refactor(auth-guard): GRGB-175 context-path /auth 적용 및 경로 정리

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.authguard.auth.dto.TokenRefreshResponse;
@@ -23,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Auth", description = "인증 API")
 @RestController
-@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -29,13 +29,13 @@ public class AuthGuardSecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
-					"/auth/kakao/**",
-					"/auth/token/refresh",
+					"/kakao/**",
+					"/token/refresh",
 					"/dev/auth/**",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
 //					"/actuator/health"
-						"/actuator/**"
+					"/actuator/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth/kakao")
+@RequestMapping("/kakao")
 public class KakaoAuthController {
     private final KakaoAuthService kakaoAuthService;
     private final KakaoOAuthClient kakaoOAuthClient;

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8080
+  servlet:
+    context-path: /auth
 
 spring:
   application:

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -1,5 +1,7 @@
 server:
   port: 8080
+  servlet:
+    context-path: /auth
 
 spring:
   application:


### PR DESCRIPTION
## 🔧 작업 내용
- Auth-Guard에 `server.servlet.context-path: /auth` 적용
- context-path 도입으로 컨트롤러 `@RequestMapping`에 중복된 `/auth` prefix 제거                                                                                                                                                                                                                                
- Spring Security `requestMatchers` 경로도 context-path 기준으로 정리

## 🧩 구현 상세 (선택)
 ### 변경 파일 요약
  | 파일 | 변경 내용 |
  |------|-----------|
  | `application.yaml` / `application-dev.yaml` | `server.servlet.context-path: /auth` 추가 |
  | `AuthController.java` | `@RequestMapping("/auth")` 제거 |
  | `KakaoAuthController.java` | `@RequestMapping("/auth/kakao")` → `@RequestMapping("/kakao")` |
  | `AuthGuardSecurityConfig.java` | `/auth/kakao/**` → `/kakao/**`, `/auth/token/refresh` → `/token/refresh` |

  ### context-path 적용 후 실제 URL 변화 없음
  - context-path `/auth` + `@RequestMapping("/kakao")` → 외부 URL은 여전히 `/auth/kakao/**`
  - Spring Security의 `requestMatchers`는 context-path를 제외한 경로로 비교하므로 prefix 제거 필요

### 📌 관련 Jira Issue
- GRGB-175
- resolve #70 

## ❗ 한 줄 요약
Controller단에 prefix로 붙어있던 `@RequestMapping("/auth")` 제거함