### PR TITLE
fix: gemini 코드리뷰 반영

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 public class JacksonConfig {
 
 	private static final DateTimeFormatter UTC_FORMATTER =
-			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
 	@Bean
 	public SimpleModule localDateTimeUtcModule() {
@@ -37,7 +37,11 @@ public class JacksonConfig {
 			@Override
 			public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers)
 					throws IOException {
-				gen.writeString(UTC_FORMATTER.format(value));
+				if (value == null) {
+					gen.writeNull();
+				} else {
+					gen.writeString(value.atOffset(ZoneOffset.UTC).format(UTC_FORMATTER));
+				}
 			}
 		});
 		return module;

--- a/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 public class JacksonConfig {
 
 	private static final DateTimeFormatter UTC_FORMATTER =
-			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+			DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").withZone(ZoneOffset.UTC);
 
 	@Bean
 	public SimpleModule localDateTimeUtcModule() {

--- a/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/JacksonConfig.java
@@ -40,7 +40,7 @@ public class JacksonConfig {
 				if (value == null) {
 					gen.writeNull();
 				} else {
-					gen.writeString(value.atOffset(ZoneOffset.UTC).format(UTC_FORMATTER));
+					gen.writeString(UTC_FORMATTER.format(value));
 				}
 			}
 		});


### PR DESCRIPTION
- 'Z' 리터럴 → XXX 패턴: "항상 Z를 붙인다"가 아니라 "UTC 오프셋을 포맷한다.
- null 체크 추가: LocalDateTime 필드가 null인 경우 NPE 대신 JSON null로 안전하게 직렬화

## 🔧 작업 내용

이전 PR #108 의 Gemini 코드 리뷰를 반영했습니다
