### PR TITLE
feat(match): 경기 service 구현

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/repository/ClubRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/repository/ClubRepository.java
@@ -2,14 +2,10 @@ package com.goormgb.be.ordercore.club.repository;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
-import com.goormgb.be.ordercore.club.dto.response.ClubDetailFlatDto;
-import com.goormgb.be.ordercore.club.dto.response.ClubListItemResponse;
 import com.goormgb.be.ordercore.club.entity.Club;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
@@ -11,23 +11,4 @@ public record MatchGuideDto(
         PurchaseStatus purchaseStatus,
         String matchDdayLabel
 ) {
-    public static MatchGuideDto of(
-            String teamsDisplay,
-            String ageLimit,
-            String placeDisplay,
-            String addressDisplay,
-            String datetimeDisplay,
-            PurchaseStatus purchaseStatus,
-            String matchDdayLabel)
-    {
-        return new MatchGuideDto(
-                teamsDisplay,
-                ageLimit,
-                placeDisplay,
-                addressDisplay,
-                datetimeDisplay,
-                purchaseStatus,
-                matchDdayLabel
-        );
-    }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
@@ -1,0 +1,33 @@
+package com.goormgb.be.ordercore.match.dto;
+
+import com.goormgb.be.ordercore.match.enums.PurchaseStatus;
+
+public record MatchGuideDto(
+        String teamsDisplay,
+        String ageLimit,
+        String placeDisplay,
+        String addressDisplay,
+        String datetimeDisplay,
+        PurchaseStatus purchaseStatus,
+        String matchDdayLabel
+) {
+    public static MatchGuideDto of(
+            String teamsDisplay,
+            String ageLimit,
+            String placeDisplay,
+            String addressDisplay,
+            String datetimeDisplay,
+            PurchaseStatus purchaseStatus,
+            String matchDdayLabel)
+    {
+        return new MatchGuideDto(
+                teamsDisplay,
+                ageLimit,
+                placeDisplay,
+                addressDisplay,
+                datetimeDisplay,
+                purchaseStatus,
+                matchDdayLabel
+        );
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/ClubMonthlyMatchesResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/ClubMonthlyMatchesResponse.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.ordercore.match.dto.response;
+
+import com.goormgb.be.ordercore.match.enums.SaleStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ClubMonthlyMatchesResponse(
+        Long clubId,
+        int year,
+        int month,
+        int totalMatchCount,
+        List<MatchItem> matches
+) {
+    public static ClubMonthlyMatchesResponse of(Long clubId, int year, int month, List<MatchItem> items) {
+        return new ClubMonthlyMatchesResponse(clubId, year, month, items.size(), items);
+    }
+
+    public record MatchItem(
+            Long matchId,
+            LocalDateTime matchAt,
+            OpponentClub opponentClub,
+            SaleStatus saleStatus,
+            boolean isHomeMatch
+    ) {}
+
+    public record OpponentClub(
+            Long clubId,
+            String koName,
+            String logoImg
+    ) {}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchDetailGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchDetailGetResponse.java
@@ -1,0 +1,46 @@
+package com.goormgb.be.ordercore.match.dto.response;
+
+import com.goormgb.be.ordercore.club.entity.Club;
+import com.goormgb.be.ordercore.match.dto.MatchGuideDto;
+import com.goormgb.be.ordercore.match.entity.Match;
+import com.goormgb.be.ordercore.match.enums.SaleStatus;
+
+import java.time.LocalDateTime;
+
+public record MatchDetailGetResponse(
+        Long matchId,
+        LocalDateTime matchAt,
+        SaleStatus saleStatus,
+        ClubDto homeClub,
+        ClubDto awayClub,
+        MatchGuideDto matchGuide
+) {
+    public static MatchDetailGetResponse of(Match match, MatchGuideDto matchGuide){
+        return new MatchDetailGetResponse(
+                match.getId(),
+                match.getMatchAt(),
+                match.getSaleStatus(),
+                ClubDto.from(match.getHomeClub()),
+                ClubDto.from(match.getAwayClub()),
+                matchGuide
+        );
+    }
+
+    public record ClubDto(
+            Long clubId,
+            String koName,
+            String enName,
+            String logoImg,
+            String clubColor
+    ){
+        public static ClubDto from(Club club){
+            return new ClubDto(
+                    club.getId(),
+                    club.getKoName(),
+                    club.getEnName(),
+                    club.getLogoImg(),
+                    club.getClubColor()
+            );
+        }
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
@@ -1,0 +1,63 @@
+package com.goormgb.be.ordercore.match.dto.response;
+
+import com.goormgb.be.ordercore.club.entity.Club;
+import com.goormgb.be.ordercore.match.entity.Match;
+import com.goormgb.be.ordercore.match.enums.SaleStatus;
+import com.goormgb.be.ordercore.stadium.entity.Stadium;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MatchListByDateResponse(
+        LocalDate date,
+        int matchCount,
+        List<MatchSummary> matches
+) {
+    public static MatchListByDateResponse of(LocalDate date, List<MatchSummary> matches) {
+        return new MatchListByDateResponse(date, matches.size(), matches);
+    }
+
+    public record MatchSummary(
+            Long matchId,
+            LocalDateTime matchAt,
+            SaleStatus saleStatus,
+            LocalDateTime salesOpenAt,
+            ClubDto homeClub,
+            ClubDto awayClub,
+            StadiumDto stadium
+    ) {
+        public static MatchSummary of(Match m, LocalDateTime salesOpenAt) {
+            return new MatchSummary(
+                    m.getId(),
+                    m.getMatchAt(),
+                    m.getSaleStatus(),
+                    salesOpenAt,
+                    ClubDto.from(m.getHomeClub()),
+                    ClubDto.from(m.getAwayClub()),
+                    StadiumDto.from(m.getStadium())
+            );
+        }
+    }
+
+    public record ClubDto(
+            Long clubId,
+            String koName,
+            String enName,
+            String logoImg
+    ) {
+        public static ClubDto from(Club c) {
+            return new ClubDto(c.getId(), c.getKoName(), c.getEnName(), c.getLogoImg());
+        }
+    }
+
+    public record StadiumDto(
+            Long stadiumId,
+            String koName,
+            String enName
+    ) {
+        public static StadiumDto from(Stadium s) {
+            return new StadiumDto(s.getId(), s.getKoName(), s.getEnName());
+        }
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/entity/Match.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/entity/Match.java
@@ -10,7 +10,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 @Entity
 @Table(name = "matches", uniqueConstraints = {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/entity/Match.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/entity/Match.java
@@ -10,12 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
-import java.time.temporal.ChronoUnit;
-import java.util.Locale;
 
 @Entity
 @Table(name = "matches", uniqueConstraints = {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/enums/PurchaseStatus.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/enums/PurchaseStatus.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.ordercore.match.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PurchaseStatus {
+    PURCHASABLE("구매 가능"),
+    NOT_PURCHASABLE("구매 불가")
+    ;
+
+    private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
@@ -3,14 +3,17 @@ package com.goormgb.be.ordercore.match.repository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.match.entity.Match;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
-    default Match findByOrThrow(Long id, ErrorCode errorCode) {
+    default Match findByIdOrThrow(Long id, ErrorCode errorCode) {
         return findById(id).orElseThrow(() -> new CustomException(errorCode));
     }
 
@@ -26,4 +29,10 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
         return findDetailById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
     }
+
+    @EntityGraph(attributePaths = {"homeClub", "awayClub", "stadium"})
+    List<Match> findAllByMatchAtGreaterThanEqualAndMatchAtLessThanOrderByMatchAtAsc(
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
@@ -4,9 +4,26 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.match.entity.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
     default Match findByOrThrow(Long id, ErrorCode errorCode) {
         return findById(id).orElseThrow(() -> new CustomException(errorCode));
+    }
+
+    @Query("""
+        select m from Match m
+        join fetch m.homeClub
+        join fetch m.awayClub
+        join fetch m.stadium
+        where m.id = :matchId
+    """)
+    Optional<Match> findDetailById(@Param("matchId") Long matchId);
+    default Match findDetailByIdOrThrow(Long id) {
+        return findDetailById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
     }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/repository/MatchRepository.java
@@ -35,4 +35,18 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
             LocalDateTime start,
             LocalDateTime end
     );
+
+    @EntityGraph(attributePaths = {"homeClub", "awayClub"})
+    @Query("""
+    select m from Match m
+    where (m.homeClub.id = :clubId or m.awayClub.id = :clubId)
+      and m.matchAt >= :start
+      and m.matchAt < :end
+    order by m.matchAt asc
+""")
+    List<Match> findMonthlyByClubId(
+            @Param("clubId") Long clubId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
@@ -1,12 +1,18 @@
 package com.goormgb.be.ordercore.match.service;
 
 import com.goormgb.be.ordercore.match.dto.response.MatchDetailGetResponse;
+import com.goormgb.be.ordercore.match.dto.response.MatchListByDateResponse;
+import com.goormgb.be.ordercore.match.entity.Match;
 import com.goormgb.be.ordercore.match.repository.MatchRepository;
 import com.goormgb.be.ordercore.match.utils.MatchDisplayUtils;
+import com.goormgb.be.ordercore.match.utils.SalesOpenUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,11 +20,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class MatchService {
     final private MatchRepository matchRepository;
     final private MatchDisplayUtils matchDisplayUtils;
+    final private SalesOpenUtils salesOpenUtils;
 
     public MatchDetailGetResponse getMatchDetail(Long id){
         var match = matchRepository.findDetailByIdOrThrow(id);
         var matchGuide = matchDisplayUtils.toGuide(match);
 
         return MatchDetailGetResponse.of(match, matchGuide);
+    }
+
+    public MatchListByDateResponse getMatchesByDate(LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+        List<Match> matches = matchRepository.findAllByMatchAtGreaterThanEqualAndMatchAtLessThanOrderByMatchAtAsc(start, end);
+
+        var summaries = matches.stream()
+                .map(m -> MatchListByDateResponse.MatchSummary.of(m, salesOpenUtils.calculateSalesOpenAt(m)))
+                .toList();
+
+        return MatchListByDateResponse.of(date, summaries);
     }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
@@ -1,5 +1,10 @@
 package com.goormgb.be.ordercore.match.service;
 
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.club.repository.ClubRepository;
+import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
+import com.goormgb.be.ordercore.club.entity.Club;
 import com.goormgb.be.ordercore.match.dto.response.MatchDetailGetResponse;
 import com.goormgb.be.ordercore.match.dto.response.MatchListByDateResponse;
 import com.goormgb.be.ordercore.match.entity.Match;
@@ -12,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
@@ -19,6 +25,7 @@ import java.util.List;
 @Transactional
 public class MatchService {
     final private MatchRepository matchRepository;
+    final private ClubRepository clubRepository;
     final private MatchDisplayUtils matchDisplayUtils;
     final private SalesOpenUtils salesOpenUtils;
 
@@ -40,5 +47,38 @@ public class MatchService {
                 .toList();
 
         return MatchListByDateResponse.of(date, summaries);
+    }
+
+    public ClubMonthlyMatchesResponse getClubMonthlyMatches(Long clubId, int year, int month){
+        Preconditions.validate(clubRepository.existsById(clubId), ErrorCode.CLUB_NOT_FOUND);
+
+        YearMonth ym = YearMonth.of(year, month);
+        LocalDateTime start = ym.atDay(1).atStartOfDay();
+        LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+
+        List<Match> matches = matchRepository.findMonthlyByClubId(clubId, start, end);
+
+        List<ClubMonthlyMatchesResponse.MatchItem> items = matches.stream()
+                .map(m -> toItem(clubId, m))
+                .toList();
+
+        return ClubMonthlyMatchesResponse.of(clubId, year, month, items);
+    }
+
+    private ClubMonthlyMatchesResponse.MatchItem toItem(Long clubId, Match m) {
+        boolean isHome = m.getHomeClub().getId().equals(clubId);
+        Club opponent = isHome ? m.getAwayClub() : m.getHomeClub();
+
+        return new ClubMonthlyMatchesResponse.MatchItem(
+                m.getId(),
+                m.getMatchAt(),
+                new ClubMonthlyMatchesResponse.OpponentClub(
+                        opponent.getId(),
+                        opponent.getKoName(),
+                        opponent.getLogoImg()
+                ),
+                m.getSaleStatus(),
+                isHome
+        );
     }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
@@ -1,0 +1,24 @@
+package com.goormgb.be.ordercore.match.service;
+
+import com.goormgb.be.ordercore.match.dto.response.MatchDetailGetResponse;
+import com.goormgb.be.ordercore.match.repository.MatchRepository;
+import com.goormgb.be.ordercore.match.utils.MatchDisplayUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchService {
+    final private MatchRepository matchRepository;
+    final private MatchDisplayUtils matchDisplayUtils;
+
+    public MatchDetailGetResponse getMatchDetail(Long id){
+        var match = matchRepository.findDetailByIdOrThrow(id);
+        var matchGuide = matchDisplayUtils.toGuide(match);
+
+        return MatchDetailGetResponse.of(match, matchGuide);
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
@@ -4,6 +4,7 @@ import com.goormgb.be.ordercore.match.dto.MatchGuideDto;
 import com.goormgb.be.ordercore.match.entity.Match;
 import com.goormgb.be.ordercore.match.enums.PurchaseStatus;
 import com.goormgb.be.ordercore.match.enums.SaleStatus;
+import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -14,6 +15,12 @@ import java.util.Locale;
 
 @Component
 public class MatchDisplayUtils {
+    final String DEFAULT_AGE_LIMIT = "전체관람가";
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy년 MM월 dd일", Locale.KOREAN);
+
+    private static final DateTimeFormatter TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm");
 
     public MatchGuideDto toGuide(Match match) {
         return new MatchGuideDto(
@@ -23,7 +30,7 @@ public class MatchDisplayUtils {
                 createAddressDisplay(match),
                 createDateTimeDisplay(match),
                 createPurchaseStatus(match),
-                createMatchDdayLabel(match)
+                createMatchDdayLabel(match, LocalDate.now())
         );
     }
 
@@ -32,7 +39,7 @@ public class MatchDisplayUtils {
     }
 
     public String createAgeLimit(){
-        return "전체관람가";
+        return DEFAULT_AGE_LIMIT;
     }
 
     public String createPlaceDisplay(Match match) {
@@ -43,19 +50,15 @@ public class MatchDisplayUtils {
         return match.getStadium().getAddress();
     }
 
-    public String createDateTimeDisplay(Match match){
-        DateTimeFormatter dateFormatter =
-                DateTimeFormatter.ofPattern("yyyy년 MM월 dd일", Locale.KOREAN);
+    public String createDateTimeDisplay(Match match) {
+        var matchAt = match.getMatchAt();
 
-        DateTimeFormatter timeFormatter =
-                DateTimeFormatter.ofPattern("HH:mm");
-
-        String dayOfWeek = match.getMatchAt().getDayOfWeek()
+        String dayOfWeek = matchAt.getDayOfWeek()
                 .getDisplayName(TextStyle.SHORT, Locale.KOREAN);
 
-        return match.getMatchAt().format(dateFormatter)
+        return matchAt.format(DATE_FORMATTER)
                 + " (" + dayOfWeek + ") "
-                + match.getMatchAt().format(timeFormatter);
+                + matchAt.format(TIME_FORMATTER);
     }
 
     public PurchaseStatus createPurchaseStatus(Match match){
@@ -64,8 +67,7 @@ public class MatchDisplayUtils {
                 : PurchaseStatus.NOT_PURCHASABLE;
     }
 
-    public String createMatchDdayLabel(Match match){
-        LocalDate today = LocalDate.now();
+    public String createMatchDdayLabel(Match match, LocalDate today){
         LocalDate matchDate = match.getMatchAt().toLocalDate();
 
         long diff = ChronoUnit.DAYS.between(today, matchDate);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
@@ -1,0 +1,78 @@
+package com.goormgb.be.ordercore.match.utils;
+
+import com.goormgb.be.ordercore.match.dto.MatchGuideDto;
+import com.goormgb.be.ordercore.match.entity.Match;
+import com.goormgb.be.ordercore.match.enums.PurchaseStatus;
+import com.goormgb.be.ordercore.match.enums.SaleStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+
+@Component
+public class MatchDisplayUtils {
+
+    public MatchGuideDto toGuide(Match match) {
+        return MatchGuideDto.of(
+                createTeamsDisplay(match),
+                createAgeLimit(),
+                createPlaceDisplay(match),
+                createAddressDisplay(match),
+                createDateTimeDisplay(match),
+                createPurchaseStatus(match),
+                createMatchDdayLabel(match)
+        );
+    }
+
+    public String createTeamsDisplay(Match match){
+        return match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName();
+    }
+
+    public String createAgeLimit(){
+        return "전체관람가";
+    }
+
+    public String createPlaceDisplay(Match match) {
+        return match.getStadium().getKoName();
+    }
+
+    public String createAddressDisplay(Match match){
+        return match.getStadium().getAddress();
+    }
+
+    public String createDateTimeDisplay(Match match){
+        DateTimeFormatter dateFormatter =
+                DateTimeFormatter.ofPattern("yyyy년 MM월 dd일", Locale.KOREAN);
+
+        DateTimeFormatter timeFormatter =
+                DateTimeFormatter.ofPattern("HH:mm");
+
+        String dayOfWeek = match.getMatchAt().getDayOfWeek()
+                .getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+
+        return match.getMatchAt().format(dateFormatter)
+                + " (" + dayOfWeek + ") "
+                + match.getMatchAt().format(timeFormatter);
+    }
+
+    public PurchaseStatus createPurchaseStatus(Match match){
+        return match.getSaleStatus() == SaleStatus.ON_SALE
+                ? PurchaseStatus.PURCHASABLE
+                : PurchaseStatus.NOT_PURCHASABLE;
+    }
+
+    public String createMatchDdayLabel(Match match){
+        LocalDate today = LocalDate.now();
+        LocalDate matchDate = match.getMatchAt().toLocalDate();
+
+        long diff = ChronoUnit.DAYS.between(today, matchDate);
+
+        if (diff > 0) return "D-" + diff;
+        if (diff == 0) return "D-DAY";
+
+        return "D+" + Math.abs(diff);
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/MatchDisplayUtils.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 public class MatchDisplayUtils {
 
     public MatchGuideDto toGuide(Match match) {
-        return MatchGuideDto.of(
+        return new MatchGuideDto(
                 createTeamsDisplay(match),
                 createAgeLimit(),
                 createPlaceDisplay(match),

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
@@ -7,11 +7,15 @@ import java.time.LocalDateTime;
 
 @Component
 public class SalesOpenUtils {
+    private static final int SALES_OPEN_DAYS_BEFORE_MATCH = 7;
+    private static final int SALES_OPEN_HOUR = 11;
+    private static final int SALES_OPEN_MINUTE = 0;
+
     public LocalDateTime calculateSalesOpenAt(Match match) {
         return match.getMatchAt()
-                .minusDays(7)
-                .withHour(11)
-                .withMinute(0)
+                .minusDays(SALES_OPEN_DAYS_BEFORE_MATCH)
+                .withHour(SALES_OPEN_HOUR)
+                .withMinute(SALES_OPEN_MINUTE)
                 .withSecond(0)
                 .withNano(0);
     }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
@@ -1,0 +1,18 @@
+package com.goormgb.be.ordercore.match.utils;
+
+import com.goormgb.be.ordercore.match.entity.Match;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class SalesOpenUtils {
+    public LocalDateTime calculateSalesOpenAt(Match match) {
+        return match.getMatchAt()
+                .minusDays(7)
+                .withHour(11)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+    }
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -46,6 +46,10 @@ public enum ErrorCode {
 	// Club
 	CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "구단을 찾을 수 없습니다."),
 
+	// Match
+	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다."),
+
+
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔧 작업 내용
- 경기 상세 조회
- 날짜 별 경기 조회
- 구단 경기 일정 조회


## 🧩 구현 상세 (선택)
**경기 상세 조회**
- `MatchDetailGetResponse`, `MatchGuideDto`로 데이터 전달
- display 계산 함수를 `MatchDisplayUtil`로 분리

**날짜 별 경기 조회**
- `MatchListByDateResponse`로 데이터 전달
- 날짜 계산 함수를 `SalesOpenUtil`로 분리

**구단 경기 일정 조회**
- `ClubMonthlyMatchesResponse`로 데이터 전달
> club controller에서 사용할 듯 함

### 📌 관련 Jira Issue
- GRBG-161


## ❗ 참고 사항
- club이랑 match랑 섞여있는 데이터가 많아서 controller할 때 조금 수정 필요한 부분 수정해야될듯 합니다
- repository도 N+1 문제 생기지 않도록 구현했는데 controller 구현할 때 직접 확인 필요할듯 합니다.