### PR TITLE
feat(club): 구단 월 단위 경기 조회 API 구현

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -3,6 +3,7 @@ package com.goormgb.be.ordercore.club.controller;
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.ordercore.club.dto.response.ClubDetailGetResponse;
 import com.goormgb.be.ordercore.club.service.ClubService;
+import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +23,17 @@ public class ClubController {
     public ApiResult<ClubDetailGetResponse> getClubDetail(
             @PathVariable Long clubId
     ) {
-        var club = clubService.getClubDetail(clubId);
-
-        return ApiResult.ok(club);
+        return ApiResult.ok(clubService.getClubDetail(clubId));
     }
+
+    @Operation(summary = "구단 경기 일정(월 단위) 조회", description = "구단 월 단위 경기 일정을 조회합니다.")
+    @GetMapping("/{clubId}/matches")
+    public ApiResult<ClubMonthlyMatchesResponse> getClubMonthlyMatches(
+            @PathVariable Long clubId,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        return ApiResult.ok(clubService.getClubMonthlyMatches(clubId, year, month));
+    }
+
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
@@ -5,6 +5,8 @@ import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.ordercore.club.dto.response.ClubDetailGetResponse;
 import com.goormgb.be.ordercore.club.dto.response.ClubGetResponse;
 import com.goormgb.be.ordercore.club.repository.ClubRepository;
+import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
+import com.goormgb.be.ordercore.match.service.MatchService;
 import com.goormgb.be.ordercore.state.repository.TeamSeasonStatsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ClubService {
+    final private MatchService matchService;
+
     final private ClubRepository clubRepository;
     final private TeamSeasonStatsRepository teamSeasonStatsRepository;
 
@@ -41,4 +45,7 @@ public class ClubService {
         return ClubDetailGetResponse.of(club, stats);
     }
 
+    public ClubMonthlyMatchesResponse getClubMonthlyMatches(Long clubId, int year, int month) {
+        return matchService.getClubMonthlyMatches(clubId, year, month);
+    }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
@@ -51,6 +51,8 @@ public class MatchService {
 
     public ClubMonthlyMatchesResponse getClubMonthlyMatches(Long clubId, int year, int month){
         Preconditions.validate(clubRepository.existsById(clubId), ErrorCode.CLUB_NOT_FOUND);
+        Preconditions.validate(month >= 1 && month <= 12, ErrorCode.INVALID_MATCH_MONTH);
+        Preconditions.validate(year >= 1900 && year <= 2100, ErrorCode.INVALID_MATCH_YEAR);
 
         YearMonth ym = YearMonth.of(year, month);
         LocalDateTime start = ym.atDay(1).atStartOfDay();

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -48,6 +48,8 @@ public enum ErrorCode {
 
 	// Match
 	MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다."),
+	INVALID_MATCH_MONTH(HttpStatus.BAD_REQUEST, "올바른 경기 월을 입력해주세요."),
+	INVALID_MATCH_YEAR(HttpStatus.BAD_REQUEST, "올바른 경기 년도를 입력해주세요."),
 
 
 	;


### PR DESCRIPTION
## 🔧 작업 내용
- 구단 월 단위 경기 일정 조회 API


## 🧩 구현 상세 (선택)
**구단 월 단위 경기 일정 조회 API**
- `GET /clubs/{clubId}/matches?year=2026&month=3`
- 1900~2100 까지 입력 가능, 1월부터 12월까지 입력가능
> 경기가 없을 경우엔 빈 배열로 응답
<img width="218" height="219" alt="image" src="https://github.com/user-attachments/assets/3b994e7f-7c9e-452d-987a-4f54e1a969fd" />



### 📌 관련 Jira Issue
- GRBG-117


## 🧪 테스트 방법(선택)
<img width="799" height="769" alt="image" src="https://github.com/user-attachments/assets/1ef8ea3e-349d-4c3a-803e-62db1b767df0" />


## ❗ 참고 사항
- 스웨거 안됐던 이슈는 아래 url 수정 안해서 안됐습니다
```
springdoc:
  swagger-ui:
    urls:
```