### PR TITLE
fix(auth-guard): 개발용 로그인 API 응답에 agreementRequired, onboardingRequired 필드 추가 [GRGB-192]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
@@ -68,6 +68,8 @@ public class DevAuthController {
 
 		return ResponseEntity.ok()
 				.header(HttpHeaders.SET_COOKIE, cookie)
-				.body(ApiResult.ok("로그인 성공", TokenRefreshResponse.of(result.accessToken())));
+				.body(ApiResult.ok("로그인 성공",
+						TokenRefreshResponse.of(result.accessToken(), result.agreementRequired(),
+								result.onboardingRequired())));
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/TokenRefreshResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/TokenRefreshResponse.java
@@ -1,15 +1,27 @@
 package com.goormgb.be.authguard.auth.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class TokenRefreshResponse {
 
 	private String accessToken;
+	private Boolean agreementRequired;
+	private Boolean onboardingRequired;
 
 	public static TokenRefreshResponse of(String accessToken) {
-		return new TokenRefreshResponse(accessToken);
+		return TokenRefreshResponse.builder()
+				.accessToken(accessToken)
+				.build();
+	}
+
+	public static TokenRefreshResponse of(String accessToken, boolean agreementRequired, boolean onboardingRequired) {
+		return TokenRefreshResponse.builder()
+				.accessToken(accessToken)
+				.agreementRequired(agreementRequired)
+				.onboardingRequired(onboardingRequired)
+				.build();
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
@@ -14,8 +14,10 @@ import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.user.entity.DevUser;
 import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.enums.UserStatus;
 import com.goormgb.be.user.repository.DevUserRepository;
 import com.goormgb.be.user.repository.UserRepository;
 
@@ -69,6 +71,12 @@ public class DevAuthService {
 		}
 
 		User user = devUser.getUser();
+
+		Preconditions.validate(
+				user.getStatus() != UserStatus.DEACTIVATE,
+				ErrorCode.USER_DEACTIVATED
+		);
+
 		user.updateLastLoginAt();
 
 		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY);
@@ -93,7 +101,10 @@ public class DevAuthService {
 
 		log.info("Dev user logged in - loginId: {}, userId: {}", loginId, user.getId());
 
-		return new DevLoginResult(accessToken, refreshToken);
+		boolean agreementRequired = !Boolean.TRUE.equals(user.getMarketingConsent());
+		boolean onboardingRequired = !Boolean.TRUE.equals(user.getOnboardingCompleted());
+
+		return new DevLoginResult(accessToken, refreshToken, agreementRequired, onboardingRequired);
 	}
 
 	private String getClientIp(HttpServletRequest request) {
@@ -104,6 +115,7 @@ public class DevAuthService {
 		return request.getRemoteAddr();
 	}
 
-	public record DevLoginResult(String accessToken, String refreshToken) {
+	public record DevLoginResult(String accessToken, String refreshToken, boolean agreementRequired,
+								 boolean onboardingRequired) {
 	}
 }

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/DevAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/DevAuthControllerTest.java
@@ -92,7 +92,7 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 		// given
 		DevLoginRequest request = DevLoginRequestFixture.createDefault();
 		DevAuthService.DevLoginResult loginResult =
-				new DevAuthService.DevLoginResult("access-token-value", "refresh-token-value");
+				new DevAuthService.DevLoginResult("access-token-value", "refresh-token-value", false, false);
 
 		given(devAuthService.login(eq(request.getLoginId()), eq(request.getPassword()), any(HttpServletRequest.class)))
 				.willReturn(loginResult);
@@ -109,7 +109,26 @@ class DevAuthControllerTest extends WebMvcTestSupport {
 				.andExpect(header().exists(HttpHeaders.SET_COOKIE))
 				.andExpect(jsonPath("$.code").value("OK"))
 				.andExpect(jsonPath("$.message").value("로그인 성공"))
-				.andExpect(jsonPath("$.data.accessToken").value("access-token-value"));
+				.andExpect(jsonPath("$.data.accessToken").value("access-token-value"))
+				.andExpect(jsonPath("$.data.agreementRequired").value(false))
+				.andExpect(jsonPath("$.data.onboardingRequired").value(false));
+	}
+
+	@Test
+	@DisplayName("POST /dev/auth/login - 비활성화된 계정 로그인 시 403")
+	void 로그인_비활성화_계정() throws Exception {
+		// given
+		DevLoginRequest request = DevLoginRequestFixture.createDefault();
+
+		given(devAuthService.login(eq(request.getLoginId()), eq(request.getPassword()), any(HttpServletRequest.class)))
+				.willThrow(new CustomException(ErrorCode.USER_DEACTIVATED));
+
+		// when & then
+		mockMvc.perform(post("/dev/auth/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.message").value("비활성화된 사용자입니다."));
 	}
 
 	@Test


### PR DESCRIPTION
##  🔧 작업 내용
- API 명세서에 맞게 POST /auth/dev/auth/login 응답에 agreementRequired, onboardingRequired 필드 추가
- DEACTIVATE 상태 유저 로그인 시 403 Forbidden 반환 처리

##  🧩 구현 상세
- TokenRefreshResponse를 @Builder 패턴으로 전환하고 새 필드 추가. 기존 of(accessToken) 메서드는 유지하여 토큰 재발급 API 호환성 보장
- DevAuthService에서 User의 marketingConsent, onboardingCompleted 상태를 확인하여 프론트에 전달
  - marketingConsent == false → agreementRequired: true
  - onboardingCompleted == false → onboardingRequired: true

###  📌 관련 Jira Issue
 - GRGB-192

## 🧪 테스트 방법

  - DevAuthControllerTest 실행
    - 로그인 성공 시 agreementRequired, onboardingRequired 필드 검증
    - 비활성화 계정 로그인 시 403 반환 검증
  - 응답 예시:
```
  {
    "code": "OK",
    "message": "로그인 성공",
    "data": {
      "accessToken": "eyJhbG...",
      "agreementRequired": false,
      "onboardingRequired": false
    }
  }
```
테스트 통과 확인
<img width="1283" height="639" alt="스크린샷 2026-03-03 오후 10 44 08" src="https://github.com/user-attachments/assets/a2622a0b-014c-439b-be02-70b1c8ec598c" />


# 참고사항
## 프론트의 빠른 작업을 위해 위 개발계정 응답 필드 수정은 리뷰 없이 바로 dev에 merge하도록 하겠습니다