### PR TITLE
PR template에 오타난 지라 이슈키 수정함

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 
 ### 📌 관련 Jira Issue
-- GRBG-XX
+- GRGB-XX
 
 
 ## 🧪 테스트 방법(선택)


### PR DESCRIPTION
Fix typo in Jira issue reference.

## 🔧 작업 내용
관련 이슈키가 
GR`GB` 가아닌 -> GR`BG`로 되어있었음