### PR TITLE
fix(order-core): salesOpenAt 계산 기준 UTC → KST(Asia/Seoul)로 변경 [GRGB-218]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/utils/SalesOpenUtils.java
@@ -1,7 +1,7 @@
 package com.goormgb.be.ordercore.match.utils;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 
 import org.springframework.stereotype.Component;
 
@@ -12,10 +12,11 @@ public class SalesOpenUtils {
 	private static final int SALES_OPEN_DAYS_BEFORE_MATCH = 7;
 	private static final int SALES_OPEN_HOUR = 11;
 	private static final int SALES_OPEN_MINUTE = 0;
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	public Instant calculateSalesOpenAt(Match match) {
 		return match.getMatchAt()
-				.atZone(ZoneOffset.UTC)
+				.atZone(KST)
 				.minusDays(SALES_OPEN_DAYS_BEFORE_MATCH)
 				.withHour(SALES_OPEN_HOUR)
 				.withMinute(SALES_OPEN_MINUTE)


### PR DESCRIPTION
## 🔧 작업 내용
- `SalesOpenUtils.calculateSalesOpenAt()`에서 판매 오픈 시각을 UTC 기준 11:00으로 계산하던 버그 수정
- `ZoneOffset.UTC` → `ZoneId.of("Asia/Seoul")` 변경으로 KST 오전 11:00 기준 계산 후 UTC로 변환
- 수정 전: `"2026-03-21T11:00:00Z"` (= KST 20:00) ← 잘못된 값
- 수정 후: `"2026-03-21T02:00:00Z"` (= KST 11:00) ← 의도한 값

## 🧩 구현 상세
- 판매 오픈 시각은 **KST 오전 11시** 기준 정책
- `Instant`는 항상 UTC로 직렬화(`Z` suffix)되므로 KST zone 기준으로 시각을 설정한 뒤 `.toInstant()`로 변환해야 올바른 UTC 값이 저장됨
- 프론트에서 `salesOpenAt`에 +9 변환 적용 시 기존에는 오후 8시로 표시되던 문제 해결로 예상됨.

### 📌 관련 Jira Issue
- GRGB-218
### 📌 관련 Github Issue
fixes #114 , 관련된 PR #112 

## 🧪 테스트 방법
- `GET /matches?date=2026-03-28` 호출
- 응답의 `salesOpenAt` 값이 `"2026-03-21T02:00:00Z"` (KST 오전 11:00)인지 확인