### PR TITLE
fix(security): Swagger UI 접근 시 403 오류 수정

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -33,8 +33,10 @@ public class AuthGuardSecurityConfig {
 					"/token/refresh",
 					"/dev/auth/**",
 					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/swagger-resources/**",
 					"/v3/api-docs/**",
-				"/actuator/health/**"
+					"/actuator/health/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/swagger-resources/**",
 					"/v3/api-docs/**",
 					"/actuator/health/**"
 				).permitAll()

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/swagger-resources/**",
 					"/v3/api-docs/**",
 					"/actuator/health/**"
 				).permitAll()

--- a/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
+++ b/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/swagger-resources/**",
 					"/v3/api-docs/**",
 					"/actuator/health/**"
 				).permitAll()

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
 					"/swagger-ui/**",
+					"/swagger-ui.html",
+					"/swagger-resources/**",
 					"/v3/api-docs/**",
 					"/actuator/health/**"
 				).permitAll()


### PR DESCRIPTION
- 각 서비스 Security 설정에 swagger-ui.html, swagger-resources 경로 permitAll 추가
## 🔧 작업 내용
- 모든 서비스(Auth-Guard, Queue, Seat, Order-Core, Recommendation)에서 Swagger UI 접근 시 403 Forbidden 오류가 발생하는 문제 수정
- Spring Security requestMatchers에 누락된 Swagger 관련 경로(/swagger-ui.html, /swagger-resources/**)를 permitAll에 추가
- Auth-Guard의 /actuator/health/** 들여쓰기 오류도 함께 수정

##  🧩 구현 상세
- Swagger UI 접근 시 내부적으로 /swagger-ui.html 리다이렉트 및 /swagger-resources/** 리소스 요청이 발생하는데, 해당 경로가 Security 허용 목록에 빠져있어 403이 반환되었음
- 5개 서비스의 SecurityConfig에 동일하게 누락 경로 추가

### 📌 관련 Jira Issue
없음

🧪 테스트 방법
- 각 서비스 로컬 실행 후 Swagger UI 접속 확인
  - http://localhost:8080/auth/swagger-ui/index.html
  - http://localhost:8081/queue/swagger-ui/index.html
  - http://localhost:8082/seat/swagger-ui/index.html
  - http://localhost:8083/order/swagger-ui/index.html
  - http://localhost:8084/recommendation/swagger-ui/index.html

- 403 없이 Swagger UI가 정상 렌더링되는지 확인

##❗ 참고 사항
  - 5개 서비스 모두 동일한 패턴의 변경이므로 일괄 확인 필요