### PR TITLE
feat(club): 홈 구단 전체 목록 조회 API

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -2,6 +2,7 @@ package com.goormgb.be.ordercore.club.controller;
 
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.ordercore.club.dto.response.ClubDetailGetResponse;
+import com.goormgb.be.ordercore.club.dto.response.ClubGetResponse;
 import com.goormgb.be.ordercore.club.service.ClubService;
 import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,12 +11,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "Club", description = "구단 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/clubs")
 public class ClubController {
     private final ClubService clubService;
+
+    @Operation(summary = "구단 전체 조회", description = "구단 전체 리스트를 조회합니다.")
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<ClubGetResponse> getAllClubs() {
+        return ApiResult.ok(clubService.getAllClubs());
+    }
 
     @Operation(summary = "구단 상세 조회", description = "구단 상세를 조회합니다.")
     @GetMapping("/{clubId}")

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Tag(name = "Club", description = "구단 API")
 @RestController
 @RequiredArgsConstructor

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubGetResponse.java
@@ -2,20 +2,35 @@ package com.goormgb.be.ordercore.club.dto.response;
 
 import com.goormgb.be.ordercore.club.entity.Club;
 
+import java.util.List;
+
 public record ClubGetResponse(
-        Long clubId,
-        String koName,
-        String enName,
-        String logoImg,
-        String clubColor
+        List<ClubItem> clubs
 ) {
-    public static ClubGetResponse from(Club club) {
+
+    public static ClubGetResponse from(List<Club> clubs) {
         return new ClubGetResponse(
-               club.getId(),
-               club.getKoName(),
-               club.getEnName(),
-               club.getLogoImg(),
-               club.getClubColor()
+                clubs.stream()
+                        .map(ClubItem::from)
+                        .toList()
         );
+    }
+
+    public record ClubItem(
+            Long clubId,
+            String koName,
+            String enName,
+            String logoImg,
+            String clubColor
+    ) {
+        public static ClubItem from(Club club) {
+            return new ClubItem(
+                    club.getId(),
+                    club.getKoName(),
+                    club.getEnName(),
+                    club.getLogoImg(),
+                    club.getClubColor()
+            );
+        }
     }
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/service/ClubService.java
@@ -24,14 +24,12 @@ public class ClubService {
     final private ClubRepository clubRepository;
     final private TeamSeasonStatsRepository teamSeasonStatsRepository;
 
-    public List<ClubGetResponse> getAllClubs(){
+    public ClubGetResponse getAllClubs(){
         var clubs = clubRepository.findAll();
 
         Preconditions.validate(!clubs.isEmpty(), ErrorCode.CLUB_NOT_FOUND);
 
-        return clubs.stream()
-                .map(ClubGetResponse::from)
-                .toList();
+        return ClubGetResponse.from(clubs);
     }
 
     public ClubDetailGetResponse getClubDetail(Long id) {


### PR DESCRIPTION
## 🔧 작업 내용
- 구단 전체 목록 조회 API


## 🧩 구현 상세 (선택)
**구단 전체 목록 조회 API**
- `GET /clubs`
- 응답 구조를 기존 배열(`data: []`)로 반환하는 것에서 명세서에 있는 것 처럼  `data.clubs: []` 로 변경했습니다. 


### 📌 관련 Jira Issue
- GRBG-114


## 🧪 테스트 방법(선택)
<img width="795" height="772" alt="image" src="https://github.com/user-attachments/assets/237002ce-9865-46f2-b9f4-6c0d5ca55404" />


## ❗ 참고 사항