### PR TITLE
[BE] PR 제목 Jira 이슈키 자동 추가 GitHub Actions 워크플로 구현 [GRGB-177]

### DIFF
--- a/.github/workflows/pr-jira-title.yml
+++ b/.github/workflows/pr-jira-title.yml
@@ -1,0 +1,54 @@
+name: Add Jira Key to PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  update-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      # PR 본문에서 GRGB 이슈키 추출 후 제목 맨 뒤에 자동 추가
+      - name: Extract Jira Key and Update PR Title
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title;
+            const body = context.payload.pull_request.body || '';
+
+            // 제목에 이미 GRGB 키가 있으면 스킵
+            if (/GRGB-\d+/.test(title)) {
+              console.log('Jira key already in title, skipping');
+              return;
+            }
+
+            // PR 본문에서 GRGB 이슈키 추출 (ex. GRGB-161)
+            const match = body.match(/GRGB-\d+/);
+            if (!match) {
+              console.log('No Jira key found in PR body, skipping');
+              return;
+            }
+
+            const jiraKey = match[0];
+            const newTitle = `${title} [${jiraKey}]`;
+
+            // PR 제목 맨 뒤에 Jira 이슈키 추가
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              title: newTitle
+            });
+
+            // 성공 시 PR 댓글 자동 등록
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `🔗 원활한 Jira 자동화를 위해 PR 제목에 이슈키 **${jiraKey}** 를 추가했어요!`
+            });
+
+            console.log(`Updated PR title: ${newTitle}`);


### PR DESCRIPTION
## 🔧 작업 내용
- PR 제목에 Jira 이슈키 자동 추가 GitHub Actions 워크플로 구현
- PR 본문에 이슈키가 있지만 제목에 없는 경우 자동으로 제목 맨 뒤에 추가
- Jira 자동화(진행중 → 리뷰중) 트리거가 PR 제목 기반이라 누락 방지를 위해 구현

## 🧩 구현 상세 (선택)
- PR 본문에서 GRGB-\d+ 정규식으로 이슈키 추출
- 제목에 이미 이슈키가 있으면 스킵 처리
- 이슈키 추가 성공 시 PR 댓글로 안내 메시지 자동 등록

### 📌 관련 Jira Issue
- GRGB-177

## 🧪 테스트 방법(선택)
- PR 제목에 이슈키 없이 생성
- PR 본문 관련 Jira Issue 항목에 GRGB-XXX 형식으로 이슈키 작성
- PR 제목 맨 뒤에 [GRGB-XXX] 자동 추가 확인
- PR 댓글에 안내 메시지 등록 확인

## ❗ 참고 사항
- PR 본문에 이슈키가 없으면 동작하지 않음 (스킵)
- edited 이벤트도 트리거되므로 PR 수정 시에도 동작