### PR TITLE
docs(swagger): 전체 컨트롤러 및 응답 DTO 스키마, Swagger 문서화 [GRGB-216]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
@@ -15,6 +15,10 @@ import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.global.support.Preconditions;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +31,11 @@ public class AuthController {
 	private final AuthService authService;
 	private final CookieUtils cookieUtils;
 
-	@Operation(summary = "토큰 재발급", description = "Refresh Token으로 새로운 Access Token과 Refresh Token을 발급합니다.")
+	@Operation(summary = "토큰 재발급", description = "HttpOnly 쿠키에 담긴 Refresh Token으로 새로운 Access Token과 Refresh Token을 재발급합니다. 새 Refresh Token은 Set-Cookie 헤더로 반환됩니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+		@ApiResponse(responseCode = "401", description = "Refresh Token 없음 또는 만료", content = @Content)
+	})
 	@PostMapping("/token/refresh")
 	public ResponseEntity<ApiResult<TokenRefreshResponse>> refresh(HttpServletRequest request) {
 		// 1. Cookie에서 Refresh Token 추출
@@ -46,7 +54,12 @@ public class AuthController {
 				.body(ApiResult.ok("토큰 재발급 성공", TokenRefreshResponse.of(result.accessToken())));
 	}
 
-	@Operation(summary = "로그아웃", description = "Access Token을 블랙리스트에 등록하고 Refresh Token을 삭제합니다.")
+	@Operation(summary = "로그아웃", description = "Access Token을 블랙리스트에 등록하고 Refresh Token 쿠키를 삭제합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요 또는 Refresh Token 없음", content = @Content)
+	})
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResult<Void>> logout(HttpServletRequest request) {
 		// 1. Refresh Token 추출
@@ -64,7 +77,12 @@ public class AuthController {
 				.body(ApiResult.ok("로그아웃 성공", null));
 	}
 
-	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 신청합니다. 서비스 이용이 중단되며, 30일의 유예 기간 뒤에 최종 삭제됩니다.")
+	@Operation(summary = "회원 탈퇴 신청", description = "회원 탈퇴를 신청합니다. 즉시 서비스 이용이 중단되고, 30일의 유예 기간 이후 계정이 최종 삭제됩니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "탈퇴 신청 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+	})
 	@PostMapping("/withdraw")
 	public ResponseEntity<ApiResult<WithdrawalResponse>> withdraw(@AuthenticationPrincipal Long userId) {
 		WithdrawalResponse response = authService.withdraw(userId);

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
 	}
 
 	@Operation(summary = "로그아웃", description = "Access Token을 블랙리스트에 등록하고 Refresh Token 쿠키를 삭제합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요 또는 Refresh Token 없음", content = @Content)
