### PR TITLE
hotfix(auth-guard): dev 환경 쿠키 SameSite=None으로 변경 (임시)

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -26,6 +26,7 @@ public class AuthGuardSecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
+				.logout(AbstractHttpConfigurer::disable)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
@@ -29,7 +29,9 @@ public class CookieUtils {
 		return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
 				.httpOnly(true)     // XSS 방지
 				.secure(jwtProperties.getCookie().isSecure())
-				.sameSite("Lax")    // CSRF 공격 완화
+				// TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
+				//  SameSite=Lax, secure=false로 되돌릴 것.
+				.sameSite("None")   // cross-site 요청에서도 쿠키 전송 (HTTPS 필수)
 				.path("/")          // 모든 경로에서 쿠키전송
 				.maxAge(maxAgeSeconds)// 7일 만료
 				.build();
@@ -42,7 +44,9 @@ public class CookieUtils {
 		return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
 				.httpOnly(true)
 				.secure(jwtProperties.getCookie().isSecure())
-				.sameSite("Lax")
+				// TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
+				//  SameSite=Lax, secure=false로 되돌릴 것.
+				.sameSite("None")
 				.path("/")
 				.maxAge(0)    // 즉시 만료 -> 브라우저에서 삭제
 				.build();

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -41,7 +41,9 @@ jwt:
     audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
     expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
   cookie:
-    secure: false
+    # TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
+    # SameSite=Lax, secure=false로 되돌릴 것.
+    secure: true
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
Hotfix/disable spring security default logout filter

## 🔧 작업 내용
로컬(localhost)에서 개발 시 cross-site 쿠키 전송 문제 임시 해결.                    
프론트(localhost:3000)와 백엔드(api.dev.goormgb.space)가 다른 도메인이어서
SameSite=Lax 쿠키가 cross-site POST 요청에 전송되지 않아
refreshToken 쿠키가 서버에 도달하지 못하는 문제 발생.

## 🧩 구현 상세 (선택)
- CookieUtils: SameSite Lax → None 변경
- application-dev.yaml: cookie.secure false → true 변경

## ❗ 참고 사항
TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
# 반드시!!!!!!!!!!!!!!!!!!SameSite=Lax, secure=false로 되돌릴 것.