### PR TITLE
fix(monitoring): application-dev 파일 prometheus 경로 수정

### DIFF
--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -75,6 +75,13 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -75,11 +75,9 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 
 logging:

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -75,6 +75,13 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -73,11 +73,9 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 
 logging:

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -75,6 +75,13 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -73,11 +73,9 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 
 logging:

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -75,6 +75,13 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -73,11 +73,9 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 
 logging:

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -75,6 +75,13 @@ management:
   endpoint:
     health:
       show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, db
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -73,11 +73,9 @@ management:
   endpoint:
     health:
       show-details: always
-    prometheus:
-      enabled: true
-  metrics:
-    export:
-      prometheus:
+  prometheus:
+    metrics:
+      export:
         enabled: true
 
 logging:


### PR DESCRIPTION
## 🔧 작업 내용
- prometheus 키 경로 변경


## 🧩 구현 상세 (선택)
```java
# 변경 전 (Deprecated)
management:
  metrics:
    export:
      prometheus:
        enabled: true
# management.metrics.export.prometheus.enabled 경로가 더 이상 사용되지 않음

# 변경 후
management:
  prometheus:
    metrics:
      export:
        enabled: true

# management.prometheus.metrics.export.enabled 경로로 바꿔야 합니다.
```

### 📌 관련 Jira Issue
- GRBG-176


## ❗ 참고 사항
fixes #72  