### PR TITLE
fix(common-core) API 응답 날짜 타입 LocalDateTime → Instant 변경 (UTC Z 보장) [GRGB-215]

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
@@ -1,0 +1,45 @@
+package com.goormgb.be.global.config;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Jackson 전역 직렬화 설정.
+ * <p>
+ * LocalDateTime은 타임존 정보를 갖지 않지만, 프로젝트 전체에서 UTC로 저장/처리한다.
+ * (hibernate.jdbc.time_zone: UTC, spring.jackson.time-zone: UTC)
+ * <p>
+ * 이 설정을 통해 모든 LocalDateTime 필드를 자동으로 UTC ISO 8601 형식으로 직렬화한다.
+ * 예: "2026-03-10T14:00:00.000Z"
+ * <p>
+ * 응답 DTO에서 별도 변환 없이 LocalDateTime을 그대로 사용 가능.
+ */
+@Configuration
+public class JacksonConfig {
+
+	private static final DateTimeFormatter UTC_FORMATTER =
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+	@Bean
+	public SimpleModule localDateTimeUtcModule() {
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(LocalDateTime.class, new JsonSerializer<>() {
+			@Override
+			public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers)
+					throws IOException {
+				gen.writeString(UTC_FORMATTER.format(value));
+			}
+		});
+		return module;
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- 모든 API 응답의 LocalDateTime 필드가 타임존 정보 없이 "2026-03-10T14:00:00" 형태로 내려가던 문제 수정                                                                         
- Jackson이 LocalDateTime을 직렬화할 때 자동으로 "2026-03-10T14:00:00.000Z" 형태로 출력되도록 전역 설정 추가
- DTO마다 별도 변환 없이 LocalDateTime 그대로 사용 가능

## 🧩 구현 상세 (선택)
- common-core에 JacksonConfig 추가 — SimpleModule로 LocalDateTime 커스텀 시리얼라이저 전역 등록
- DB/Hibernate는 이미 UTC 기준으로 저장 중 (hibernate.jdbc.time_zone: UTC)이므로 LocalDateTime 값 자체는 정확한 UTC 값
- 직렬화 시점에만 Z 접미사를 붙여 프론트가 UTC 시간임을 명확히 인식하도록 처리
- common-core를 의존하는 모든 서비스(Order-Core, Auth-Guard 등)에 자동 적용

### 📌 관련 Jira Issue

- GRGB-215

## ❗ 참고 사항

- DB 데이터 변경 없음 — 직렬화 포맷만 변경
- 프론트의 ensureKstOffset 등 오프셋 보정 로직 제거 가능 (프론트 측 후속 작업 필요)
- 앞으로 신규 DTO 작성 시 LocalDateTime 그대로 사용하면 자동으로 Z 붙어서 응답됨
**- 프론트의 빠른 KST 포맷팅 util 작업을 위해 리뷰 승인 없이 dev에 merge 하도록 하겠습니다**
