### PR TITLE
feat(match): 날짜 별 경기 리스트 조회 API [GRGB-115]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/controller/MatchController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/controller/MatchController.java
@@ -2,12 +2,16 @@ package com.goormgb.be.ordercore.match.controller;
 
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.ordercore.match.dto.response.MatchDetailGetResponse;
+import com.goormgb.be.ordercore.match.dto.response.MatchListByDateResponse;
 import com.goormgb.be.ordercore.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Tag(name = "Match", description = "경기 API")
 @RestController
@@ -25,4 +29,14 @@ public class MatchController {
         return ApiResult.ok(matchService.getMatchDetail(matchId));
     }
 
+    @Operation(summary = "날짜 별 경기 조회 API", description = "날짜 별 경기를 조회합니다.")
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<MatchListByDateResponse> getMatchList(
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
+    ) {
+        return ApiResult.ok(matchService.getMatchesByDate(date));
+    }
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.goormgb.be.global.exception;
 
 import java.util.Arrays;
 
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import com.goormgb.be.global.response.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -38,5 +40,13 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(AuthorizationDeniedException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleAuthorizationDenied(AuthorizationDeniedException e) {
 		return ErrorResponse.error(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ErrorResponse.ErrorData> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+		if ("date".equals(e.getName())) {
+			return ErrorResponse.error(HttpStatus.BAD_REQUEST, "올바른 날짜를 입력해주세요.");
+		}
+		return ErrorResponse.error(HttpStatus.BAD_REQUEST, "요청 파라미터 형식이 올바르지 않습니다.");
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -44,8 +44,8 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
-		if ("date".equals(e.getName())) {
-			return ErrorResponse.error(HttpStatus.BAD_REQUEST, "올바른 날짜를 입력해주세요.");
+		if (e.getRequiredType() != null && e.getRequiredType().equals(java.time.LocalDate.class)) {
+			return ErrorResponse.error(HttpStatus.BAD_REQUEST, "올바른 날짜를 입력해주세요. (형식: yyyy-MM-dd)");
 		}
 		return ErrorResponse.error(HttpStatus.BAD_REQUEST, "요청 파라미터 형식이 올바르지 않습니다.");
 	}


### PR DESCRIPTION
## 🔧 작업 내용
- 날짜 별 경기 리스트 조회 API


## 🧩 구현 상세 (선택)
**날짜 별 경기 리스트 조회 API**
- `GET /matches?date=2026-03-28`
- 잘못된 date 형식에 에러 반환 -> `GlobalExceptionHanlder`에 `handleTypeMismatch` 추가


### 📌 관련 Jira Issue
- GRGB-115


## 🧪 테스트 방법(선택)
**올바른 요청 `GET /matches?date=2026-03-28`** 
<img width="795" height="768" alt="image" src="https://github.com/user-attachments/assets/3f5dd177-2c93-4985-82dc-002979b8fede" />

**이상한 날짜 `GET /matches?date=2026-03-40`**
<img width="801" height="753" alt="image" src="https://github.com/user-attachments/assets/29ad21c9-d6bb-4d67-8a4b-0e9d757a76f9" />


## ❗ 참고 사항
