### PR TITLE
fix(auth-guard): 컨트롤러 테스트 요청 경로에서 context-path prefix 제거 [GRGB-186]

### DIFF
--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/ApiGatewayApplicationTests.java
@@ -2,8 +2,10 @@ package com.goormgb.be.apigateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApiGatewayApplicationTests {
 
 	@Test

--- a/API-Gateway/src/test/resources/application-test.yaml
+++ b/API-Gateway/src/test/resources/application-test.yaml
@@ -1,11 +1,44 @@
 spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          globalcors:
+            corsConfigurations:
+              '[/**]':
+                allowedOriginPatterns:
+                  - "http://localhost"
+                allowedMethods: [GET, POST, PUT, DELETE, OPTIONS]
+                allowedHeaders: ["*"]
+                allowCredentials: true
+          routes:
+            - id: auth-guard
+              uri: http://localhost
+              predicates:
+                - Path=/auth/**
+            - id: queue
+              uri: http://localhost
+              predicates:
+                - Path=/queue/**
+            - id: seat
+              uri: http://localhost
+              predicates:
+                - Path=/seat/**
+            - id: order-core
+              uri: http://localhost
+              predicates:
+                - Path=/order/**
+            - id: recommendation
+              uri: http://localhost
+              predicates:
+                - Path=/recommendation/**
   data:
     redis:
       host: localhost
       port: 6379
 
 jwt:
-  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260227
+  secret-key: goormgb-test-secret-key-do-not-use-in-production-20260302-must-be-at-least-256-bits
   issuer: test-issuer
   access-token:
     audience: test-audience

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/AuthControllerTest.java
@@ -58,7 +58,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 		given(cookieUtils.createRefreshTokenCookie("new-refresh-token")).willReturn(cookie);
 
 		// when & then
-		mockMvc.perform(post("/auth/token/refresh"))
+		mockMvc.perform(post("/token/refresh"))
 			.andExpect(status().isOk())
 			.andExpect(header().exists(HttpHeaders.SET_COOKIE))
 			.andExpect(jsonPath("$.code").value("OK"))
@@ -73,7 +73,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 		given(cookieUtils.extractRefreshToken(any(HttpServletRequest.class))).willReturn(null);
 
 		// when & then
-		mockMvc.perform(post("/auth/token/refresh"))
+		mockMvc.perform(post("/token/refresh"))
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.message").value("Refresh Token이 존재하지 않거나 만료, 유효하지 않습니다."));
 	}
@@ -92,7 +92,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 		given(cookieUtils.deleteRefreshTokenCookie()).willReturn(deleteCookie);
 
 		// when & then
-		mockMvc.perform(post("/auth/logout"))
+		mockMvc.perform(post("/logout"))
 			.andExpect(status().isOk())
 			.andExpect(header().exists(HttpHeaders.SET_COOKIE))
 			.andExpect(header().string(HttpHeaders.SET_COOKIE, org.hamcrest.Matchers.containsString("Max-Age=0")))
@@ -107,7 +107,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 		given(cookieUtils.extractRefreshToken(any(HttpServletRequest.class))).willReturn(null);
 
 		// when & then
-		mockMvc.perform(post("/auth/logout"))
+		mockMvc.perform(post("/logout"))
 			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.message").value("Refresh Token이 존재하지 않거나 만료, 유효하지 않습니다."));
 	}
@@ -126,7 +126,7 @@ class AuthControllerTest extends WebMvcTestSupport {
 		given(authService.withdraw(userId)).willReturn(response);
 
 		// when & then
-		mockMvc.perform(post("/auth/withdraw"))
+		mockMvc.perform(post("/withdraw"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.message").value("탈퇴 처리 완료"))

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
@@ -47,7 +47,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 		given(kakaoOAuthClient.createLoginUrl(isNull())).willReturn(expectedUrl);
 
 		// when & then
-		mockMvc.perform(get("/auth/kakao/login-url"))
+		mockMvc.perform(get("/kakao/login-url"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.data.loginUrl").value(expectedUrl));
@@ -80,7 +80,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 		given(cookieUtils.createRefreshTokenCookie("kakao-refresh-token")).willReturn(cookie);
 
 		// when & then
-		mockMvc.perform(post("/auth/kakao/login")
+		mockMvc.perform(post("/kakao/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -100,7 +100,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 		KakaoLoginRequest request = new KakaoLoginRequest();
 
 		// when & then
-		mockMvc.perform(post("/auth/kakao/login")
+		mockMvc.perform(post("/kakao/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())

--- a/docs/test-context-path-guide.md
+++ b/docs/test-context-path-guide.md
@@ -1,0 +1,117 @@
+# 테스트 코드에서 context-path 처리 가이드
+
+## 결론부터
+
+**`@WebMvcTest`에서는 `context-path`가 적용되지 않는다.**
+테스트 코드의 요청 경로에 context-path prefix를 붙이지 않는다.
+
+```java
+// ✅ 올바른 작성법 — 컨트롤러 매핑 경로만 사용
+mockMvc.perform(get("/kakao/login-url"))
+mockMvc.perform(post("/token/refresh"))
+mockMvc.perform(post("/onboarding/preferences"))
+
+// ❌ 잘못된 작성법 — context-path prefix 포함
+mockMvc.perform(get("/auth/kakao/login-url"))
+mockMvc.perform(post("/auth/token/refresh"))
+mockMvc.perform(post("/order/onboarding/preferences"))
+```
+
+---
+
+## 왜 그런가?
+
+### `@WebMvcTest` vs `@SpringBootTest`의 차이
+
+| | `@WebMvcTest` | `@SpringBootTest(webEnvironment = RANDOM_PORT)` |
+|---|---|---|
+| 서블릿 컨테이너 | 띄우지 않음 (MockMvc) | 실제로 띄움 |
+| `context-path` 적용 | **무시됨** | 적용됨 |
+| 사용 목적 | 컨트롤러 단위 테스트 | 통합 테스트 |
+
+`server.servlet.context-path`는 **서블릿 컨테이너(Tomcat)가 요청을 받을 때** 경로 앞에 붙이는 설정이다.
+`@WebMvcTest`는 서블릿 컨테이너를 띄우지 않고 `MockMvc`로 직접 `DispatcherServlet`을 호출하기 때문에
+`context-path` 설정이 아예 적용되지 않는다.
+
+### 실제 운영 환경의 요청 흐름
+
+```
+클라이언트 → API Gateway → Auth-Guard (Tomcat, context-path: /auth)
+
+요청: POST /auth/token/refresh
+Tomcat이 /auth를 벗겨냄 → DispatcherServlet은 /token/refresh를 받음
+→ AuthController의 @PostMapping("/token/refresh") 매칭
+```
+
+### @WebMvcTest의 요청 흐름
+
+```
+MockMvc → DispatcherServlet (Tomcat 없음, context-path 미적용)
+
+요청: POST /token/refresh
+→ DispatcherServlet이 /token/refresh를 그대로 받음
+→ AuthController의 @PostMapping("/token/refresh") 매칭 ✅
+
+요청: POST /auth/token/refresh
+→ DispatcherServlet이 /auth/token/refresh를 그대로 받음
+→ 매칭되는 컨트롤러 없음 → NoResourceFoundException (500) ❌
+```
+
+---
+
+## 모듈별 테스트 작성 규칙
+
+### 각 모듈의 context-path
+
+| 모듈 | context-path | 컨트롤러 예시 | 테스트 요청 경로 |
+|---|---|---|---|
+| Auth-Guard | `/auth` | `@PostMapping("/token/refresh")` | `/token/refresh` |
+| Auth-Guard | `/auth` | `@RequestMapping("/kakao")` + `@GetMapping("/login-url")` | `/kakao/login-url` |
+| Auth-Guard | `/auth` | `@RequestMapping("/dev/auth")` + `@PostMapping("/login")` | `/dev/auth/login` |
+| Order-Core | `/order` | `@RequestMapping("/clubs")` + `@GetMapping("/{clubId}")` | `/clubs/{clubId}` |
+| Order-Core | `/order` | `@RequestMapping("/onboarding")` + `@PostMapping("/preferences")` | `/onboarding/preferences` |
+| Queue | `/queue` | (향후 추가) | context-path 제외한 매핑 경로 |
+| Seat | `/seat` | (향후 추가) | context-path 제외한 매핑 경로 |
+| Recommendation | `/recommendation` | (향후 추가) | context-path 제외한 매핑 경로 |
+
+### 규칙 요약
+
+1. **`@WebMvcTest`** (컨트롤러 단위 테스트)
+   - 요청 경로 = `@RequestMapping` + `@GetMapping/@PostMapping` 값 그대로
+   - context-path prefix 절대 붙이지 않음
+   - `application-test.yaml`에 `server.servlet.context-path` 설정 불필요
+
+2. **`@SpringBootTest(webEnvironment = RANDOM_PORT)`** (통합 테스트, `TestRestTemplate` 사용)
+   - 서블릿 컨테이너가 실제로 뜨므로 context-path가 적용됨
+   - 이 경우에만 요청 경로에 context-path prefix를 포함해야 함
+   - 현재 프로젝트에서는 이 방식을 사용하지 않음
+
+---
+
+## application-test.yaml에 넣을 필요가 없는 것들
+
+`@WebMvcTest` 기반 테스트만 사용하는 경우 아래 설정은 `application-test.yaml`에 불필요하다:
+
+- `server.servlet.context-path` — MockMvc에서 무시됨
+- `server.port` — 서블릿 컨테이너를 띄우지 않으므로 의미 없음
+
+---
+
+## 이전 Auth-Guard 테스트 실패 원인과 수정 내용
+
+### 원인
+
+`AuthControllerTest`와 `KakaoAuthControllerTest`에서 요청 경로에 `/auth` prefix를 포함하여 작성했음.
+`@WebMvcTest`에서는 context-path가 적용되지 않으므로 매핑 불일치로 `NoResourceFoundException` 발생.
+
+### 수정 내용
+
+| 파일 | Before | After |
+|---|---|---|
+| `AuthControllerTest` | `post("/auth/token/refresh")` | `post("/token/refresh")` |
+| `AuthControllerTest` | `post("/auth/logout")` | `post("/logout")` |
+| `AuthControllerTest` | `post("/auth/withdraw")` | `post("/withdraw")` |
+| `KakaoAuthControllerTest` | `get("/auth/kakao/login-url")` | `get("/kakao/login-url")` |
+| `KakaoAuthControllerTest` | `post("/auth/kakao/login")` | `post("/kakao/login")` |
+
+`DevAuthControllerTest`와 `OnboardingPreferenceControllerTest`는 원래부터 prefix 없이 작성되어 있어 수정 불필요.


### PR DESCRIPTION
## 🔧 작업 내용
- Auth-Guard 컨트롤러 테스트 8개가 실패하던 문제 수정
- `@WebMvcTest`에서 `context-path`가 적용되지 않아 발생한 요청 경로 불일치 해결
 - 테스트 요청 경로에서 `/auth` prefix를 제거하여 컨트롤러 매핑과 일치시킴

## 🧩 구현 상세
  - `@WebMvcTest`는 서블릿 컨테이너(Tomcat)를 띄우지 않고 MockMvc가 DispatcherServlet을 직접 호출
  - `server.servlet.context-path`는 Tomcat이 요청을 받을 때 벗겨주는 역할이므로, Tomcat 없는 `@WebMvcTest`에서는 적용되지 않음
  - 따라서 테스트 요청 경로는 컨트롤러 `@RequestMapping` + `@GetMapping/@PostMapping` 값만 사용해야 함
  - 이 패턴은 Order-Core의 `OnboardingPreferenceControllerTest`, Auth-Guard의 `DevAuthControllerTest` 등 기존 통과 중인 테스트와 동일

  | 파일 | Before | After |
  |---|---|---|
  | `AuthControllerTest` | `post("/auth/token/refresh")` | `post("/token/refresh")` |
  | `AuthControllerTest` | `post("/auth/logout")` | `post("/logout")` |
  | `AuthControllerTest` | `post("/auth/withdraw")` | `post("/withdraw")` |
  | `KakaoAuthControllerTest` | `get("/auth/kakao/login-url")` | `get("/kakao/login-url")` |
  | `KakaoAuthControllerTest` | `post("/auth/kakao/login")` | `post("/kakao/login")` |

### 📌 관련 Jira Issue
  - GRGB-186

## 🧪 테스트 방법
- `./gradlew :Auth-Guard:test` → 14개 전체 통과 확인
- `./gradlew build` → 모든 모듈 빌드 성공 확인

## ❗ 참고 사항
- `@WebMvcTest` 기반 테스트에서는 context-path prefix를 사용하지 않는 것이 Spring 표준 패턴
- 향후 다른 모듈(Queue, Seat, Recommendation) 컨트롤러 테스트 작성 시에도 동일하게 적용
- 상세 가이드: `docs/test-context-path-guide.md` 참고