### PR TITLE
test(api-gateway): JWT 필터 및 토큰 프로바이더 Unit 테스트 추가 [GRGB-184]

### DIFF
--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
@@ -2,8 +2,10 @@ package com.goormgb.be.apigateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApiGatewayApplicationTests {
 
 	@Test

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,280 @@
+package com.goormgb.be.apigateway.filter;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.goormgb.be.apigateway.fixture.JwtTokenFixture;
+import com.goormgb.be.apigateway.jwt.config.JwtProperties;
+import com.goormgb.be.apigateway.jwt.provider.JwtTokenProvider;
+import com.goormgb.be.apigateway.jwt.repository.AccessTokenBlacklistRepository;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+	@Mock
+	private AccessTokenBlacklistRepository blacklistRepository;
+
+	@Mock
+	private GatewayFilterChain chain;
+
+	private JwtAuthenticationFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		JwtProperties properties = new JwtProperties();
+		properties.setSecretKey(JwtTokenFixture.SECRET_KEY);
+		properties.setIssuer("test-issuer");
+
+		JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(properties);
+		jwtTokenProvider.init();
+
+		filter = new JwtAuthenticationFilter(jwtTokenProvider, blacklistRepository);
+	}
+
+	private MockServerWebExchange createExchange(String path) {
+		return MockServerWebExchange.from(
+				MockServerHttpRequest.get(path).build());
+	}
+
+	private MockServerWebExchange createExchangeWithToken(String path, String token) {
+		return MockServerWebExchange.from(
+				MockServerHttpRequest.get(path)
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+						.build());
+	}
+
+	@Test
+	@DisplayName("필터 순서는 -1이다")
+	void getOrder_returnsMinusOne() {
+		assertThat(filter.getOrder()).isEqualTo(-1);
+	}
+
+	@Nested
+	@DisplayName("화이트리스트 경로")
+	class WhitelistedPaths {
+
+		@ParameterizedTest
+		@ValueSource(strings = {
+				"/auth/kakao",
+				"/auth/kakao/callback",
+				"/auth/token/refresh",
+				"/auth/dev/auth",
+				"/auth/dev/auth/login",
+				"/swagger-ui",
+				"/swagger-ui/index.html",
+				"/v3/api-docs",
+				"/v3/api-docs/swagger-config",
+				"/auth/v3/api-docs",
+				"/queue/v3/api-docs",
+				"/seat/v3/api-docs",
+				"/order/v3/api-docs",
+				"/recommendation/v3/api-docs",
+				"/actuator",
+				"/actuator/health",
+				"/actuator/prometheus",
+				"/order/clubs",
+				"/order/clubs/1",
+				"/order/clubs/1/matches",
+				"/order/matches",
+				"/order/matches/1"
+		})
+		@DisplayName("화이트리스트 경로는 인증 없이 통과한다")
+		void whitelistedPath_passesWithoutAuth(String path) {
+			MockServerWebExchange exchange = createExchange(path);
+			when(chain.filter(any())).thenReturn(Mono.empty());
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			verify(chain).filter(any());
+			verify(blacklistRepository, never()).isBlacklisted(anyString());
+		}
+	}
+
+	@Nested
+	@DisplayName("토큰이 없는 경우")
+	class NoToken {
+
+		@Test
+		@DisplayName("Authorization 헤더가 없으면 401을 반환한다")
+		void noAuthorizationHeader_returns401() {
+			MockServerWebExchange exchange = createExchange("/order/onboarding/preferences");
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+
+		@Test
+		@DisplayName("Bearer 접두사가 없으면 401을 반환한다")
+		void noBearerPrefix_returns401() {
+			MockServerWebExchange exchange = MockServerWebExchange.from(
+					MockServerHttpRequest.get("/order/onboarding/preferences")
+							.header(HttpHeaders.AUTHORIZATION, "Basic some-token")
+							.build());
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("유효한 ACCESS 토큰")
+	class ValidAccessToken {
+
+		@Test
+		@DisplayName("유효한 토큰이면 X-User-Id, X-User-Role 헤더를 추가하고 통과한다")
+		void validToken_addsHeadersAndPasses() {
+			String jti = UUID.randomUUID().toString();
+			String token = JwtTokenFixture.createAccessToken(42L, "ROLE_USER", jti);
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", token);
+
+			when(blacklistRepository.isBlacklisted(jti)).thenReturn(Mono.just(false));
+
+			ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+			when(chain.filter(captor.capture())).thenReturn(Mono.empty());
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			ServerWebExchange capturedExchange = captor.getValue();
+			HttpHeaders headers = capturedExchange.getRequest().getHeaders();
+			assertThat(headers.getFirst("X-User-Id")).isEqualTo("42");
+			assertThat(headers.getFirst("X-User-Role")).isEqualTo("ROLE_USER");
+		}
+
+		@Test
+		@DisplayName("다른 userId도 정확히 헤더에 전달된다")
+		void differentUserId_isPassedCorrectly() {
+			String jti = UUID.randomUUID().toString();
+			String token = JwtTokenFixture.createAccessToken(99L, "ROLE_USER", jti);
+			MockServerWebExchange exchange = createExchangeWithToken("/seat/available", token);
+
+			when(blacklistRepository.isBlacklisted(jti)).thenReturn(Mono.just(false));
+
+			ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+			when(chain.filter(captor.capture())).thenReturn(Mono.empty());
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			ServerWebExchange capturedExchange = captor.getValue();
+			assertThat(capturedExchange.getRequest().getHeaders().getFirst("X-User-Id")).isEqualTo("99");
+			assertThat(capturedExchange.getRequest().getHeaders().getFirst("X-User-Role")).isEqualTo("ROLE_USER");
+		}
+	}
+
+	@Nested
+	@DisplayName("블랙리스트 토큰")
+	class BlacklistedToken {
+
+		@Test
+		@DisplayName("블랙리스트에 등록된 토큰이면 401을 반환한다")
+		void blacklistedToken_returns401() {
+			String jti = "blacklisted-jti";
+			String token = JwtTokenFixture.createAccessTokenWithJti(jti);
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", token);
+
+			when(blacklistRepository.isBlacklisted(jti)).thenReturn(Mono.just(true));
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("잘못된 토큰")
+	class InvalidToken {
+
+		@Test
+		@DisplayName("잘못된 서명의 토큰이면 401을 반환한다")
+		void invalidSignature_returns401() {
+			String token = JwtTokenFixture.createWrongSignatureToken();
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", token);
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+
+		@Test
+		@DisplayName("만료된 토큰이면 401을 반환한다")
+		void expiredToken_returns401() {
+			String token = JwtTokenFixture.createExpiredAccessToken();
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", token);
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+
+		@Test
+		@DisplayName("형식이 잘못된 토큰이면 401을 반환한다")
+		void malformedToken_returns401() {
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", "not-a-jwt");
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("REFRESH 토큰")
+	class RefreshTokenUsed {
+
+		@Test
+		@DisplayName("REFRESH 타입 토큰이면 401을 반환한다")
+		void refreshToken_returns401() {
+			String token = JwtTokenFixture.createRefreshToken(JwtTokenFixture.DEFAULT_USER_ID);
+			MockServerWebExchange exchange = createExchangeWithToken("/order/onboarding/preferences", token);
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+			verify(blacklistRepository, never()).isBlacklisted(anyString());
+		}
+	}
+}

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/fixture/JwtTokenFixture.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/fixture/JwtTokenFixture.java
@@ -12,7 +12,7 @@ import io.jsonwebtoken.security.Keys;
 
 public final class JwtTokenFixture {
 
-	public static final String SECRET_KEY = "goormgb-test-secret-key-do-not-use-in-production-20260321-must-be-at-least-256-bits";
+	public static final String SECRET_KEY = "goormgb-test-secret-key-do-not-use-in-production-20260302-must-be-at-least-256-bits";
 	public static final String WRONG_SECRET_KEY = "wrong-secret-key-that-is-long-enough-for-hmac-sha256!!";
 	public static final Long DEFAULT_USER_ID = 1L;
 	public static final String DEFAULT_ROLE = "ROLE_USER";

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/fixture/JwtTokenFixture.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/fixture/JwtTokenFixture.java
@@ -1,0 +1,96 @@
+package com.goormgb.be.apigateway.fixture;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import com.goormgb.be.apigateway.jwt.enums.TokenType;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+public final class JwtTokenFixture {
+
+	public static final String SECRET_KEY = "goormgb-test-secret-key-do-not-use-in-production-20260321-must-be-at-least-256-bits";
+	public static final String WRONG_SECRET_KEY = "wrong-secret-key-that-is-long-enough-for-hmac-sha256!!";
+	public static final Long DEFAULT_USER_ID = 1L;
+	public static final String DEFAULT_ROLE = "ROLE_USER";
+	public static final String DEFAULT_JTI = "test-jti-123";
+
+	private static final SecretKey KEY = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+	private JwtTokenFixture() {
+	}
+
+	public static SecretKey secretKey() {
+		return KEY;
+	}
+
+	public static String createAccessToken(Long userId, String role, String jti) {
+		return Jwts.builder()
+				.subject(String.valueOf(userId))
+				.id(jti)
+				.claim("tokenType", TokenType.ACCESS.getValue())
+				.claim("auth", role)
+				.issuedAt(new Date())
+				.expiration(new Date(System.currentTimeMillis() + 3600_000))
+				.signWith(KEY)
+				.compact();
+	}
+
+	public static String createDefaultAccessToken() {
+		return createAccessToken(DEFAULT_USER_ID, DEFAULT_ROLE, UUID.randomUUID().toString());
+	}
+
+	public static String createAccessTokenWithJti(String jti) {
+		return createAccessToken(DEFAULT_USER_ID, DEFAULT_ROLE, jti);
+	}
+
+	public static String createRefreshToken(Long userId) {
+		return Jwts.builder()
+				.subject(String.valueOf(userId))
+				.id(UUID.randomUUID().toString())
+				.claim("tokenType", TokenType.REFRESH.getValue())
+				.claim("auth", DEFAULT_ROLE)
+				.issuedAt(new Date())
+				.expiration(new Date(System.currentTimeMillis() + 3600_000))
+				.signWith(KEY)
+				.compact();
+	}
+
+	public static String createExpiredAccessToken() {
+		return Jwts.builder()
+				.subject(String.valueOf(DEFAULT_USER_ID))
+				.id(UUID.randomUUID().toString())
+				.claim("tokenType", TokenType.ACCESS.getValue())
+				.claim("auth", DEFAULT_ROLE)
+				.issuedAt(new Date(System.currentTimeMillis() - 7200_000))
+				.expiration(new Date(System.currentTimeMillis() - 3600_000))
+				.signWith(KEY)
+				.compact();
+	}
+
+	public static String createWrongSignatureToken() {
+		SecretKey wrongKey = Keys.hmacShaKeyFor(WRONG_SECRET_KEY.getBytes());
+		return Jwts.builder()
+				.subject(String.valueOf(DEFAULT_USER_ID))
+				.claim("tokenType", TokenType.ACCESS.getValue())
+				.claim("auth", DEFAULT_ROLE)
+				.signWith(wrongKey)
+				.compact();
+	}
+
+	public static String createTokenWithCustomExpiration(Long userId, String role, TokenType tokenType,
+			String jti, Date expiration) {
+		return Jwts.builder()
+				.subject(String.valueOf(userId))
+				.id(jti)
+				.claim("tokenType", tokenType.getValue())
+				.claim("auth", role)
+				.issuedAt(new Date())
+				.expiration(expiration)
+				.signWith(KEY)
+				.compact();
+	}
+}

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProviderTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProviderTest.java
@@ -1,0 +1,130 @@
+package com.goormgb.be.apigateway.jwt.provider;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.apigateway.fixture.JwtTokenFixture;
+import com.goormgb.be.apigateway.jwt.config.JwtProperties;
+import com.goormgb.be.apigateway.jwt.enums.TokenType;
+
+import io.jsonwebtoken.Claims;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+	private JwtTokenProvider jwtTokenProvider;
+
+	@BeforeEach
+	void setUp() {
+		JwtProperties properties = new JwtProperties();
+		properties.setSecretKey(JwtTokenFixture.SECRET_KEY);
+		properties.setIssuer("test-issuer");
+
+		jwtTokenProvider = new JwtTokenProvider(properties);
+		jwtTokenProvider.init();
+	}
+
+	@Nested
+	@DisplayName("parseClaims")
+	class ParseClaims {
+
+		@Test
+		@DisplayName("유효한 토큰이면 Claims를 반환한다")
+		void validToken_returnsClaims() {
+			String token = JwtTokenFixture.createDefaultAccessToken();
+
+			Claims claims = jwtTokenProvider.parseClaims(token);
+
+			assertThat(claims).isNotNull();
+			assertThat(claims.getSubject()).isEqualTo(String.valueOf(JwtTokenFixture.DEFAULT_USER_ID));
+		}
+
+		@Test
+		@DisplayName("다른 시크릿으로 서명된 토큰이면 예외를 던진다")
+		void wrongSignature_throwsException() {
+			String token = JwtTokenFixture.createWrongSignatureToken();
+
+			assertThatThrownBy(() -> jwtTokenProvider.parseClaims(token))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Invalid JWT token");
+		}
+
+		@Test
+		@DisplayName("만료된 토큰이면 예외를 던진다")
+		void expiredToken_throwsException() {
+			String token = JwtTokenFixture.createExpiredAccessToken();
+
+			assertThatThrownBy(() -> jwtTokenProvider.parseClaims(token))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessageContaining("Invalid JWT token");
+		}
+
+		@Test
+		@DisplayName("잘못된 형식의 토큰이면 예외를 던진다")
+		void malformedToken_throwsException() {
+			assertThatThrownBy(() -> jwtTokenProvider.parseClaims("not.a.valid.jwt"))
+					.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("클레임 추출 메서드")
+	class ClaimExtraction {
+
+		private Claims claims;
+
+		@BeforeEach
+		void setUp() {
+			String token = JwtTokenFixture.createTokenWithCustomExpiration(
+					42L, "ROLE_USER", TokenType.ACCESS,
+					JwtTokenFixture.DEFAULT_JTI,
+					new Date(System.currentTimeMillis() + 3600_000));
+			claims = jwtTokenProvider.parseClaims(token);
+		}
+
+		@Test
+		@DisplayName("getTokenType - ACCESS 타입을 반환한다")
+		void getTokenType_returnsAccess() {
+			assertThat(jwtTokenProvider.getTokenType(claims)).isEqualTo(TokenType.ACCESS);
+		}
+
+		@Test
+		@DisplayName("getUserId - subject에서 userId를 추출한다")
+		void getUserId_returnsUserId() {
+			assertThat(jwtTokenProvider.getUserId(claims)).isEqualTo(42L);
+		}
+
+		@Test
+		@DisplayName("getAuthority - auth 클레임을 반환한다")
+		void getAuthority_returnsRole() {
+			assertThat(jwtTokenProvider.getAuthority(claims)).isEqualTo("ROLE_USER");
+		}
+
+		@Test
+		@DisplayName("getJti - JTI를 반환한다")
+		void getJti_returnsJti() {
+			assertThat(jwtTokenProvider.getJti(claims)).isEqualTo(JwtTokenFixture.DEFAULT_JTI);
+		}
+	}
+
+	@Nested
+	@DisplayName("REFRESH 토큰 타입")
+	class RefreshToken {
+
+		@Test
+		@DisplayName("REFRESH 타입 토큰의 tokenType을 정확히 반환한다")
+		void refreshTokenType() {
+			String token = JwtTokenFixture.createRefreshToken(JwtTokenFixture.DEFAULT_USER_ID);
+			Claims claims = jwtTokenProvider.parseClaims(token);
+
+			assertThat(jwtTokenProvider.getTokenType(claims)).isEqualTo(TokenType.REFRESH);
+		}
+	}
+}

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/jwt/repository/AccessTokenBlacklistRepositoryTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/jwt/repository/AccessTokenBlacklistRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.goormgb.be.apigateway.jwt.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccessTokenBlacklistRepositoryTest {
+
+	@Mock
+	private ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+	@InjectMocks
+	private AccessTokenBlacklistRepository blacklistRepository;
+
+	@Test
+	@DisplayName("블랙리스트에 존재하는 jti면 true를 반환한다")
+	void isBlacklisted_whenKeyExists_returnsTrue() {
+		String jti = "blacklisted-jti";
+		when(reactiveRedisTemplate.hasKey("token_blacklist:" + jti))
+				.thenReturn(Mono.just(true));
+
+		StepVerifier.create(blacklistRepository.isBlacklisted(jti))
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test
+	@DisplayName("블랙리스트에 존재하지 않는 jti면 false를 반환한다")
+	void isBlacklisted_whenKeyNotExists_returnsFalse() {
+		String jti = "valid-jti";
+		when(reactiveRedisTemplate.hasKey("token_blacklist:" + jti))
+				.thenReturn(Mono.just(false));
+
+		StepVerifier.create(blacklistRepository.isBlacklisted(jti))
+				.expectNext(false)
+				.verifyComplete();
+	}
+}

--- a/API-Gateway/src/test/resources/application-test.yaml
+++ b/API-Gateway/src/test/resources/application-test.yaml
@@ -38,7 +38,7 @@ spring:
       port: 6379
 
 jwt:
-  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260227-must-be-at-least-256-bits
+  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260302-must-be-at-least-256-bits
   issuer: test-issuer
   access-token:
     audience: test-audience

--- a/API-Gateway/src/test/resources/application-test.yaml
+++ b/API-Gateway/src/test/resources/application-test.yaml
@@ -1,11 +1,44 @@
 spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          globalcors:
+            corsConfigurations:
+              '[/**]':
+                allowedOriginPatterns:
+                  - "http://localhost"
+                allowedMethods: [GET, POST, PUT, DELETE, OPTIONS]
+                allowedHeaders: ["*"]
+                allowCredentials: true
+          routes:
+            - id: auth-guard
+              uri: http://localhost
+              predicates:
+                - Path=/auth/**
+            - id: queue
+              uri: http://localhost
+              predicates:
+                - Path=/queue/**
+            - id: seat
+              uri: http://localhost
+              predicates:
+                - Path=/seat/**
+            - id: order-core
+              uri: http://localhost
+              predicates:
+                - Path=/order/**
+            - id: recommendation
+              uri: http://localhost
+              predicates:
+                - Path=/recommendation/**
   data:
     redis:
       host: localhost
       port: 6379
 
 jwt:
-  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260227
+  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260227-must-be-at-least-256-bits
   issuer: test-issuer
   access-token:
     audience: test-audience


### PR DESCRIPTION
## 🔧 작업 내용
- API Gateway 모듈의 핵심 컴포넌트 단위 테스트 작성
- 테스트 환경 설정 보완 (`application-test.yaml`, `@ActiveProfiles`)
- `JwtTokenFixture` 생성

## 🧩 구현 상세
### JwtAuthenticationFilterTest (22 tests)
- 화이트리스트 경로 인증 skip 검증 (Swagger, actuator, 공개 API 등)
- 토큰 없음 / Bearer 접두사 없음 → 401
- 유효한 ACCESS 토큰 → X-User-Id, X-User-Role 헤더 주입 검증
- 블랙리스트 등록 토큰 → 401
- 잘못된 서명 / 만료 / 형식 오류 토큰 → 401
- REFRESH 타입 토큰 → 401 (블랙리스트 확인 없이 즉시 거부)
<img width="763" height="471" alt="스크린샷 2026-03-02 오전 2 46 55" src="https://github.com/user-attachments/assets/ded03e21-a26e-4fa1-9637-77e20acaa0d1" />

### JwtTokenProviderTest (8 tests)
- 유효한 토큰 파싱 및 Claims 반환
- 잘못된 서명 / 만료 / 형식 오류 → 예외
- 클레임 추출: tokenType, userId, authority, jti
- REFRESH 토큰 타입 구분
<img width="775" height="336" alt="스크린샷 2026-03-02 오전 2 47 54" src="https://github.com/user-attachments/assets/b8199be1-287f-455d-9bed-1b840127d5e6" />


### AccessTokenBlacklistRepositoryTest (2 tests)
- Redis 블랙리스트 존재 시 true, 미존재 시 false (ReactiveRedisTemplate mock)

<img width="872" height="311" alt="스크린샷 2026-03-02 오전 2 48 49" src="https://github.com/user-attachments/assets/cfc71e30-efef-42d6-8156-207b05a68466" />


### JwtTokenFixture
- 프로젝트 기존 fixture 패턴(`static final` 상수 + `static` 팩토리 메서드) 준수
- 테스트 전반에서 중복되던 토큰 생성 로직 통합

### application-test.yaml
- 라우팅, CORS 등 Gateway 설정 추가 (컨텍스트 로드 테스트 통과용)
- 서비스 포트번호 미노출 (`http://localhost`)

### 📌 관련 Jira Issue
- GRGB-184

## 🧪 테스트 방법
- `./gradlew :API-Gateway:test` 실행 → 44개 테스트 전체 통과 확인

## ❗ 참고 사항
- **선행 PR 필요**: 구단/경기 조회 API 비로그인 접근 허용 PR이 먼저 머지되어야 전체 빌드(`./gradlew build`) 시 테스트가 통과합니다. 해당 PR에서 `JwtAuthenticationFilter` 화이트리스트에 `/order/clubs`,
  `/order/matches`가 추가되며, 본 PR의 화이트리스트 테스트 케이스가 이를 포함하고 있기 때문입니다.
- Auth-Guard 모듈의 기존 테스트 실패(context-path 불일치)는 본 PR과 무관하며 별도 티켓(`fix/auth-guard-test-context-path`)으로 처리 예정입니다.
