### PR TITLE
refactor(services): 각 서비스 SecurityConfig 교체 및 JWT 설정 제거 [GRGB-181]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,7 +33,7 @@ public class SecurityConfig {
 				).permitAll()
 				.anyRequest().authenticated()
 			)
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(xUserIdAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
@@ -6,7 +6,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import tools.jackson.databind.ObjectMapper;
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 @ActiveProfiles("test")
 public abstract class WebMvcTestSupport {
@@ -18,5 +18,5 @@ public abstract class WebMvcTestSupport {
 	protected ObjectMapper objectMapper;
 
 	@MockitoBean
-	protected JwtAuthenticationFilter jwtAuthenticationFilter;
+	protected XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 }

--- a/Order-Core/src/test/resources/application-test.yaml
+++ b/Order-Core/src/test/resources/application-test.yaml
@@ -21,18 +21,6 @@ spring:
       host: localhost
       port: 6379
 
-jwt:
-  secret-key: test-secret-key-for-unit-test-goormgb-20260217
-  issuer: test-issuer
-  access-token:
-    audience: test-audience
-    expiration-minutes: 15
-  refresh-token:
-    audience: test-refresh-audience
-    expiration-days: 7
-  cookie:
-    secure: false
-
 kakao:
   client-id: test-client-id
   client-secret: test-client-secret

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,7 +33,7 @@ public class SecurityConfig {
 				).permitAll()
 				.anyRequest().authenticated()
 			)
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(xUserIdAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Queue/src/test/resources/application-test.yaml
+++ b/Queue/src/test/resources/application-test.yaml
@@ -21,18 +21,6 @@ spring:
       host: localhost
       port: 6379
 
-jwt:
-  secret-key: test-secret-key-for-unit-test-goormgb-20260217
-  issuer: test-issuer
-  access-token:
-    audience: test-audience
-    expiration-minutes: 15
-  refresh-token:
-    audience: test-refresh-audience
-    expiration-days: 7
-  cookie:
-    secure: false
-
 kakao:
   client-id: test-client-id
   client-secret: test-client-secret

--- a/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
+++ b/Recommendation/src/main/java/com/goormgb/be/recommendation/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,7 +33,7 @@ public class SecurityConfig {
 				).permitAll()
 				.anyRequest().authenticated()
 			)
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(xUserIdAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Recommendation/src/main/resources/application.yaml
+++ b/Recommendation/src/main/resources/application.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Recommendation/src/test/resources/application-test.yaml
+++ b/Recommendation/src/test/resources/application-test.yaml
@@ -21,18 +21,6 @@ spring:
       host: localhost
       port: 6379
 
-jwt:
-  secret-key: test-secret-key-for-unit-test-goormgb-20260217
-  issuer: test-issuer
-  access-token:
-    audience: test-audience
-    expiration-minutes: 15
-  refresh-token:
-    audience: test-refresh-audience
-    expiration-days: 7
-  cookie:
-    secure: false
-
 kakao:
   client-id: test-client-id
   client-secret: test-client-secret

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import com.goormgb.be.global.jwt.filter.JwtAuthenticationFilter;
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,7 +33,7 @@ public class SecurityConfig {
 				).permitAll()
 				.anyRequest().authenticated()
 			)
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(xUserIdAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -30,19 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
-  issuer: ${JWT_ISSUER}
-  access-token:
-    audience: ${JWT_ACCESS_TOKEN_AUDIENCE}
-    expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
-  refresh-token:
-    audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
-  cookie:
-    secure: false
-
 springdoc:
   swagger-ui:
     urls:

--- a/Seat/src/test/resources/application-test.yaml
+++ b/Seat/src/test/resources/application-test.yaml
@@ -21,18 +21,6 @@ spring:
       host: localhost
       port: 6379
 
-jwt:
-  secret-key: test-secret-key-for-unit-test-goormgb-20260217
-  issuer: test-issuer
-  access-token:
-    audience: test-audience
-    expiration-minutes: 15
-  refresh-token:
-    audience: test-refresh-audience
-    expiration-days: 7
-  cookie:
-    secure: false
-
 kakao:
   client-id: test-client-id
   client-secret: test-client-secret


### PR DESCRIPTION
## 🔧 작업 내용
- 다운스트림 서비스 4개(Queue, Seat, Order-Core, Recommendation)의 SecurityConfig에서 JwtAuthenticationFilter → XUserIdAuthenticationFilter로 교체                                                                                                                                                             
- 각 서비스 application.yaml(default, dev, local, test)에서 jwt: 설정 블록 전체 제거                                                                                                                                                                                                                           
- API Gateway가 JWT 검증을 대신하므로 각 서비스는 더 이상 JWT를 직접 검증하지 않고, Gateway가 전달하는 X-User-Id, X-User-Role 헤더만 신뢰하는 구조로 전환


## 🧩 구현 상세 (선택)
- SecurityConfig 변경: import, 필드, addFilterBefore() 모두 XUserIdAuthenticationFilter로 교체
- Order-Core WebMvcTestSupport의 @MockitoBean 대상도 XUserIdAuthenticationFilter로 교체
- JWT yaml 설정 제거: 4개 서비스 x 4개 프로필(default, dev, local, test) = 총 16개 파일
- Auth-Guard는 JWT 발급/관리 서비스이므로 교체 대상에서 제외
- build.gradle에는 jjwt 의존성이 없어 변경 불필요


### 📌 관련 Jira Issue
- GRGB-181


## 🧪 테스트 방법(선택)
- `./gradlew clean build -x test` 전체 빌드 성공 확인


## ❗ 참고 사항
- 다운스트림 서비스가 외부에 직접 노출되면 X-User-Id 헤더 위조로 인증 우회가 가능하므로, T7(다음작업)에서 Gateway만 외부 포트를 노출하고 각 서비스 포트는 내부 통신으로 제한할 예정

- 사용법은 기존과 동일합니다. 바뀐 건 필터 내부 동작뿐이고, 서비스 코드에서 userId를 꺼내는 방식은 그대로입니다.

기존 JWT 필터도, 새 XUserIdAuthenticationFilter도 둘 다 SecurityContext에 동일한 형태로 넣어줍니다:                                                                                                                                                                                                            
```java
new UsernamePasswordAuthenticationToken(                                                                                                                                                                                                                                                                       
      Long userId,    // principal                                                                                                                                                                                                                                                                               
      null,                                                                                                                                                                                                                                                                                                      
      List.of(authority)                                                                                                                                                                                                                                                                                         
  );                                                                                                                                                                                                                                                                                                             
```
그래서 서비스 코드에서는 똑같이:
```java
  // Controller에서 userId 가져오기
  Long userId = (Long) SecurityContextHolder.getContext()
      .getAuthentication()
      .getPrincipal();
```

또는 @AuthenticationPrincipal을 쓰고 있었다면 그것도 동일하게 동작합니다.

### 흐름 비교

| 항목 | 기존 | 변경 후 |
|---|---|---|
| JWT 검증 | 각 서비스가 직접 수행 | API Gateway가 대신 수행 |
| userId 전달 | JWT 토큰에서 파싱 | `X-User-Id` 헤더로 전달 |
| SecurityContext 등록 | `JwtAuthenticationFilter` | `XUserIdAuthenticationFilter` |
| 서비스 코드에서 userId 사용 | `SecurityContextHolder`에서 `Long` 사용 | 동일 |───────────┴─────────────────────────────┘

개발자 입장에서 Controller/Service 코드는 아무것도 안 바꿔도 됩니다.
