### PR TITLE
feat(auth): JWT 서명 방식을 HMAC에서 RSA 비대칭키(RS256)로 전환 [GRGB-208]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,12 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+### JWT Keys (프로덕션 키는 절대 커밋 금지!!) ###
+*.pem
+*.key
+*.p8
+*.p12
+*.jks
+
 ### AI Agent ###
 .claude/

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/config/JwtProperties.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/config/JwtProperties.java
@@ -10,7 +10,8 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-	private String secretKey;
+	/** X.509 형식 RSA 공개키 (base64 DER). 검증 전용 — 서명 불가. */
+	private String publicKey;
 	private String issuer;
 	private AccessToken accessToken = new AccessToken();
 

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
@@ -1,16 +1,16 @@
 package com.goormgb.be.apigateway.jwt.provider;
 
-import javax.crypto.SecretKey;
+import java.security.interfaces.RSAPublicKey;
 
 import org.springframework.stereotype.Component;
 
 import com.goormgb.be.apigateway.jwt.config.JwtProperties;
 import com.goormgb.be.apigateway.jwt.enums.TokenType;
+import com.goormgb.be.apigateway.jwt.util.RsaKeyUtils;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,11 +24,11 @@ public class JwtTokenProvider {
 	private static final String CLAIM_AUTH = "auth";
 
 	private final JwtProperties jwtProperties;
-	private SecretKey secretKey;
+	private RSAPublicKey publicKey;
 
 	@PostConstruct
 	public void init() {
-		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+		this.publicKey = RsaKeyUtils.parsePublicKey(jwtProperties.getPublicKey());
 	}
 
 	/**
@@ -38,7 +38,7 @@ public class JwtTokenProvider {
 	public Claims parseClaims(String token) {
 		try {
 			return Jwts.parser()
-					.verifyWith(secretKey)
+					.verifyWith(publicKey)
 					.build()
 					.parseSignedClaims(token)
 					.getPayload();

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/util/RsaKeyUtils.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/util/RsaKeyUtils.java
@@ -1,0 +1,45 @@
+package com.goormgb.be.apigateway.jwt.util;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * API-Gateway 전용 RSA 공개키 로드 유틸리티.
+ * <p>
+ * API-Gateway는 WebFlux 기반으로 common-core(WebMVC) 의존을 추가할 수 없으므로
+ * 공개키 로드 로직만 별도로 유지한다.
+ * 검증(verify)만 수행 — 서명(sign) 불가.
+ */
+public final class RsaKeyUtils {
+
+	private RsaKeyUtils() {
+	}
+
+	/**
+	 * base64 DER 형식의 X.509 공개키 문자열을 RSAPublicKey로 변환한다.
+	 *
+	 * @param base64Der PEM 헤더·개행 없이 base64만 남긴 X.509 공개키 문자열
+	 * @return RSAPublicKey
+	 */
+	public static RSAPublicKey parsePublicKey(String base64Der) {
+		try {
+			byte[] decoded = Base64.getDecoder().decode(sanitize(base64Der));
+			X509EncodedKeySpec spec = new X509EncodedKeySpec(decoded);
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return (RSAPublicKey)kf.generatePublic(spec);
+		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+			throw new IllegalStateException("RSA 공개키 로드 실패", e);
+		}
+	}
+
+	private static String sanitize(String pem) {
+		return pem
+			.replaceAll("-----BEGIN[^-]*-----", "")
+			.replaceAll("-----END[^-]*-----", "")
+			.replaceAll("\\s", "");
+	}
+}

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -53,7 +53,7 @@ spring:
       port: ${REDIS_PORT}
 
 jwt:
-  secret-key: ${JWT_SECRET_KEY}
+  public-key: ${JWT_PUBLIC_KEY}
   issuer: ${JWT_ISSUER}
   access-token:
     audience: ${JWT_ACCESS_TOKEN_AUDIENCE}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
@@ -10,7 +10,10 @@ import lombok.Setter;
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
 
-	private String secretKey;
+	/** PKCS#8 형식 RSA 개인키 (base64 DER). Auth-Guard 전용 — 서명에 사용. */
+	private String privateKey;
+	/** X.509 형식 RSA 공개키 (base64 DER). 모든 서비스 공유 — 검증에 사용. */
+	private String publicKey;
 	private String issuer;
 	private AccessToken accessToken = new AccessToken();
 	private RefreshToken refreshToken = new RefreshToken();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -1,11 +1,11 @@
 package com.goormgb.be.authguard.jwt.provider;
 
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.UUID;
-
-import javax.crypto.SecretKey;
 
 import org.springframework.stereotype.Component;
 
@@ -13,12 +13,12 @@ import com.goormgb.be.authguard.jwt.config.JwtProperties;
 import com.goormgb.be.authguard.jwt.enums.TokenType;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.util.RsaKeyUtils;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +32,13 @@ public class JwtTokenProvider {
 	private static final String CLAIM_AUTH = "auth";
 
 	private final JwtProperties jwtProperties;
-	private SecretKey secretKey;
+	private RSAPrivateKey privateKey;
+	private RSAPublicKey publicKey;
 
 	@PostConstruct
 	public void init() {
-		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+		this.privateKey = RsaKeyUtils.parsePrivateKey(jwtProperties.getPrivateKey());
+		this.publicKey = RsaKeyUtils.parsePublicKey(jwtProperties.getPublicKey());
 	}
 
 	public String createAccessToken(Long userId, String authority) {
@@ -57,7 +59,7 @@ public class JwtTokenProvider {
 				.id(UUID.randomUUID().toString())
 				.claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
 				.claim(CLAIM_AUTH, authority)
-				.signWith(secretKey)
+				.signWith(privateKey, Jwts.SIG.RS256)
 				.compact();
 	}
 
@@ -78,7 +80,7 @@ public class JwtTokenProvider {
 				.expiration(Date.from(expiration))
 				.id(UUID.randomUUID().toString())
 				.claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
-				.signWith(secretKey)
+				.signWith(privateKey, Jwts.SIG.RS256)
 				.compact();
 	}
 
@@ -123,7 +125,7 @@ public class JwtTokenProvider {
 
 	private Claims parseClaimsFromToken(String token) {
 		return Jwts.parser()
-				.verifyWith(secretKey)
+				.verifyWith(publicKey)
 				.build()
 				.parseSignedClaims(token)
 				.getPayload();

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -31,8 +31,8 @@ spring:
       port: ${REDIS_PORT}
 
 jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
+  private-key: ${JWT_PRIVATE_KEY}
+  public-key: ${JWT_PUBLIC_KEY}
   issuer: ${JWT_ISSUER}
   access-token:
     audience: ${JWT_ACCESS_TOKEN_AUDIENCE}

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -31,8 +31,8 @@ spring:
       port: ${REDIS_PORT}
 
 jwt:
-  secret-key: ${JWT_SECRET_KEY}
-
+  private-key: ${JWT_PRIVATE_KEY}
+  public-key: ${JWT_PUBLIC_KEY}
   issuer: ${JWT_ISSUER}
   access-token:
     audience: ${JWT_ACCESS_TOKEN_AUDIENCE}

--- a/common-core/src/main/java/com/goormgb/be/global/util/RsaKeyUtils.java
+++ b/common-core/src/main/java/com/goormgb/be/global/util/RsaKeyUtils.java
@@ -1,0 +1,71 @@
+package com.goormgb.be.global.util;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * RSA 키를 로드하는 유틸리티 클래스.
+ * <p>
+ * 환경변수 또는 application.yaml에서 주입된 base64 DER 문자열을
+ * Java의 RSAPrivateKey / RSAPublicKey로 변환한다.
+ * <p>
+ * 저장 형식: PEM 헤더·푸터 및 개행 제거 후 base64 DER 문자열
+ * - 개인키: PKCS#8 형식 (openssl pkcs8 -topk8 ... -nocrypt)
+ * - 공개키: X.509 형식 (openssl rsa -pubout)
+ */
+public final class RsaKeyUtils {
+
+	private RsaKeyUtils() {
+	}
+
+	/**
+	 * base64 DER 형식의 PKCS#8 개인키 문자열을 RSAPrivateKey로 변환한다.
+	 *
+	 * @param base64Der PEM 헤더·개행 없이 base64만 남긴 PKCS#8 개인키 문자열
+	 * @return RSAPrivateKey
+	 */
+	public static RSAPrivateKey parsePrivateKey(String base64Der) {
+		try {
+			byte[] decoded = Base64.getDecoder().decode(sanitize(base64Der));
+			PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return (RSAPrivateKey)kf.generatePrivate(spec);
+		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+			throw new IllegalStateException("RSA 개인키 로드 실패", e);
+		}
+	}
+
+	/**
+	 * base64 DER 형식의 X.509 공개키 문자열을 RSAPublicKey로 변환한다.
+	 *
+	 * @param base64Der PEM 헤더·개행 없이 base64만 남긴 X.509 공개키 문자열
+	 * @return RSAPublicKey
+	 */
+	public static RSAPublicKey parsePublicKey(String base64Der) {
+		try {
+			byte[] decoded = Base64.getDecoder().decode(sanitize(base64Der));
+			X509EncodedKeySpec spec = new X509EncodedKeySpec(decoded);
+			KeyFactory kf = KeyFactory.getInstance("RSA");
+			return (RSAPublicKey)kf.generatePublic(spec);
+		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+			throw new IllegalStateException("RSA 공개키 로드 실패", e);
+		}
+	}
+
+	/**
+	 * PEM 헤더/푸터와 개행문자를 제거하여 순수 base64 DER 문자열로 정규화한다.
+	 * 이미 헤더 없는 순수 base64 문자열이 입력되어도 정상 동작한다.
+	 */
+	private static String sanitize(String pem) {
+		return pem
+			.replaceAll("-----BEGIN[^-]*-----", "")
+			.replaceAll("-----END[^-]*-----", "")
+			.replaceAll("\\s", "");
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- JWT 서명 알고리즘을 대칭키(HMAC-SHA256)에서 비대칭키(RSA RS256)로 전환
- Auth-Guard: RSA 개인키(PKCS#8)로 서명, 공개키로 검증
- common-core: RsaKeyUtils 추가 (base64 DER → RSA Key 변환)
- API-Gateway: 자체 RsaKeyUtils 추가 (WebFlux/WebMVC 충돌 방지)
- 환경변수 `JWT_SECRET_KEY` → `JWT_PRIVATE_KEY` + `JWT_PUBLIC_KEY` 로 변경
- .gitignore에 *.pem 등 키 파일 확장자 추가

## 🧩 구현 상세
### 비대칭키로 전환 이유
```
기존 HMAC 대칭키 방식은 서명키와 검증키가 동일하여, 
API-Gateway나 다른 서비스에도 같은 시크릿키를 공유해야 했음.

->  키가 하나라도 유출되면 모든 서비스에서 토큰 위조가 가능한 문제 발생.
```

```
RSA 비대칭키는 서명(Private Key)과 검증(Public Key)을 분리하므로, 
Auth-Guard만 개인키를 가지고 나머지 서비스는 공개키로 검증만 수행함.

-> 검증 서비스에서는 토큰 위조가구조적으로 불가능함.
```

### 변경된 구조
Auth-Guard    → Private Key (서명 전용)
API-Gateway   → Public Key  (검증 전용)
Queue / Seat  → Public Key  (추후 동일 방식으로 검증- admission 토큰 등...)

### API-Gateway의 RsaKeyUtils 별도 관리
API-Gateway는 WebFlux 기반으로 WebMVC 기반인 common-core를 의존할 수 없어,
공개키 로드 로직(`RsaKeyUtils`)을 API-Gateway 내부에 별도로 유지합니다.

### 키 관리 방식
- 로컬: `application-local.yaml` 기본값으로 테스트용 키 하드코딩
- dev/prod: 환경변수 `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`로 주입

  ### 📌 관련 Jira Issue
  - GRGB-208

  ## 🧪 테스트 방법
- `local` 프로파일로 Auth-Guard 실행 후 카카오/개발용 로그인 → access/refresh 토큰 발급 확인
- 발급된 토큰으로 API 호출 → API-Gateway 검증 통과 확인
- 기존 HMAC 토큰으로 요청 시 401 반환 확인

## ❗ 참고 사항
-  **배포 시 환경변수 변경 필수**: `JWT_SECRET_KEY` 제거 후 `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` 추가
**[환경변수 관련은 구름공방 알림디코 > backend >설정-환경변수env 채널 참조]**
- **기존 발급 토큰 전체 무효화**: 배포 후 모든 유저 재로그인 필요
- Redis에 저장된 기존 refresh token도 검증 실패 — dev 배포 전 Redis flush 해야함
- 후속 작업: Docker Compose 환경변수 반영, JWT 테스트 코드 작성 