### PR TITLE
fix(order-core): 구단/경기 조회 API 비로그인 접근 허용 [GRGB-185]

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -43,7 +43,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 			"/seat/v3/api-docs",
 			"/order/v3/api-docs",
 			"/recommendation/v3/api-docs",
-			"/actuator"
+			"/actuator",
+			"/order/clubs",
+			"/order/matches"
 	);
 
 	private final JwtTokenProvider jwtTokenProvider;

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -31,7 +31,9 @@ public class SecurityConfig {
 					"/swagger-ui.html",
 					"/swagger-resources/**",
 					"/v3/api-docs/**",
-					"/actuator/health/**"
+					"/actuator/health/**",
+					"/clubs/**",
+					"/matches/**"
 				).permitAll()
 				.anyRequest().authenticated()
 			)


### PR DESCRIPTION
## 🔧 작업 내용
- 비로그인 사용자가 구단(Club) 및 경기(Match) 조회 API에 접근 시 401 에러가 발생하는 문제 수정
- API Gateway와 Order-Core 양쪽에서 인증을 요구하고 있어 두 레이어 모두 수정

## 🧩 구현 상세
- **API Gateway** (`JwtAuthenticationFilter`): 화이트리스트에 `/order/clubs`, `/order/matches` 추가
  - Gateway 레벨에서 JWT 없이도 해당 경로의 요청을 downstream으로 전달
  - **Order-Core** (`SecurityConfig`): `permitAll()`에 `/clubs/**`, `/matches/**` 추가
  - `X-User-Id` 헤더 없이도 Spring Security에서 접근 허용
- 온보딩(`/onboarding/**`) 등 나머지 API는 기존대로 인증 필요

### 📌 관련 Jira Issue
- GRGB-185

  ## 🧪 테스트 방법
- 토큰 없이 아래 엔드포인트 호출 시 200 응답 확인
  - `GET /order/clubs`
  - `GET /order/clubs/{clubId}`
  - `GET /order/clubs/{clubId}/matches`
  - `GET /order/matches`
  - `GET /order/matches/{matchId}`
- 토큰 없이 `POST /order/onboarding/preferences` 호출 시 기존대로 401 확인

  ## ❗ 참고 사항
- Gateway 화이트리스트는 prefix 매칭(`startsWith`)이므로 `/order/clubs`로 시작하는 모든 하위 경로 포함