### PR TITLE
fix(auth-guard): Spring Security 기본 로그아웃 필터 비활성화

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -26,6 +26,7 @@ public class AuthGuardSecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
+				.logout(AbstractHttpConfigurer::disable)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(


### PR DESCRIPTION
## 🔧 작업 내용
Spring Security의 기본 LogoutFilter가 POST /logout을 가로채 /login?logout으로 리다이렉트하는 문제 수정.
커스텀 로그아웃 컨트롤러가 정상 동작하도록 logout 필터 비활성화.

문제 흐름

  프론트: POST /auth/logout
    → Gateway: /auth/** → Auth-Guard로 전달 (prefix 유지)
      → Auth-Guard: context-path=/auth → Spring이 /logout으로 인식
        → Spring Security의 기본 LogoutFilter가 낚아챔
          → /login?logout 으로 redirect
            → dev-auth-guard.dev-webs.svc.cluster.local/auth/login?logout (내부 클러스터 URL)
              → 프론트에서 ERR_NAME_NOT_RESOLVED

  우리 컨트롤러 @PostMapping("/logout")에 도달하기 전에 Spring Security 기본 로그아웃 필터가 먼저 가로채감...


## 🧩 구현 상세 (선택)
- 기본 LogoutFilter를 끄면 POST /logout → 커스텀 컨트롤러 → Access Token 블랙리스트 등록 + Refresh Token 삭제 흐름이 정상 동작

## ❗ 참고 사항
- 프론트에서 logout 호출 시 반드시 auth.post (Authorization 헤더 포함) 사용해야 함 (pub.post 사용 시 게이트웨이에서 401)