### PR TITLE
chore: Docker Compose 업데이트 및 Gateway 통합 테스트, Swagger UI 라우팅 통합 [GRGB-182]

### DIFF
--- a/API-Gateway/Dockerfile
+++ b/API-Gateway/Dockerfile
@@ -14,10 +14,14 @@ COPY Queue/build.gradle Queue/
 COPY Seat/build.gradle Seat/
 COPY Recommendation/build.gradle Recommendation/
 
-# 3. 필요한 소스 코드만 복사 (현재 서비스만 — common-core 의존 없음)
+# 3. 의존성 다운로드 (소스 코드 복사 전)
+# 소스 코드가 없으므로 빌드는 실패하지만, 의존성은 다운로드되어 캐시됩니다.
+RUN gradle :API-Gateway:classes -x test --no-daemon || true
+
+# 4. 필요한 소스 코드만 복사 (현재 서비스만 — common-core 의존 없음)
 COPY API-Gateway/src API-Gateway/src
 
-# 4. 빌드 수행 (테스트 제외)
+# 5. 실제 빌드 수행
 RUN gradle :API-Gateway:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine

--- a/API-Gateway/Dockerfile
+++ b/API-Gateway/Dockerfile
@@ -14,14 +14,13 @@ COPY Queue/build.gradle Queue/
 COPY Seat/build.gradle Seat/
 COPY Recommendation/build.gradle Recommendation/
 
-# 3. 필요한 소스 코드만 복사 (공통 모듈 + 현재 서비스)
-COPY common-core/src common-core/src
-COPY Seat/src Seat/src
+# 3. 필요한 소스 코드만 복사 (현재 서비스만 — common-core 의존 없음)
+COPY API-Gateway/src API-Gateway/src
 
 # 4. 빌드 수행 (테스트 제외)
