### PR TITLE
fix(auth-guard): 카카오 OAuth 토큰 교환 시 Redirect URI 불일치 수정 및 에러 핸들링 개선 [GRGB-198]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
@@ -52,13 +52,17 @@ public class KakaoOAuthClient {
 	 * @param authorizationCode 카카오 로그인 성공 후 받은 code
 	 * @return 카카오 Access Token
 	 */
-	public KakaoTokenResponse requestAccessToken(String authorizationCode) {
+	public KakaoTokenResponse requestAccessToken(String authorizationCode, String redirectUri) {
+		String effectiveRedirectUri = StringUtils.hasText(redirectUri)
+				? redirectUri
+				: properties.getRedirectUri();
+
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
 		params.add("grant_type", "authorization_code");
 		params.add("client_id", properties.getClientId());
 		params.add("client_secret", properties.getClientSecret());
-		params.add("redirect_uri", properties.getRedirectUri());
+		params.add("redirect_uri", effectiveRedirectUri);
 		params.add("code", authorizationCode);
 
 		HttpHeaders headers = new HttpHeaders();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
@@ -7,20 +7,25 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.goormgb.be.authguard.kakao.config.KakaoOAuthProperties;
 import com.goormgb.be.authguard.kakao.dto.KakaoTokenResponse;
 import com.goormgb.be.authguard.kakao.dto.KakaoUserResponse;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 카카오 OAuth 서버와 통신만 담당
  * 인가 코드 → Access Token
  * Access Token → 사용자 정보
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoOAuthClient {
@@ -70,10 +75,23 @@ public class KakaoOAuthClient {
 
 		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
-		return restTemplate.postForObject(
-				properties.getTokenUrl(),
-				request,
-				KakaoTokenResponse.class);
+		try {
+			return restTemplate.postForObject(
+					properties.getTokenUrl(),
+					request,
+					KakaoTokenResponse.class);
+		} catch (HttpClientErrorException e) {
+			String body = e.getResponseBodyAsString();
+			log.warn("카카오 토큰 요청 실패: {}", body);
+
+			if (body.contains("KOE320")) {
+				throw new CustomException(ErrorCode.OAUTH_CODE_EXPIRED);
+			}
+			if (body.contains("KOE303")) {
+				throw new CustomException(ErrorCode.OAUTH_REDIRECT_URI_MISMATCH);
+			}
+			throw new CustomException(ErrorCode.OAUTH_PROVIDER_ERROR);
+		}
 	}
 
 	/**

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
@@ -77,7 +77,7 @@ public class KakaoAuthController {
 
 		// 서비스 로직 실행
 		KakaoLoginResponse loginResponse = kakaoAuthService.kakaoLogin(
-				request.getAuthorizationCode(), httpRequest
+				request.getAuthorizationCode(), request.getRedirectUri(), httpRequest
 		);
 
 		// Refresh Token Cookie 생성

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginRequest.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginRequest.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class KakaoLoginRequest {
 	private String authorizationCode;
+	private String redirectUri;
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -40,10 +40,10 @@ public class KakaoAuthService {
 	private final JwtProperties jwtProperties;
 	private final RefreshTokenRepository refreshTokenRepository;
 
-	public KakaoLoginResponse kakaoLogin(String authorizationCode, HttpServletRequest request) {
+	public KakaoLoginResponse kakaoLogin(String authorizationCode, String redirectUri, HttpServletRequest request) {
 
 		// 1. authorizationCode → 카카오 Access Token 요청
-		KakaoTokenResponse kakaoAccessToken = kakaoOAuthClient.requestAccessToken(authorizationCode);
+		KakaoTokenResponse kakaoAccessToken = kakaoOAuthClient.requestAccessToken(authorizationCode, redirectUri);
 
 		Optional.ofNullable(kakaoAccessToken)
 				.filter(token -> token.getAccessToken() != null)

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/fixture/KakaoLoginRequestFixture.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/fixture/KakaoLoginRequestFixture.java
@@ -7,17 +7,23 @@ import com.goormgb.be.authguard.kakao.dto.KakaoLoginRequest;
 public final class KakaoLoginRequestFixture {
 
 	public static final String DEFAULT_AUTHORIZATION_CODE = "test_kakao_auth_code_12345";
+	public static final String DEFAULT_REDIRECT_URI = "http://localhost:3000/callback/kakao";
 
 	private KakaoLoginRequestFixture() {
 	}
 
 	public static KakaoLoginRequest createDefault() {
-		return createWithCode(DEFAULT_AUTHORIZATION_CODE);
+		return createWithCodeAndRedirectUri(DEFAULT_AUTHORIZATION_CODE, DEFAULT_REDIRECT_URI);
 	}
 
 	public static KakaoLoginRequest createWithCode(String authorizationCode) {
+		return createWithCodeAndRedirectUri(authorizationCode, DEFAULT_REDIRECT_URI);
+	}
+
+	public static KakaoLoginRequest createWithCodeAndRedirectUri(String authorizationCode, String redirectUri) {
 		KakaoLoginRequest request = new KakaoLoginRequest();
 		ReflectionTestUtils.setField(request, "authorizationCode", authorizationCode);
+		ReflectionTestUtils.setField(request, "redirectUri", redirectUri);
 		return request;
 	}
 }

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthControllerTest.java
@@ -68,7 +68,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 				.onboardingRequired(false)
 				.build();
 
-		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), any(HttpServletRequest.class)))
+		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), eq(request.getRedirectUri()), any(HttpServletRequest.class)))
 				.willReturn(loginResponse);
 
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", "kakao-refresh-token")
@@ -108,7 +108,7 @@ class KakaoAuthControllerTest extends WebMvcTestSupport {
 				.onboardingRequired(true)
 				.build();
 
-		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), any(HttpServletRequest.class)))
+		given(kakaoAuthService.kakaoLogin(eq(request.getAuthorizationCode()), eq(request.getRedirectUri()), any(HttpServletRequest.class)))
 				.willReturn(loginResponse);
 
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", "kakao-refresh-token")

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
 	BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
 	OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
 	OAUTH_CODE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "인가 코드는 필수입니다."),
+	OAUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인가 코드가 만료되었거나 이미 사용되었습니다."),
+	OAUTH_REDIRECT_URI_MISMATCH(HttpStatus.BAD_REQUEST, "Redirect URI가 일치하지 않습니다."),
+	OAUTH_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "카카오 인증 서버 요청에 실패했습니다."),
 
 	// Club
 	CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "구단을 찾을 수 없습니다."),

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ import java.util.Arrays;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -39,6 +41,18 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(AuthorizationDeniedException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleAuthorizationDenied(AuthorizationDeniedException e) {
 		return ErrorResponse.error(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse.ErrorData> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+		log.warn("JSON parse error: {}", e.getMessage());
+		return ErrorResponse.error(HttpStatus.BAD_REQUEST, "요청 본문의 JSON 형식이 올바르지 않습니다.");
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse.ErrorData> handleMissingParam(MissingServletRequestParameterException e) {
+		String message = String.format("필수 파라미터 '%s'이(가) 누락되었습니다.", e.getParameterName());
+		return ErrorResponse.error(HttpStatus.BAD_REQUEST, message);
 	}
 
 	@ExceptionHandler(MethodArgumentTypeMismatchException.class)


### PR DESCRIPTION
## 🔧 작업 내용
- 카카오 OAuth 토큰 교환 시 프론트가 사용한 redirectUri와 백엔드의 redirectUri가 불일치하여 발생하던 KOE303 에러 수정
- 카카오 API 에러(KOE320, KOE303 등) 발생 시 500 대신 적절한 상태코드(400, 502)로 반환하도록 에러 핸들링 추가
- 잘못된 JSON 요청 시 500 대신 400으로 반환하도록 GlobalExceptionHandler 개선

## 🧩 구현 상세
- `KakaoLoginRequest`에 optional `redirectUri` 필드 추가하여 프론트가 인가 코드 발급 시 사용한 redirectUri를 토큰 교환에도 동일하게 전달
- `KakaoOAuthClient.requestAccessToken()`에서 redirectUri 파라미터를 받아 값이 있으면 사용, 없으면 환경변수 기본값(`KAKAO_REDIRECT_URI`) fallback
- Controller → Service → Client까지 redirectUri 전달 경로 구성
- `KakaoOAuthClient`에서 `HttpClientErrorException`을 catch하여 카카오 에러 코드별 분기 처리 (KOE320 → 인가 코드 만료, KOE303 → URI 불일치)
- `GlobalExceptionHandler`에 `HttpMessageNotReadableException`, `MissingServletRequestParameterException` 핸들러 추가

### 📌 관련 Jira Issue
- GRGB-198

## 🧪 테스트 방법
- `POST /auth/kakao/login` 호출 시 body에 `redirectUri` 포함하여 요청
  ```json
  {
    "authorizationCode": "카카오_인가코드",
    "redirectUri": "http://localhost:3000/callback/kakao"
  }
- redirectUri 생략 시 환경변수 기본값(https://dev.goormgb.space/auth/kakao/callback)으로 fallback 확인
- 만료된 인가 코드 전송 시 400 + "인가 코드가 만료되었거나 이미 사용되었습니다." 응답 확인
- 잘못된 JSON 전송 시 400 + "요청 본문의 JSON 형식이 올바르지 않습니다." 응답 확인
- ./gradlew :Auth-Guard:test 전체 통과 확인

##❗ 참고 사항
- 프론트에서 GET /auth/kakao/login-url에 커스텀 redirectUri를 사용했다면, POST /auth/kakao/login에도 동일한 값을 전달해야 함
- redirectUri는 optional 필드로, 기존 프론트 코드가 전달하지 않아도 하위 호환성 유지
- 기존 환경변수(KAKAO_REDIRECT_URI)만 사용하는 배포 환경에는 영향 없음