### PR TITLE
feat(club): 구단 상세 조회 API

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -1,0 +1,29 @@
+package com.goormgb.be.ordercore.club.controller;
+
+import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.ordercore.club.dto.response.ClubDetailGetResponse;
+import com.goormgb.be.ordercore.club.service.ClubService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Club", description = "구단 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/clubs")
+public class ClubController {
+    final private ClubService clubService;
+
+    @Operation(summary = "구단 상세 조회", description = "구단 상세를 조회합니다.")
+    @GetMapping("/{clubId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<ClubDetailGetResponse> getClubDetail(
+            @PathVariable Long clubId
+    ) {
+        var club = clubService.getClubDetail(clubId);
+
+        return ApiResult.ok(club);
+    }
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/clubs")
 public class ClubController {
-    final private ClubService clubService;
+    private final ClubService clubService;
 
     @Operation(summary = "구단 상세 조회", description = "구단 상세를 조회합니다.")
     @GetMapping("/{clubId}")


### PR DESCRIPTION
## 🔧 작업 내용
구단 상세 조회 API 구현


## 🧩 구현 상세 (선택)
**구단 상세 조회 API**
`GET /clubs/{clubId}`
- 구단 상세 페이지에서 구단 상세 정보를 조회



### 📌 관련 Jira Issue
- GRBG-116


## 🧪 테스트 방법(선택)
<img width="797" height="770" alt="image" src="https://github.com/user-attachments/assets/b03d7fb0-a1cb-4b63-a06b-1df59344944a" />


## ❗ 참고 사항
- 스웨거에서 요청할 때 해당 정보는 비로그인 사용자도 조회 가능한데 스웨거에서는 토큰 없으면 요청이 안되는 이슈가 있습다 슬기님 `api-gateway` 브랜치에서 해결된 부분인지 궁금합니당