-RUN gradle :Seat:bootJar -x test --no-daemon
+RUN gradle :API-Gateway:bootJar -x test --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
-COPY --from=builder /app/Seat/build/libs/*.jar app.jar
+COPY --from=builder /app/API-Gateway/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/API-Gateway/src/main/resources/application-dev.yaml
+++ b/API-Gateway/src/main/resources/application-dev.yaml
@@ -6,41 +6,43 @@ spring:
     name: api-gateway
   cloud:
     gateway:
-      globalcors:
-        corsConfigurations:
-          '[/**]':
-            allowedOriginPatterns:
-              - "${ALLOWED_ORIGINS}"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - DELETE
-              - OPTIONS
-            allowedHeaders:
-              - "*"
-            allowCredentials: true
-      routes:
-        - id: auth-guard
-          uri: ${AUTH_GUARD_URL}
-          predicates:
-            - Path=/auth/**
-        - id: queue
-          uri: ${QUEUE_URL}
-          predicates:
-            - Path=/queue/**
-        - id: seat
-          uri: ${SEAT_URL}
-          predicates:
-            - Path=/seat/**
-        - id: order-core
-          uri: ${ORDER_CORE_URL}
-          predicates:
-            - Path=/order/**
-        - id: recommendation
-          uri: ${RECOMMENDATION_URL}
-          predicates:
-            - Path=/recommendation/**
+      server:
+        webflux:
+          globalcors:
+            corsConfigurations:
+              '[/**]':
+                allowedOriginPatterns:
+                  - "${ALLOWED_ORIGINS}"
+                allowedMethods:
+                  - GET
+                  - POST
+                  - PUT
+                  - DELETE
+                  - OPTIONS
+                allowedHeaders:
+                  - "*"
+                allowCredentials: true
+          routes:
+            - id: auth-guard
+              uri: ${AUTH_GUARD_URL}
+              predicates:
+                - Path=/auth/**
+            - id: queue
+              uri: ${QUEUE_URL}
+              predicates:
+                - Path=/queue/**
+            - id: seat
+              uri: ${SEAT_URL}
+              predicates:
+                - Path=/seat/**
+            - id: order-core
+              uri: ${ORDER_CORE_URL}
+              predicates:
+                - Path=/order/**
+            - id: recommendation
+              uri: ${RECOMMENDATION_URL}
+              predicates:
+                - Path=/recommendation/**
 
   data:
     redis:

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -6,41 +6,43 @@ spring:
     name: api-gateway
   cloud:
     gateway:
-      globalcors:
-        corsConfigurations:
-          '[/**]':
-            allowedOriginPatterns:
-              - "${ALLOWED_ORIGINS}"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - DELETE
-              - OPTIONS
-            allowedHeaders:
-              - "*"
-            allowCredentials: true
-      routes:
-        - id: auth-guard
-          uri: ${AUTH_GUARD_URL}
-          predicates:
-            - Path=/auth/**
-        - id: queue
-          uri: ${QUEUE_URL}
-          predicates:
-            - Path=/queue/**
-        - id: seat
-          uri: ${SEAT_URL}
-          predicates:
-            - Path=/seat/**
-        - id: order-core
-          uri: ${ORDER_CORE_URL}
-          predicates:
-            - Path=/order/**
-        - id: recommendation
-          uri: ${RECOMMENDATION_URL}
-          predicates:
-            - Path=/recommendation/**
+      server:
+        webflux:
+          globalcors:
+            corsConfigurations:
+              '[/**]':
+                allowedOriginPatterns:
+                  - "${ALLOWED_ORIGINS}"
+                allowedMethods:
+                  - GET
+                  - POST
+                  - PUT
+                  - DELETE
+                  - OPTIONS
+                allowedHeaders:
+                  - "*"
+                allowCredentials: true
+          routes:
+            - id: auth-guard
+              uri: ${AUTH_GUARD_URL}
+              predicates:
+                - Path=/auth/**
+            - id: queue
+              uri: ${QUEUE_URL}
+              predicates:
+                - Path=/queue/**
+            - id: seat
+              uri: ${SEAT_URL}
+              predicates:
+                - Path=/seat/**
+            - id: order-core
+              uri: ${ORDER_CORE_URL}
+              predicates:
+                - Path=/order/**
+            - id: recommendation
+              uri: ${RECOMMENDATION_URL}
+              predicates:
+                - Path=/recommendation/**
   jackson:
     time-zone: UTC
     date-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'

--- a/API-Gateway/src/test/resources/application-test.yaml
+++ b/API-Gateway/src/test/resources/application-test.yaml
@@ -1,0 +1,11 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260227
+  issuer: test-issuer
+  access-token:
+    audience: test-audience

--- a/Auth-Guard/Dockerfile
+++ b/Auth-Guard/Dockerfile
@@ -6,6 +6,7 @@ COPY build.gradle .
 COPY settings.gradle .
 
 # 2. 모든 모듈의 build.gradle 복사 (Gradle 멀티 모듈 구조 유지 필수)
+COPY API-Gateway/build.gradle API-Gateway/
 COPY Auth-Guard/build.gradle Auth-Guard/
 COPY common-core/build.gradle common-core/
 COPY Order-Core/build.gradle Order-Core/

--- a/Order-Core/Dockerfile
+++ b/Order-Core/Dockerfile
@@ -6,6 +6,7 @@ COPY build.gradle .
 COPY settings.gradle .
 
 # 2. 모든 모듈의 build.gradle 복사 (Gradle 멀티 모듈 구조 유지 필수)
+COPY API-Gateway/build.gradle API-Gateway/
 COPY Auth-Guard/build.gradle Auth-Guard/
 COPY common-core/build.gradle common-core/
 COPY Order-Core/build.gradle Order-Core/

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoints:
     web:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoint:
     health:

--- a/Order-Core/src/test/resources/application-test.yaml
+++ b/Order-Core/src/test/resources/application-test.yaml
@@ -21,10 +21,3 @@ spring:
       host: localhost
       port: 6379
 
-kakao:
-  client-id: test-client-id
-  client-secret: test-client-secret
-  redirect-uri: http://localhost:3000/auth/callback/kakao
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Queue/Dockerfile
+++ b/Queue/Dockerfile
@@ -6,6 +6,7 @@ COPY build.gradle .
 COPY settings.gradle .
 
 # 2. 모든 모듈의 build.gradle 복사 (Gradle 멀티 모듈 구조 유지 필수)
+COPY API-Gateway/build.gradle API-Gateway/
 COPY Auth-Guard/build.gradle Auth-Guard/
 COPY common-core/build.gradle common-core/
 COPY Order-Core/build.gradle Order-Core/

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoints:
     web:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoint:
     health:

--- a/Queue/src/test/resources/application-test.yaml
+++ b/Queue/src/test/resources/application-test.yaml
@@ -21,10 +21,3 @@ spring:
       host: localhost
       port: 6379
 
-kakao:
-  client-id: test-client-id
-  client-secret: test-client-secret
-  redirect-uri: http://localhost:3000/auth/callback/kakao
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Recommendation/Dockerfile
+++ b/Recommendation/Dockerfile
@@ -6,6 +6,7 @@ COPY build.gradle .
 COPY settings.gradle .
 
 # 2. 모든 모듈의 build.gradle 복사 (Gradle 멀티 모듈 구조 유지 필수)
+COPY API-Gateway/build.gradle API-Gateway/
 COPY Auth-Guard/build.gradle Auth-Guard/
 COPY common-core/build.gradle common-core/
 COPY Order-Core/build.gradle Order-Core/

--- a/Recommendation/src/main/resources/application-dev.yaml
+++ b/Recommendation/src/main/resources/application-dev.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoints:
     web:

--- a/Recommendation/src/main/resources/application.yaml
+++ b/Recommendation/src/main/resources/application.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoint:
     health:

--- a/Recommendation/src/test/resources/application-test.yaml
+++ b/Recommendation/src/test/resources/application-test.yaml
@@ -21,10 +21,3 @@ spring:
       host: localhost
       port: 6379
 
-kakao:
-  client-id: test-client-id
-  client-secret: test-client-secret
-  redirect-uri: http://localhost:3000/auth/callback/kakao
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoints:
     web:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -44,15 +44,6 @@ springdoc:
       - name: Recommendation
         url: http://localhost:8084/recommendation/v3/api-docs
 
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  client-secret: ${KAKAO_CLIENT_SECRET}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me
-
 management:
   endpoint:
     health:

--- a/Seat/src/test/resources/application-test.yaml
+++ b/Seat/src/test/resources/application-test.yaml
@@ -21,10 +21,3 @@ spring:
       host: localhost
       port: 6379
 
-kakao:
-  client-id: test-client-id
-  client-secret: test-client-secret
-  redirect-uri: http://localhost:3000/auth/callback/kakao
-  auth-url: https://kauth.kakao.com/oauth/authorize
-  token-url: https://kauth.kakao.com/oauth/token
-  user-info-url: https://kapi.kakao.com/v2/user/me

--- a/common-core/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -7,9 +8,13 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+
+	@Value("${server.servlet.context-path:}")
+	private String contextPath;
 
 	@Bean
 	public OpenAPI customOpenAPI() {
@@ -28,6 +33,7 @@ public class SwaggerConfig {
 						.title("표고 API")
 						.description("구름공방 백엔드 API 문서")
 						.version("v1"))
+				.addServersItem(new Server().url(contextPath.isEmpty() ? "/" : contextPath))
 				.addSecurityItem(securityRequirement)
 				.schemaRequirement("BearerAuth", securityScheme);
 	}

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,10 @@
 version: '3.8'
 
 services:
+  api-gateway:
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+
   auth-guard:
     environment:
       SPRING_PROFILES_ACTIVE: dev

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api-gateway:
     environment:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,10 @@
 version: '3.8'
 
 services:
+  api-gateway:
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+
   auth-guard:
     environment:
       SPRING_PROFILES_ACTIVE: local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,31 @@ services:
       timeout: 5s
       retries: 5
 
+  api-gateway:
+    build:
+      context: ..
+      dockerfile: API-Gateway/Dockerfile
+    container_name: api-gateway
+    environment:
+      AUTH_GUARD_URL: http://auth-guard:8080
+      QUEUE_URL: http://queue:8081
+      SEAT_URL: http://seat:8082
+      ORDER_CORE_URL: http://order-core:8083
+      RECOMMENDATION_URL: http://recommendation:8084
+      REDIS_HOST: local-redis
+      REDIS_PORT: 6379
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_ACCESS_TOKEN_AUDIENCE: ${JWT_ACCESS_TOKEN_AUDIENCE}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
+    ports:
+      - "8085:8085"
+    depends_on:
+      local-redis:
+        condition: service_healthy
+    networks:
+      - goormgb-network
+
   auth-guard:
     build:
       context: ..
@@ -53,8 +78,6 @@ services:
       KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
       KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
-    ports:
-      - "8080:8080"
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -74,14 +97,6 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
-      JWT_ISSUER: ${JWT_ISSUER}
-      JWT_ACCESS_TOKEN_AUDIENCE: ${JWT_ACCESS_TOKEN_AUDIENCE}
-      JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
-      JWT_REFRESH_TOKEN_AUDIENCE: ${JWT_REFRESH_TOKEN_AUDIENCE}
-      JWT_REFRESH_TOKEN_EXPIRATION: ${JWT_REFRESH_TOKEN_EXPIRATION}
-    ports:
-      - "8081:8081"
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -101,14 +116,6 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
-      JWT_ISSUER: ${JWT_ISSUER}
-      JWT_ACCESS_TOKEN_AUDIENCE: ${JWT_ACCESS_TOKEN_AUDIENCE}
-      JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
-      JWT_REFRESH_TOKEN_AUDIENCE: ${JWT_REFRESH_TOKEN_AUDIENCE}
-      JWT_REFRESH_TOKEN_EXPIRATION: ${JWT_REFRESH_TOKEN_EXPIRATION}
-    ports:
-      - "8082:8082"
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -128,17 +135,6 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
-      JWT_ISSUER: ${JWT_ISSUER}
-      JWT_ACCESS_TOKEN_AUDIENCE: ${JWT_ACCESS_TOKEN_AUDIENCE}
-      JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
-      JWT_REFRESH_TOKEN_AUDIENCE: ${JWT_REFRESH_TOKEN_AUDIENCE}
-      JWT_REFRESH_TOKEN_EXPIRATION: ${JWT_REFRESH_TOKEN_EXPIRATION}
-      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
-      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
-      KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
-    ports:
-      - "8083:8083"
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -158,17 +154,6 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
-      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
-      JWT_ISSUER: ${JWT_ISSUER}
-      JWT_ACCESS_TOKEN_AUDIENCE: ${JWT_ACCESS_TOKEN_AUDIENCE}
-      JWT_ACCESS_TOKEN_EXPIRATION: ${JWT_ACCESS_TOKEN_EXPIRATION}
-      JWT_REFRESH_TOKEN_AUDIENCE: ${JWT_REFRESH_TOKEN_AUDIENCE}
-      JWT_REFRESH_TOKEN_EXPIRATION: ${JWT_REFRESH_TOKEN_EXPIRATION}
-      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
-      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
-      KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
-    ports:
-      - "8084:8084"
     depends_on:
       local-postgres:
         condition: service_healthy

--- a/docs/docker-local-env-config.md
+++ b/docs/docker-local-env-config.md
@@ -1,0 +1,108 @@
+# Docker 환경과 로컬(IntelliJ) 환경의 설정 차이
+
+## 배경
+
+API Gateway 도입 후, Docker 환경과 IntelliJ 로컬 환경에서 동일한 `local` 프로필을 사용하되 네트워크 설정만 다르게 동작해야 하는 요구사항이 생겼습니다.
+
+## 핵심 문제: Docker vs IntelliJ 네트워크 차이
+
+| 환경 | 네트워크 | `localhost`의 의미 |
+|------|----------|-------------------|
+| IntelliJ | 모든 서비스가 같은 머신에서 실행 | 다른 서비스에 접근 가능 |
+| Docker | 각 서비스가 별도 컨테이너(별도 네트워크) | **자기 자신 컨테이너만 가리킴** |
+
+예를 들어 Gateway 컨테이너에서 `http://localhost:8083`으로 요청하면, Order-Core가 아니라 **Gateway 자기 자신의 8083 포트**로 요청하게 되어 `Connection refused` 에러가 발생합니다.
+
+## 해결 방법: `${ENV_VAR:기본값}` 패턴
+
+### 변경 전 (application-local.yaml)
+
+```yaml
+routes:
+  - id: order-core
+    uri: http://localhost:8083    # 하드코딩 → Docker에서 안 됨
+    predicates:
+      - Path=/order/**
+```
+
+### 변경 후 (application-local.yaml)
+
+```yaml
+routes:
+  - id: order-core
+    uri: ${ORDER_CORE_URL:http://localhost:8083}    # 환경변수 + 기본값
+    predicates:
+      - Path=/order/**
+```
+
+### 동작 방식
+
+| 환경 | `ORDER_CORE_URL` 환경변수 | 사용되는 값 |
+|------|--------------------------|-----------|
+| IntelliJ | 없음 (미설정) | 기본값 `http://localhost:8083` |
+| Docker | `http://order-core:8083` (docker-compose.yml에서 주입) | `http://order-core:8083` |
+
+Spring의 `${VAR:default}` 문법 덕분에 하나의 yaml 파일로 두 환경을 모두 커버할 수 있습니다.
+
+## 변경된 파일 목록
+
+### 1. API-Gateway/src/main/resources/application-local.yaml
+
+라우팅 URI를 환경변수 + 기본값 패턴으로 변경:
+
+```yaml
+routes:
+  - id: auth-guard
+    uri: ${AUTH_GUARD_URL:http://localhost:8080}
+  - id: queue
+    uri: ${QUEUE_URL:http://localhost:8081}
+  - id: seat
+    uri: ${SEAT_URL:http://localhost:8082}
+  - id: order-core
+    uri: ${ORDER_CORE_URL:http://localhost:8083}
+  - id: recommendation
+    uri: ${RECOMMENDATION_URL:http://localhost:8084}
+```
+
+### 2. .env (프로젝트 루트)
+
+Docker 실행 시 `--env-file ../.env`로 주입되는 환경변수에 Gateway 라우팅 URL 추가:
+
+```env
+# === API Gateway ===
+ALLOWED_ORIGINS=http://localhost:*
+AUTH_GUARD_URL=http://auth-guard:8080
+QUEUE_URL=http://queue:8081
+SEAT_URL=http://seat:8082
+ORDER_CORE_URL=http://order-core:8083
+RECOMMENDATION_URL=http://recommendation:8084
+```
+
+`http://auth-guard:8080`에서 `auth-guard`는 Docker Compose의 **서비스 이름(= 컨테이너 DNS 이름)**입니다.
+
+### 3. 나머지 downstream 서비스 (Auth-Guard, Queue, Seat, Order-Core, Recommendation)
+
+이들은 변경 불필요. 이유:
+- DB, Redis 접속 정보는 이미 `${DB_URL:jdbc:postgresql://localhost:5432/goormgb}` 패턴으로 되어 있음
+- Docker 환경에서 `docker-compose.yml`의 `environment`로 덮어쓰기됨
+- 이 서비스들은 다른 서비스로 라우팅하지 않으므로 localhost 문제가 발생하지 않음
+
+## Docker 실행 명령어
+
+```bash
+cd docker
+
+# local 프로필
+docker compose --env-file ../.env -f docker-compose.yml -f docker-compose.local.yml up --build -d
+
+# dev 프로필
+docker compose --env-file ../.env -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+
+# default 프로필 (프로필 오버라이드 없이)
+docker compose --env-file ../.env -f docker-compose.yml up --build -d
+```
+
+## 주의사항
+
+- `.env` 파일은 `.gitignore`에 포함되어 있으므로 팀원과 공유 시 별도 전달 필요 (구름공방 알림디코 채널의 -> backend 카테고리 -> 설정-환경변수env 채팅방으로 공유)
+- Docker 컨테이너는 Spring Boot 기동에 시간이 걸리므로 (약 15~30초), Gateway Swagger UI 접속 전 모든 서비스가 기동 완료될 때까지 대기 필요


### PR DESCRIPTION
## 🔧 작업 내용
- Spring Cloud Gateway 5.x 호환을 위한 설정 prefix 수정 및 통합 테스트 중 발견된 이슈 해결
- downstream 서비스에 불필요하게 포함되어 있던 kakao 설정 제거
- Gateway Swagger UI에서 각 서비스로 요청 시 라우팅이 정상 동작하도록 SwaggerConfig에 context-path 기반 server URL 설정 추가

## 🧩 구현 상세 (선택)
### 1. Spring Cloud Gateway 5.x 설정 prefix 수정
**- Spring Cloud Gateway 5.x(Spring Boot 4.x)에서 설정 prefix가 spring.cloud.gateway → spring.cloud.gateway.server.webflux로 변경됨**
- application.yaml, application-dev.yaml의 globalcors, routes 설정을 새 prefix로 마이그레이션
- API-Gateway 테스트용 application-test.yaml 추가

### 2. downstream 서비스 불필요 설정 제거
- Queue, Seat, Order-Core, Recommendation에서 kakao 설정 블록 제거
- kakao 관련 설정은 Auth-Guard에서만 사용하므로 다른 서비스에 존재할 필요 없음

### 3. Swagger UI Gateway 라우팅 수정
- SwaggerConfig에 `@Value("${server.servlet.context-path:}")`로 각 서비스의 **context-path를 동적 주입**
- **server URL을 context-path 기반으로 설정**하여,
Gateway Swagger UI에서 요청 시 `/auth/**`, `/order/**` 등 **Gateway route에 정상 매칭되도록 수정**

  - 기존 문제: server URL이 Spring Doc로 인해 자동으로 서비스별 url로 고정되어 → Gateway route 미매칭
  - 수정 후: server URL이 /auth로 설정되어 /auth/dev/auth/login으로 요청 → 정상 라우팅
 
### 📌 관련 Jira Issue
- GRGB-182

## 🧪 테스트 방법(선택)
1. 모든 서비스(Auth-Guard, Queue, Seat, Order-Core, Recommendation) + API-Gateway 기동
2. http://localhost:8085/swagger-ui.html 접속
3. 각 서비스(Auth-Guard, Order-Core 등) 선택 후 API 요청 시 200 응답 확인
4. Gateway 로그에서 라우팅 정상 동작 확인

# 모든 profile(defalut, dev, local) 라우팅 정상 동작 확인

## ❗ 참고 사항
- Spring Cloud Gateway 5.x prefix 변경은 공식 문서에 명시되어 있지 않아 javap로 GatewayProperties.PREFIX 확인하여 발견한 사항

# 다음작업
- API Gateway 기능 구현(T1~T7)이 feat/api-gateway 브랜치에서 완료.
현재 dev 브랜치에 다른 개발 작업이 진행되었으므로, 아래 순서로 머지를 진행할 예정입니다.:
  - a. dev → feat/api-gateway 머지하여 최신 개발 내용과 싱크 맞추기
  - b. 충돌 발생 시 feat/api-gateway에서 해결
  - c. feat/api-gateway → dev PR을 올려 API Gateway 전체 기능 합치기
- 이 PR은 T7(통합 테스트) 범위의 마지막 커밋이며, 위 머지 작업은 별도 PR로 진행할 예정입니다.