### PR TITLE
feat(common-core): API Gateway 연동을 위한 XUserIdAuthenticationFilter 추가 [GRGB-180]

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
@@ -14,7 +14,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@Component
+@Component @Slf4j
 public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String HEADER_USER_ID = "X-User-Id";

--- a/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.goormgb.be.global.security.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String HEADER_USER_ID = "X-User-Id";
+	private static final String HEADER_USER_ROLE = "X-User-Role";
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String userId = request.getHeader(HEADER_USER_ID);
+		String userRole = request.getHeader(HEADER_USER_ROLE);
+
+		if (userId != null && !userId.isBlank()) {
+			SimpleGrantedAuthority authority = new SimpleGrantedAuthority(
+				userRole != null && !userRole.isBlank() ? userRole : "ROLE_USER"
+			);
+
+			UsernamePasswordAuthenticationToken authentication =
+				new UsernamePasswordAuthenticationToken(
+					Long.valueOf(userId),
+					null,
+					List.of(authority)
+				);
+
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
@@ -13,8 +13,10 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
-@Component @Slf4j
+@Slf4j
+@Component
 public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String HEADER_USER_ID = "X-User-Id";
@@ -31,18 +33,24 @@ public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 		String userRole = request.getHeader(HEADER_USER_ROLE);
 
 		if (userId != null && !userId.isBlank()) {
-			SimpleGrantedAuthority authority = new SimpleGrantedAuthority(
-				userRole != null && !userRole.isBlank() ? userRole : "ROLE_USER"
-			);
+			try {
+				Long parsedUserId = Long.valueOf(userId);
 
-			UsernamePasswordAuthenticationToken authentication =
-				new UsernamePasswordAuthenticationToken(
-					Long.valueOf(userId),
-					null,
-					List.of(authority)
+				SimpleGrantedAuthority authority = new SimpleGrantedAuthority(
+					userRole != null && !userRole.isBlank() ? userRole : "ROLE_USER"
 				);
 
-			SecurityContextHolder.getContext().setAuthentication(authentication);
+				UsernamePasswordAuthenticationToken authentication =
+					new UsernamePasswordAuthenticationToken(
+						parsedUserId,
+						null,
+						List.of(authority)
+					);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			} catch (NumberFormatException e) {
+				log.warn("Invalid X-User-Id header value: {}", userId);
+			}
 		}
 
 		filterChain.doFilter(request, response);


### PR DESCRIPTION
## 🔧 작업 내용
- API Gateway가 JWT 검증 후 전달하는 X-User-Id, X-User-Role 헤더를 읽어 SecurityContext에 인증 정보를 등록하는 XUserIdAuthenticationFilter를 common-core에 추가
- API Gateway 도입으로 각 서비스가 직접 JWT를 검증할 필요가 없어지므로, 헤더만 신뢰하는 경량 필터를 공통 모듈에 구현 (현업자 멘토링때 나왔던 멘토링 내용 반영)
- OncePerRequestFilter 기반 서블릿 필터로 구현하여 기존 다운스트림 서비스(WebMVC)와 호환
-**[Gemini 리뷰반영]** X-User-Id 파싱 시 NumberFormatException 방어 처리 — 필터 계층은 @RestControllerAdvice 범위 밖이므로 Preconditions 대신 try-catch로 anonymous 처리

## 🧩 구현 상세 (선택)
- X-User-Id 헤더 → Long userId를 principal로 UsernamePasswordAuthenticationToken 생성 (기존 JwtAuthenticationFilter와 동일한 principal 타입 유지)
- X-User-Role 헤더 → SimpleGrantedAuthority로 권한 설정, 값이 없으면 ROLE_USER 기본값 적용
- 헤더가 없는 경우 인증 정보를 설정하지 않아 Spring Security가 anonymousUser로 처리 (공개 API 대응)
- JWT 검증 로직 없음 — Gateway에서 이미 검증 완료된 요청만 도달하는 구조

### 📌 관련 Jira Issue
- GRGB-180


## 🧪 테스트 방법(선택)
- `./gradlew :common-core:compileJava` 빌드 성공 확인
- T6 작업 후 통합 테스트 시 Gateway → 다운스트림 서비스 흐름에서 X-User-Id 헤더가 SecurityContext에 정상 등록되는지 확인 예정

## ❗ 참고 사항
- 이 PR 단독으로는 다운스트림 서비스에 적용되지 않음 — 후속 작업(T6)에서 각 서비스 SecurityConfig의 JwtAuthenticationFilter → XUserIdAuthenticationFilter 교체 필요
- 현재 다운스트림 서비스들이 import하는 com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter는 common-core에 존재하지 않아 빌드가 깨진 상태이며, 이는 T6에서 해결 예정

### X-User-Id 파싱 실패 시 Preconditions가 아닌 try-catch를 사용한 이유:                                                                                                                                                                                                                                         
- Spring 요청 처리 흐름:
```
클라이언트 요청
│
├─ [1] Servlet Filter Chain
│      ├─ XUserIdAuthenticationFilter    ← 여기서 동작
│      ├─ UsernamePasswordAuthenticationFilter
│      └─ ...
│
├─ [2] DispatcherServlet
│
├─ [3] HandlerMapping → Controller
│
├─ [4] Controller → Service → Repository
│      └─ 여기서 CustomException 발생 시
│
└─ [5] @RestControllerAdvice (GlobalExceptionHandler)  ← 여기서 잡음
```
- Preconditions.validate()는 CustomException을 던지는데, 필터는 DispatcherServlet 이전에 실행되므로 @RestControllerAdvice가 잡을 수 없음
- 처리 안 하면 CustomException이 Tomcat까지 전파되어 500 반환
- 헤더 없음 자체가 공개 API 요청(anonymous)이므로 예외가 아닌 정상 분기

 ### 핵심 포인트
| 계층 | CustomException 처리 가능? | 이유 |
|------|--------------------------|------|
| Controller / Service / Repository | 가능 | DispatcherServlet 내부에서 실행되므로 `@RestControllerAdvice`가 잡음 |
| Servlet Filter | **불가능** | DispatcherServlet **이전 단계**에서 실행되므로 `@RestControllerAdvice`까지 도달하지 않음 |