### PR TITLE
feat(auth-guard): 카카오 로그인 신규 사용자 가입 시 201 Created 반환 [GRGB-197]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
@@ -3,6 +3,7 @@ package com.goormgb.be.authguard.kakao.controller;
 import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -82,7 +83,9 @@ public class KakaoAuthController {
 		// Refresh Token Cookie 생성
 		String cookie = cookieUtils.createRefreshTokenCookie(loginResponse.getRefreshToken()).toString();
 
-		return ResponseEntity.ok()
+		HttpStatus status = loginResponse.isNewUser() ? HttpStatus.CREATED : HttpStatus.OK;
+
+		return ResponseEntity.status(status)
 				.header(HttpHeaders.SET_COOKIE, cookie)
 				.body(ApiResult.ok(loginResponse));
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
@@ -14,6 +14,8 @@ public class KakaoLoginResponse {
 	private String accessToken;
 	@JsonIgnore
 	private String refreshToken;
+	@JsonIgnore
+	private boolean newUser;
 	private UserInfo user;
 	private boolean onboardingRequired;
 
@@ -30,11 +32,13 @@ public class KakaoLoginResponse {
 	public static KakaoLoginResponse of(
 			String accessToken,
 			String refreshToken,
-			User user
+			User user,
+			boolean newUser
 	) {
 		return KakaoLoginResponse.builder()
 				.accessToken(accessToken)
 				.refreshToken(refreshToken)
+				.newUser(newUser)
 				.user(UserInfo.builder()
 						.userId(user.getId())
 						.email(user.getEmail())

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -57,11 +57,16 @@ public class KakaoAuthService {
 		String profileImageUrl = userResponse.getProfileImageUrl();
 
 		// 3. user_sns 기준으로 기존 사용자 조회
-		User user = userSnsRepository.findByProviderAndProviderUserId(
-						SocialProvider.KAKAO,
-						providerUserId
-				).map(UserSns::getUser)
-				.orElseGet(() -> signUp(email, nickname, profileImageUrl, providerUserId));
+		boolean isNewUser = false;
+		Optional<UserSns> existingUserSns = userSnsRepository.findByProviderAndProviderUserId(
+				SocialProvider.KAKAO, providerUserId);
+		User user;
+		if (existingUserSns.isPresent()) {
+			user = existingUserSns.get().getUser();
+		} else {
+			user = signUp(email, nickname, profileImageUrl, providerUserId);
+			isNewUser = true;
+		}
 
 		// 4. 상태 체크
 		Preconditions.validate(
@@ -101,9 +106,7 @@ public class KakaoAuthService {
 
 		refreshTokenRepository.save(tokenInfo);
 
-		// 컨트롤러에서 쿠키 설정을 위해 응답 DTO에 refreshToken을 잠시 포함하거나
-		// 서비스 결과 객체를 따로 만들어 리턴하는 것이 좋습니다.
-		return KakaoLoginResponse.of(accessToken, refreshToken, user);
+		return KakaoLoginResponse.of(accessToken, refreshToken, user, isNewUser);
 
 	}
 

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
@@ -49,14 +49,15 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 	}
 
 	@Test
-	@DisplayName("POST /auth/kakao/login - 카카오 로그인 성공")
-	void 카카오_로그인_성공() throws Exception {
+	@DisplayName("POST /auth/kakao/login - 기존 사용자 로그인 시 200 OK")
+	void 카카오_로그인_기존_사용자_200() throws Exception {
 		// given
 		KakaoLoginRequest request = KakaoLoginRequestFixture.createDefault();
 
 		KakaoLoginResponse loginResponse = KakaoLoginResponse.builder()
 				.accessToken("kakao-access-token")
 				.refreshToken("kakao-refresh-token")
+				.newUser(false)
 				.user(KakaoLoginResponse.UserInfo.builder()
 						.userId(1L)
 						.email("user@kakao.com")
@@ -64,7 +65,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 						.profileImageUrl("https://img.kakao.com/profile.jpg")
 						.status(UserStatus.ACTIVATE)
 						.build())
-				.onboardingRequired(true)
+				.onboardingRequired(false)
 				.build();
 
 		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), any(HttpServletRequest.class)))
@@ -83,9 +84,47 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.code").value("OK"))
 				.andExpect(jsonPath("$.data.accessToken").value("kakao-access-token"))
 				.andExpect(jsonPath("$.data.refreshToken").doesNotExist())
-				.andExpect(jsonPath("$.data.user.userId").value(1))
-				.andExpect(jsonPath("$.data.user.email").value("user@kakao.com"))
-				.andExpect(jsonPath("$.data.user.nickname").value("카카오유저"))
+				.andExpect(jsonPath("$.data.newUser").doesNotExist())
+				.andExpect(jsonPath("$.data.onboardingRequired").value(false));
+	}
+
+	@Test
+	@DisplayName("POST /auth/kakao/login - 신규 사용자 가입 시 201 Created")
+	void 카카오_로그인_신규_사용자_201() throws Exception {
+		// given
+		KakaoLoginRequest request = KakaoLoginRequestFixture.createDefault();
+
+		KakaoLoginResponse loginResponse = KakaoLoginResponse.builder()
+				.accessToken("kakao-access-token")
+				.refreshToken("kakao-refresh-token")
+				.newUser(true)
+				.user(KakaoLoginResponse.UserInfo.builder()
+						.userId(2L)
+						.email("newuser@kakao.com")
+						.nickname("신규유저")
+						.profileImageUrl("https://img.kakao.com/profile.jpg")
+						.status(UserStatus.ACTIVATE)
+						.build())
+				.onboardingRequired(true)
+				.build();
+
+		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), any(HttpServletRequest.class)))
+				.willReturn(loginResponse);
+
+		ResponseCookie cookie = ResponseCookie.from("refreshToken", "kakao-refresh-token")
+				.httpOnly(true).path("/").build();
+		given(cookieUtils.createRefreshTokenCookie("kakao-refresh-token")).willReturn(cookie);
+
+		// when & then
+		mockMvc.perform(post("/kakao/login")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(header().exists(HttpHeaders.SET_COOKIE))
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.data.accessToken").value("kakao-access-token"))
+				.andExpect(jsonPath("$.data.refreshToken").doesNotExist())
+				.andExpect(jsonPath("$.data.newUser").doesNotExist())
 				.andExpect(jsonPath("$.data.onboardingRequired").value(true));
 	}
 


### PR DESCRIPTION
## 🔧 작업 내용
 - 카카오 로그인 시 신규 사용자는 201 Created, 기존 사용자는 200 OK를 반환하도록 수정
onboardingRequired 필드로도 신규/기존 구분이 가능하지만
 HTTP 상태코드로도 명확하게 구분할 수 있으면 좋을것 같아서용
 프론트에서 응답 body를 파싱하지 않아도 상태코드만으로 신규/기존 사용자를 구분할 수 있음

## 🧩 구현 상세
### 신규/기존 사용자 판단 기준
  user_sns 테이블에 해당 카카오 계정이 존재하는지 여부로 판단합니다.
  - 존재하지 않음 → 신규 사용자 → signUp() 호출 후 isNewUser = true
  - 존재함 → 기존 사용자 → isNewUser = false

###  상태코드 전달 방식
  서비스에서 판단한 isNewUser 값을 컨트롤러까지 전달해야 하므로, KakaoLoginResponse에 newUser 필드를 추가했습니다. 이 필드는 컨트롤러에서 상태코드 분기 용도로만 사용되므로 @JsonIgnore를 적용하여 응답 body에는 노출되지 않습니다.
```java
  // KakaoAuthController.java
  HttpStatus status = loginResponse.isNewUser() ? HttpStatus.CREATED : HttpStatus.OK;
  return ResponseEntity.status(status)
          .header(HttpHeaders.SET_COOKIE, cookie)
          .body(ApiResult.ok(loginResponse));
```
  응답 예시

  신규/기존 모두 응답 body 구조는 동일하며, HTTP 상태코드만 다릅니다.

<img width="268" height="130" alt="스크린샷 2026-03-04 오전 12 25 52" src="https://github.com/user-attachments/assets/7edba85c-faef-478c-9885-407a7a90b1c3" />


###  📌 관련 Jira Issue
- GRGB-197

##  🧪 테스트 방법
  - KakaoAuthControllerTest
    - 카카오_로그인_기존_사용자_200: newUser(false) → status().isOk() 검증
    - 카카오_로그인_신규_사용자_201: newUser(true) → status().isCreated() 검증
    - 두 케이스 모두 $.data.newUser가 응답 body에 미포함 검증 (.doesNotExist())

##  ❗ 참고 사항
  - 응답 body 구조 변경 없음 — 프론트 기존 로직에 영향 없음
  - newUser 필드는 @JsonIgnore 처리되어 클라이언트에 노출되지 않음