@@ -78,7 +78,7 @@ public class AuthController {
 	}
 
 	@Operation(summary = "회원 탈퇴 신청", description = "회원 탈퇴를 신청합니다. 즉시 서비스 이용이 중단되고, 30일의 유예 기간 이후 계정이 최종 삭제됩니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "탈퇴 신청 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
@@ -18,6 +18,9 @@ import com.goormgb.be.authguard.metrics.AuthMetricsService;
 import com.goormgb.be.global.response.ApiResult;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -34,7 +37,12 @@ public class DevAuthController {
 	private final CookieUtils cookieUtils;
 	private final AuthMetricsService authMetricsService;
 
-	@Operation(summary = "개발용 회원가입", description = "ID/PW 기반 개발용 계정을 생성합니다.")
+	@Operation(summary = "개발용 회원가입", description = "ID/PW 기반 개발용 계정을 생성합니다. local/dev/test 프로필에서만 사용 가능합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "회원가입 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검사 실패", content = @Content),
+		@ApiResponse(responseCode = "409", description = "이미 존재하는 ID", content = @Content)
+	})
 	@PostMapping("/signup")
 	public ResponseEntity<ApiResult<Void>> signup(@Valid @RequestBody DevSignupRequest request) {
 		devAuthService.signup(
@@ -48,7 +56,12 @@ public class DevAuthController {
 				.body(ApiResult.ok("회원가입 성공", null));
 	}
 
-	@Operation(summary = "개발용 로그인", description = "ID/PW 기반 개발용 로그인 후 JWT를 발급합니다.")
+	@Operation(summary = "개발용 로그인", description = "ID/PW 기반 개발용 로그인 후 Access Token을 반환하고 Refresh Token을 쿠키로 설정합니다. local/dev/test 프로필에서만 사용 가능합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그인 성공"),
+		@ApiResponse(responseCode = "400", description = "유효성 검사 실패", content = @Content),
+		@ApiResponse(responseCode = "401", description = "잘못된 ID 또는 비밀번호", content = @Content)
+	})
 	@PostMapping("/login")
 	public ResponseEntity<ApiResult<TokenRefreshResponse>> login(
 			@Valid @RequestBody DevLoginRequest request,

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
@@ -9,6 +9,10 @@ import com.goormgb.be.user.dto.response.UserInfoGetResponse;
 import com.goormgb.be.user.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +23,12 @@ public class UserController {
 
 	private final UserService userService;
 
-	@Operation(summary = "유저 정보 조회", description = "로그인 된 유저의 내 정보 조회 API")
+	@Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 기본 정보(ID, 이메일, 닉네임, 상태)를 조회합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+	})
 	@GetMapping("/me")
 	public ApiResult<UserInfoGetResponse> getMyInfo(@AuthenticationPrincipal Long id) {
 		return ApiResult.ok(userService.getMyInfo(id));

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
 	private final UserService userService;
 
 	@Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 기본 정보(ID, 이메일, 닉네임, 상태)를 조회합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/TokenRefreshResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/TokenRefreshResponse.java
@@ -1,14 +1,19 @@
 package com.goormgb.be.authguard.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "토큰 응답")
 @Getter
 @Builder
 public class TokenRefreshResponse {
 
+	@Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	private String accessToken;
+	@Schema(description = "이용약관 동의 필요 여부", example = "false")
 	private Boolean agreementRequired;
+	@Schema(description = "온보딩 진행 필요 여부", example = "true")
 	private Boolean onboardingRequired;
 
 	public static TokenRefreshResponse of(String accessToken) {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/WithdrawalResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/WithdrawalResponse.java
@@ -5,9 +5,15 @@ import java.time.Instant;
 import com.goormgb.be.user.entity.WithdrawalRequest;
 import com.goormgb.be.user.enums.UserStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 탈퇴 응답")
 public record WithdrawalResponse(
+		@Schema(description = "계정 상태", example = "DEACTIVATE")
 		String status,
+		@Schema(description = "탈퇴 신청 시각 (UTC ISO-8601)", type = "string", example = "2026-03-10T10:00:00Z")
 		Instant withdrawnAt,
+		@Schema(description = "계정 최종 삭제 예정 시각 - 유예 기간 30일 (UTC ISO-8601)", type = "string", example = "2026-04-09T10:00:00Z")
 		Instant reactivateUntil
 ) {
 	public static WithdrawalResponse from(WithdrawalRequest request) {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/controller/KakaoAuthController.java
@@ -21,9 +21,16 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.global.support.Preconditions;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Kakao Auth", description = "카카오 OAuth 인증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/kakao")
@@ -32,8 +39,13 @@ public class KakaoAuthController {
 	private final KakaoOAuthClient kakaoOAuthClient;
 	private final CookieUtils cookieUtils;
 
+	@Operation(summary = "카카오 로그인 URL 조회", description = "프론트엔드가 카카오 로그인 페이지로 이동하기 위한 URL을 반환합니다. redirectUri를 생략하면 서버에 설정된 기본값을 사용합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "로그인 URL 반환 성공")
+	})
 	@GetMapping("/login-url")
 	public ResponseEntity<ApiResult<Map<String, String>>> getKakaoUrl(
+			@Parameter(description = "카카오 로그인 후 리다이렉트될 URI (미입력 시 서버 기본값 사용)", example = "http://localhost:3000/auth/callback")
 			@RequestParam(required = false) String redirectUri) {
 		/**
 		 * 프론트엔드가 카카오 로그인 페이지로 이동하기 위한 URL 생성
@@ -64,6 +76,17 @@ public class KakaoAuthController {
 	 * - 기존 사용자 → 로그인
 	 * 을 모두 처리한다
 	 */
+	@Operation(summary = "카카오 로그인 / 회원가입", description = """
+			카카오 인증 코드(authorizationCode)를 받아 로그인 또는 회원가입을 처리합니다.
+			- 신규 회원: 회원가입 + 로그인 → HTTP 201
+			- 기존 회원: 로그인 → HTTP 200
+			Refresh Token은 HttpOnly 쿠키(Set-Cookie)로 내려갑니다.
+			""")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "기존 회원 로그인 성공"),
+		@ApiResponse(responseCode = "201", description = "신규 회원 로그인(회원가입) 성공"),
+		@ApiResponse(responseCode = "400", description = "인증 코드 누락", content = @Content)
+	})
 	@PostMapping("/login")
 	public ResponseEntity<ApiResult<KakaoLoginResponse>> kakaoLogin(
 			@RequestBody KakaoLoginRequest request,

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/dto/KakaoLoginResponse.java
@@ -4,28 +4,39 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.enums.UserStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+@Schema(description = "카카오 로그인 응답")
 @Getter
 @Builder
 public class KakaoLoginResponse {
 
+	@Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 	private String accessToken;
 	@JsonIgnore
 	private String refreshToken;
 	@JsonIgnore
 	private boolean newUser;
+	@Schema(description = "유저 기본 정보")
 	private UserInfo user;
+	@Schema(description = "온보딩 진행 필요 여부", example = "true")
 	private boolean onboardingRequired;
 
+	@Schema(description = "유저 정보")
 	@Getter
 	@Builder
 	public static class UserInfo {
+		@Schema(description = "유저 ID", example = "1")
 		private Long userId;
+		@Schema(description = "이메일", example = "user@example.com")
 		private String email;
+		@Schema(description = "닉네임", example = "홍길동")
 		private String nickname;
+		@Schema(description = "프로필 이미지 URL", example = "https://k.kakaocdn.net/example.jpg")
 		private String profileImageUrl;
+		@Schema(description = "계정 상태", example = "ACTIVATE")
 		private UserStatus status;
 	}
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/controller/ClubController.java
@@ -15,6 +15,10 @@ import com.goormgb.be.ordercore.club.service.ClubService;
 import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -25,27 +29,42 @@ import lombok.RequiredArgsConstructor;
 public class ClubController {
 	private final ClubService clubService;
 
-	@Operation(summary = "구단 전체 조회", description = "구단 전체 리스트를 조회합니다.")
+	@Operation(summary = "구단 전체 조회", description = "KBO 10개 구단 전체 리스트를 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
 	@GetMapping()
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<ClubGetResponse> getAllClubs() {
 		return ApiResult.ok(clubService.getAllClubs());
 	}
 
-	@Operation(summary = "구단 상세 조회", description = "구단 상세를 조회합니다.")
+	@Operation(summary = "구단 상세 조회", description = "구단 ID로 구단 상세 정보 및 현재 시즌 성적을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "404", description = "구단을 찾을 수 없음", content = @Content)
+	})
 	@GetMapping("/{clubId}")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<ClubDetailGetResponse> getClubDetail(
+			@Parameter(description = "구단 ID", required = true, example = "1")
 			@PathVariable Long clubId
 	) {
 		return ApiResult.ok(clubService.getClubDetail(clubId));
 	}
 
-	@Operation(summary = "구단 경기 일정(월 단위) 조회", description = "구단 월 단위 경기 일정을 조회합니다.")
+	@Operation(summary = "구단 월별 경기 일정 조회", description = "특정 구단의 월 단위 홈/원정 경기 일정을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "404", description = "구단을 찾을 수 없음", content = @Content)
+	})
 	@GetMapping("/{clubId}/matches")
 	public ApiResult<ClubMonthlyMatchesResponse> getClubMonthlyMatches(
+			@Parameter(description = "구단 ID", required = true, example = "1")
 			@PathVariable Long clubId,
+			@Parameter(description = "조회 연도", required = true, example = "2026")
 			@RequestParam int year,
+			@Parameter(description = "조회 월 (1~12)", required = true, example = "3")
 			@RequestParam int month
 	) {
 		return ApiResult.ok(clubService.getClubMonthlyMatches(clubId, year, month));

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/controller/MatchController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/controller/MatchController.java
@@ -17,6 +17,11 @@ import com.goormgb.be.ordercore.match.dto.response.MatchListByDateResponse;
 import com.goormgb.be.ordercore.match.service.MatchService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -27,19 +32,29 @@ import lombok.RequiredArgsConstructor;
 public class MatchController {
 	private final MatchService matchService;
 
-	@Operation(summary = "경기 상세 조회 API", description = "경기 상세를 조회합니다.")
+	@Operation(summary = "경기 상세 조회", description = "경기 ID로 경기 상세 정보를 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "404", description = "경기를 찾을 수 없음", content = @Content)
+	})
 	@GetMapping("/{matchId}")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MatchDetailGetResponse> getMatchDetail(
+			@Parameter(description = "경기 ID", required = true, example = "1")
 			@PathVariable Long matchId
 	) {
 		return ApiResult.ok(matchService.getMatchDetail(matchId));
 	}
 
-	@Operation(summary = "날짜 별 경기 조회 API", description = "날짜 별 경기를 조회합니다.")
+	@Operation(summary = "날짜별 경기 목록 조회", description = "특정 날짜의 전체 경기 목록을 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공")
+	})
 	@GetMapping()
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MatchListByDateResponse> getMatchList(
+			@Parameter(description = "조회 날짜 (yyyy-MM-dd)", required = true, example = "2026-03-28",
+					schema = @Schema(type = "string", format = "date"))
 			@RequestParam
 			@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 			LocalDate date

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/MatchGuideDto.java
@@ -2,13 +2,23 @@ package com.goormgb.be.ordercore.match.dto;
 
 import com.goormgb.be.ordercore.match.enums.PurchaseStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경기 안내 정보")
 public record MatchGuideDto(
+		@Schema(description = "팀 표시 문자열", example = "LG 트윈스 vs 두산 베어스")
 		String teamsDisplay,
+		@Schema(description = "관람 연령 제한", example = "전체관람가")
 		String ageLimit,
+		@Schema(description = "경기장 이름", example = "잠실야구장")
 		String placeDisplay,
+		@Schema(description = "경기장 주소", example = "서울특별시 송파구 올림픽로 25")
 		String addressDisplay,
+		@Schema(description = "경기 날짜/시간 표시 (KST)", example = "2026년 03월 28일 (토) 14:00")
 		String datetimeDisplay,
+		@Schema(description = "구매 가능 여부", example = "PURCHASABLE")
 		PurchaseStatus purchaseStatus,
+		@Schema(description = "D-Day 라벨", example = "D-18")
 		String matchDdayLabel
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/ClubMonthlyMatchesResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/ClubMonthlyMatchesResponse.java
@@ -5,29 +5,47 @@ import java.util.List;
 
 import com.goormgb.be.ordercore.match.enums.SaleStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "구단 월별 경기 일정 조회 응답")
 public record ClubMonthlyMatchesResponse(
+		@Schema(description = "구단 ID", example = "1")
 		Long clubId,
+		@Schema(description = "조회 연도", example = "2026")
 		int year,
+		@Schema(description = "조회 월", example = "3")
 		int month,
+		@Schema(description = "해당 월 전체 경기 수", example = "12")
 		int totalMatchCount,
+		@Schema(description = "경기 목록")
 		List<MatchItem> matches
 ) {
 	public static ClubMonthlyMatchesResponse of(Long clubId, int year, int month, List<MatchItem> items) {
 		return new ClubMonthlyMatchesResponse(clubId, year, month, items.size(), items);
 	}
 
+	@Schema(description = "경기 항목")
 	public record MatchItem(
+			@Schema(description = "경기 ID", example = "1")
 			Long matchId,
+			@Schema(description = "경기 시작 시간 (UTC ISO-8601)", type = "string", example = "2026-03-28T05:00:00Z")
 			Instant matchAt,
+			@Schema(description = "상대 구단 정보")
 			OpponentClub opponentClub,
+			@Schema(description = "판매 상태", example = "ON_SALE")
 			SaleStatus saleStatus,
+			@Schema(description = "홈 경기 여부", example = "true")
 			boolean isHomeMatch
 	) {
 	}
 
+	@Schema(description = "상대 구단 정보")
 	public record OpponentClub(
+			@Schema(description = "구단 ID", example = "2")
 			Long clubId,
+			@Schema(description = "구단 한글 이름", example = "두산 베어스")
 			String koName,
+			@Schema(description = "구단 로고 이미지 URL", example = "https://example.com/logo.png")
 			String logoImg
 	) {
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchDetailGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchDetailGetResponse.java
@@ -7,12 +7,21 @@ import com.goormgb.be.ordercore.match.dto.MatchGuideDto;
 import com.goormgb.be.ordercore.match.entity.Match;
 import com.goormgb.be.ordercore.match.enums.SaleStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경기 상세 조회 응답")
 public record MatchDetailGetResponse(
+		@Schema(description = "경기 ID", example = "1")
 		Long matchId,
+		@Schema(description = "경기 시작 시간 (UTC ISO-8601)", type = "string", example = "2026-03-28T05:00:00Z")
 		Instant matchAt,
+		@Schema(description = "판매 상태", example = "ON_SALE")
 		SaleStatus saleStatus,
+		@Schema(description = "홈 구단 정보")
 		ClubDto homeClub,
+		@Schema(description = "원정 구단 정보")
 		ClubDto awayClub,
+		@Schema(description = "경기 안내 정보")
 		MatchGuideDto matchGuide
 ) {
 	public static MatchDetailGetResponse of(Match match, MatchGuideDto matchGuide) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
@@ -9,22 +9,36 @@ import com.goormgb.be.ordercore.match.entity.Match;
 import com.goormgb.be.ordercore.match.enums.SaleStatus;
 import com.goormgb.be.ordercore.stadium.entity.Stadium;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "날짜별 경기 목록 조회 응답")
 public record MatchListByDateResponse(
+		@Schema(description = "조회 날짜", type = "string", example = "2026-03-28")
 		LocalDate date,
+		@Schema(description = "경기 수", example = "5")
 		int matchCount,
+		@Schema(description = "경기 목록")
 		List<MatchSummary> matches
 ) {
 	public static MatchListByDateResponse of(LocalDate date, List<MatchSummary> matches) {
 		return new MatchListByDateResponse(date, matches.size(), matches);
 	}
 
+	@Schema(description = "경기 요약 정보")
 	public record MatchSummary(
+			@Schema(description = "경기 ID", example = "1")
 			Long matchId,
+			@Schema(description = "경기 시작 시간 (UTC ISO-8601)", type = "string", example = "2026-03-28T05:00:00Z")
 			Instant matchAt,
+			@Schema(description = "판매 상태", example = "ON_SALE")
 			SaleStatus saleStatus,
+			@Schema(description = "티켓 판매 오픈 시간 (UTC ISO-8601)", type = "string", example = "2026-03-21T02:00:00Z")
 			Instant salesOpenAt,
+			@Schema(description = "홈 구단 정보")
 			ClubDto homeClub,
+			@Schema(description = "원정 구단 정보")
 			ClubDto awayClub,
+			@Schema(description = "경기장 정보")
 			StadiumDto stadium
 	) {
 		public static MatchSummary of(Match m, Instant salesOpenAt) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
@@ -21,6 +21,9 @@ import com.goormgb.be.ordercore.onboarding.service.OnboardingPreferenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +34,13 @@ import lombok.RequiredArgsConstructor;
 public class OnboardingPreferenceController {
 	final private OnboardingPreferenceService onboardingPreferenceService;
 
-	@Operation(summary = "온보딩 선호도 조회", description = "온보딩 선호도를 조회합니다.")
+	@Operation(summary = "온보딩 선호도 조회", description = "로그인한 유저의 온보딩 좌석 선호도를 조회합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "404", description = "선호도 정보 없음", content = @Content)
+	})
 	@GetMapping("/preferences")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<OnboardingPreferenceGetResponse> getPreferences(
@@ -42,7 +51,13 @@ public class OnboardingPreferenceController {
 		return ApiResult.ok(preferences);
 	}
 
-	@Operation(summary = "온보딩 선호도 생성", description = "온보딩 선호도를 생성합니다.")
+	@Operation(summary = "온보딩 선호도 생성", description = "온보딩 좌석 선호도를 최초 생성합니다. 선호도 3개를 우선순위(1~3) 순서로 입력해야 합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "생성 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "409", description = "이미 선호도가 존재함", content = @Content)
+	})
 	@PostMapping("/preferences")
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResult<OnboardingPreferenceCreateResponse> createPreferences(
@@ -98,7 +113,13 @@ public class OnboardingPreferenceController {
 		return ApiResult.ok(response);
 	}
 
-	@Operation(summary = "온보딩 선호도 수정", description = "온보딩 선호도를 수정합니다.")
+	@Operation(summary = "온보딩 선호도 수정", description = "기존 온보딩 좌석 선호도를 전체 교체(PUT)합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "수정 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "404", description = "선호도 정보 없음", content = @Content)
+	})
 	@PutMapping("/preferences")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<Void> updatePreferences(
@@ -153,7 +174,12 @@ public class OnboardingPreferenceController {
 		return ApiResult.ok();
 	}
 
-	@Operation(summary = "온보딩 완료 여부 조회", description = "온보딩 완료 여부를 조회합니다.")
+	@Operation(summary = "온보딩 완료 여부 조회", description = "로그인한 유저의 온보딩 완료 여부 및 완료 시각을 조회합니다.",
+		security = @SecurityRequirement(name = "bearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+	})
 	@GetMapping("/status")
 	public ApiResult<OnboardingStatusGetResponse> getOnboardingStatus(
 		@AuthenticationPrincipal Long userId

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
@@ -35,7 +35,7 @@ public class OnboardingPreferenceController {
 	final private OnboardingPreferenceService onboardingPreferenceService;
 
 	@Operation(summary = "온보딩 선호도 조회", description = "로그인한 유저의 온보딩 좌석 선호도를 조회합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
@@ -52,7 +52,7 @@ public class OnboardingPreferenceController {
 	}
 
 	@Operation(summary = "온보딩 선호도 생성", description = "온보딩 좌석 선호도를 최초 생성합니다. 선호도 3개를 우선순위(1~3) 순서로 입력해야 합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "201", description = "생성 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
@@ -114,7 +114,7 @@ public class OnboardingPreferenceController {
 	}
 
 	@Operation(summary = "온보딩 선호도 수정", description = "기존 온보딩 좌석 선호도를 전체 교체(PUT)합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "수정 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
@@ -175,7 +175,7 @@ public class OnboardingPreferenceController {
 	}
 
 	@Operation(summary = "온보딩 완료 여부 조회", description = "로그인한 유저의 온보딩 완료 여부 및 완료 시각을 조회합니다.",
-		security = @SecurityRequirement(name = "bearerAuth"))
+		security = @SecurityRequirement(name = "BearerAuth"))
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingPreferenceCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingPreferenceCreateResponse.java
@@ -4,10 +4,17 @@ import java.time.Instant;
 
 import com.goormgb.be.user.entity.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 선호도 생성 응답")
 public record OnboardingPreferenceCreateResponse(
+		@Schema(description = "온보딩 완료 여부", example = "true")
 		boolean onboardingStatus,
+		@Schema(description = "온보딩 완료 시각 (UTC ISO-8601)", type = "string", example = "2026-03-10T10:00:00Z")
 		Instant onboardingCompletedAt,
+		@Schema(description = "마케팅 수신 동의 여부", example = "true")
 		boolean marketingConsent,
+		@Schema(description = "마케팅 수신 동의 시각 (UTC ISO-8601), 미동의 시 null", type = "string", example = "2026-03-10T10:00:00Z", nullable = true)
 		Instant marketingConsentedAt
 ) {
 	public static OnboardingPreferenceCreateResponse from(User user) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingStatusGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingStatusGetResponse.java
@@ -4,8 +4,13 @@ import java.time.Instant;
 
 import com.goormgb.be.user.entity.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "온보딩 완료 여부 조회 응답")
 public record OnboardingStatusGetResponse(
+	@Schema(description = "온보딩 완료 여부", example = "true")
 	Boolean onboardingStatus,
+	@Schema(description = "온보딩 완료 시각 (UTC ISO-8601), 미완료 시 null", type = "string", example = "2026-03-10T10:00:00Z", nullable = true)
 	Instant onboardingCompletedAt
 ) {
 	public static OnboardingStatusGetResponse from(User user) {

--- a/common-core/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/SwaggerConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
@@ -25,16 +24,12 @@ public class SwaggerConfig {
 				.in(SecurityScheme.In.HEADER)
 				.name("Authorization");
 
-		SecurityRequirement securityRequirement = new SecurityRequirement()
-				.addList("BearerAuth");
-
 		return new OpenAPI()
 				.info(new Info()
 						.title("표고 API")
 						.description("구름공방 백엔드 API 문서")
 						.version("v1"))
 				.addServersItem(new Server().url(contextPath.isEmpty() ? "/" : contextPath))
-				.addSecurityItem(securityRequirement)
 				.schemaRequirement("BearerAuth", securityScheme);
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/user/dto/response/UserInfoGetResponse.java
+++ b/common-core/src/main/java/com/goormgb/be/user/dto/response/UserInfoGetResponse.java
@@ -3,10 +3,17 @@ package com.goormgb.be.user.dto.response;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.enums.UserStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 내 정보 조회 응답")
 public record UserInfoGetResponse(
+	@Schema(description = "유저 ID", example = "1")
 	Long id,
+	@Schema(description = "계정 상태", example = "ACTIVATE")
 	UserStatus status,
+	@Schema(description = "이메일", example = "user@example.com")
 	String email,
+	@Schema(description = "닉네임", example = "홍길동")
 	String nickname
 ) {
 	public static UserInfoGetResponse from(User user) {


### PR DESCRIPTION
## 🔧 작업 내용
- 전체 7개 컨트롤러에 `@Parameter`, `@ApiResponse`, `@SecurityRequirement` 추가                                                                          
- 주요 응답 DTO 9개에 `@Schema` 추가하여 프론트엔드에서 Swagger UI로 타입 확인 가능하도록 개선
- 인증이 필요한 엔드포인트에 `@SecurityRequirement(name = "BearerAuth")` 명시 
- `KakaoAuthController`에 누락된 `@Tag`, `@Operation` 전체 신규 작성
- SwaggerConfig에서 BearerAuth가 전역으로 설정되던 .`addSecurityItem(securityRequirement)` 제거.
- Swagger 문서에서 @SecurityRequirement 개별 설정과 무관하게 전부 자물쇠가 달리는 설정을, 실제 Access Token이 필요한 API 만 자물쇠가 달리게끔 변경

### ‼️ 수정 방향:
 전역 securityRequirement 제거 → 개별 컨트롤러의 @SecurityRequirement로만 관리

**Swagger에서 전역으로 자물쇠를 달고, JWT 필터에서 화이트리스트로 통과시켜주던 이전과 달리,
실제 BearAuth가 필요한 부분만 자물쇠가 달리게끔 추가 개선했습니다!**

### Controller에서 인증이 필요한 API 작업시
```java
@Operation(summary = "회원 탈퇴 신청", description = "회원 탈퇴를 신청합니다. 즉시 서비스 이용이 중단되고, 30일의 유예 기간 이후 계정이 최종 삭제됩니다.",
		security = @SecurityRequirement(name = "BearerAuth"))
```
와 같이 `security = @SecurityRequirement(name = "BearerAuth")` 를 추가해주시면 됩니다

### 이전
<img width="905" height="891" alt="스크린샷 2026-03-11 오전 9 40 43" src="https://github.com/user-attachments/assets/7a53a2fc-d0da-42c5-bade-fdf2270d58f8" />

### 수정 후(현재 PR)
<img width="902" height="1028" alt="스크린샷 2026-03-11 오전 9 40 52" src="https://github.com/user-attachments/assets/92a915f5-2915-4514-b35c-ceae9f4bd88d" />

## 🧩 구현 상세
**컨트롤러별 작업**
- `MatchController` / `ClubController`: 경로·쿼리 파라미터 설명 및 200/404 응답 코드 추가
- `OnboardingPreferenceController`: 인증 요구 명시, 201/401/404/409 응답 코드 추가
- `AuthController`: 토큰 재발급·로그아웃·탈퇴 엔드포인트 응답 코드 및 인증 표시
- `UserController`: 인증 요구 명시, 200/401 응답 코드 추가
- `KakaoAuthController`: `@Tag` 추가 및 전체 Swagger 어노테이션 신규 작성
- `DevAuthController`: 201/400/401/409 응답 코드 추가

**DTO `@Schema` 작업**
- `Instant` 타입 필드에 `type = "string"`, `example = "2026-03-28T05:00:00Z"` 명시
→ 프론트에서 ISO-8601 UTC 문자열임을 Swagger UI에서 확인 가능

### 📌 관련 Jira Issue
- GRGB-216

## ❗ 참고 사항
- 기능 로직 변경 없이 문서 어노테이션만 추가한 작업입니다
- `Instant` 필드는 JSON 직렬화 시 `"2026-03-28T05:00:00Z"` 형식의 문자열로 내려갑니다
