### PR TITLE
feat(seats): 좌석 관련 도메인 생성 [GRGB-231]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubDetailGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/club/dto/response/ClubDetailGetResponse.java
@@ -3,8 +3,8 @@ package com.goormgb.be.ordercore.club.dto.response;
 import java.math.BigDecimal;
 
 import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.domain.state.entity.TeamSeasonStats;
-import com.goormgb.be.domain.statium.entity.Stadium;
 
 public record ClubDetailGetResponse(
 	Long clubId,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/dto/response/MatchListByDateResponse.java
@@ -7,18 +7,18 @@ import java.util.List;
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.domain.match.enums.SaleStatus;
-import com.goormgb.be.domain.statium.entity.Stadium;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "날짜별 경기 목록 조회 응답")
 public record MatchListByDateResponse(
-		@Schema(description = "조회 날짜", type = "string", example = "2026-03-28")
-		LocalDate date,
-		@Schema(description = "경기 수", example = "5")
-		int matchCount,
-		@Schema(description = "경기 목록")
-		List<MatchSummary> matches
+	@Schema(description = "조회 날짜", type = "string", example = "2026-03-28")
+	LocalDate date,
+	@Schema(description = "경기 수", example = "5")
+	int matchCount,
+	@Schema(description = "경기 목록")
+	List<MatchSummary> matches
 ) {
 	public static MatchListByDateResponse of(LocalDate date, List<MatchSummary> matches) {
 		return new MatchListByDateResponse(date, matches.size(), matches);
@@ -26,20 +26,20 @@ public record MatchListByDateResponse(
 
 	@Schema(description = "경기 요약 정보")
 	public record MatchSummary(
-			@Schema(description = "경기 ID", example = "1")
-			Long matchId,
-			@Schema(description = "경기 시작 시간 (UTC ISO-8601)", type = "string", example = "2026-03-28T05:00:00Z")
-			Instant matchAt,
-			@Schema(description = "판매 상태", example = "ON_SALE")
-			SaleStatus saleStatus,
-			@Schema(description = "티켓 판매 오픈 시간 (UTC ISO-8601)", type = "string", example = "2026-03-21T02:00:00Z")
-			Instant salesOpenAt,
-			@Schema(description = "홈 구단 정보")
-			ClubDto homeClub,
-			@Schema(description = "원정 구단 정보")
-			ClubDto awayClub,
-			@Schema(description = "경기장 정보")
-			StadiumDto stadium
+		@Schema(description = "경기 ID", example = "1")
+		Long matchId,
+		@Schema(description = "경기 시작 시간 (UTC ISO-8601)", type = "string", example = "2026-03-28T05:00:00Z")
+		Instant matchAt,
+		@Schema(description = "판매 상태", example = "ON_SALE")
+		SaleStatus saleStatus,
+		@Schema(description = "티켓 판매 오픈 시간 (UTC ISO-8601)", type = "string", example = "2026-03-21T02:00:00Z")
+		Instant salesOpenAt,
+		@Schema(description = "홈 구단 정보")
+		ClubDto homeClub,
+		@Schema(description = "원정 구단 정보")
+		ClubDto awayClub,
+		@Schema(description = "경기장 정보")
+		StadiumDto stadium
 	) {
 		public static MatchSummary of(Match m, Instant salesOpenAt) {
 			return new MatchSummary(

--- a/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
@@ -1,6 +1,6 @@
 package com.goormgb.be.seat.area.entity;
 
-import com.goormgb.be.domain.statium.entity.Stadium;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.seat.area.enums.AreaCode;
 

--- a/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
@@ -1,0 +1,53 @@
+package com.goormgb.be.seat.area.entity;
+
+import com.goormgb.be.domain.statium.entity.Stadium;
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.area.enums.AreaCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "areas",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_area_stadium_code", columnNames = {"stadium_id", "code"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Area extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "stadium_id", nullable = false)
+	private Stadium stadium;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "code", nullable = false, length = 50)
+	private AreaCode code;
+
+	@Column(name = "name", nullable = false, length = 100)
+	private String name;
+
+	@Builder
+	public Area(
+		Stadium stadium,
+		AreaCode code,
+		String name
+	) {
+		this.stadium = stadium;
+		this.code = code;
+		this.name = name;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/area/enums/AreaCode.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/enums/AreaCode.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.seat.area.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AreaCode {
+	HOME("1루(홈)"),
+	AWAY("3루(어웨이)"),
+	PREMIUM("프리미엄");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/area/repository/AreaRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/repository/AreaRepository.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.seat.area.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.area.entity.Area;
+
+public interface AreaRepository extends JpaRepository<Area, Long> {
+
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
@@ -1,0 +1,73 @@
+package com.goormgb.be.seat.block.entity;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.section.entity.Section;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "blocks",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_block_section_code",
+			columnNames = {"section_id", "block_code"}
+		)
+	},
+	indexes = {
+		@Index(name = "idx_block_section_id", columnList = "section_id"),
+		@Index(name = "idx_block_viewpoint", columnList = "viewpoint"),
+		@Index(name = "idx_block_home_cheer_rank", columnList = "home_cheer_rank"),
+		@Index(name = "idx_block_away_cheer_rank", columnList = "away_cheer_rank")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "section_id", nullable = false)
+	private Section section;
+
+	@Column(name = "block_code", nullable = false, length = 20)
+	private String blockCode;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "viewpoint", nullable = false, length = 30)
+	private Viewpoint viewpoint;
+
+	@Column(name = "home_cheer_rank")
+	private Integer homeCheerRank;
+
+	@Column(name = "away_cheer_rank")
+	private Integer awayCheerRank;
+
+	@Builder
+	public Block(
+		Section section,
+		String blockCode,
+		Viewpoint viewpoint,
+		Integer homeCheerRank,
+		Integer awayCheerRank
+	) {
+		this.section = section;
+		this.blockCode = blockCode;
+		this.viewpoint = viewpoint;
+		this.homeCheerRank = homeCheerRank;
+		this.awayCheerRank = awayCheerRank;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.block.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.block.entity.Block;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seat/entity/Seat.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seat/entity/Seat.java
@@ -1,0 +1,75 @@
+package com.goormgb.be.seat.seat.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "seats",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_seat_block_row_seat",
+			columnNames = {"block_id", "row_no", "seat_no"}
+		),
+		@UniqueConstraint(
+			name = "uk_seat_block_row_template_col",
+			columnNames = {"block_id", "row_no", "template_col_no"}
+		)
+	},
+	indexes = {
+		@Index(name = "idx_seat_block_id", columnList = "block_id"),
+		@Index(name = "idx_seat_block_seat_zone", columnList = "block_id, seat_zone")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seat extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "block_id", nullable = false)
+	private Block block;
+
+	@Column(name = "row_no", nullable = false)
+	private Integer rowNo;
+
+	@Column(name = "seat_no", nullable = false)
+	private Integer seatNo;
+
+	@Column(name = "template_col_no", nullable = false)
+	private Integer templateColNo;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "seat_zone", nullable = false, length = 10)
+	private SeatZone seatZone;
+
+	@Builder
+	public Seat(
+		Block block,
+		Integer rowNo,
+		Integer seatNo,
+		Integer templateColNo,
+		SeatZone seatZone
+	) {
+		this.block = block;
+		this.rowNo = rowNo;
+		this.seatNo = seatNo;
+		this.templateColNo = templateColNo;
+		this.seatZone = seatZone;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seat/enums/SeatZone.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seat/enums/SeatZone.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.seat.seat.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatZone {
+	LOW("하단"),
+	MID("중단"),
+	HIGH("상단");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/section/entity/Section.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/entity/Section.java
@@ -1,0 +1,65 @@
+package com.goormgb.be.seat.section.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.section.enums.SectionCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "sections",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_section_area_code",
+			columnNames = {"area_id", "code"}
+		)
+	},
+	indexes = {
+		@Index(name = "idx_section_area_id", columnList = "area_id")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Section extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "area_id", nullable = false)
+	private Area area;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "code", nullable = false, length = 30)
+	private SectionCode code;
+
+	@Column(name = "name", nullable = false, length = 50)
+	private String name;
+
+	@Column(name = "color_hex", length = 10)
+	private String colorHex;
+
+	@Builder
+	public Section(
+		Area area,
+		SectionCode code,
+		String name,
+		String colorHex
+	) {
+		this.area = area;
+		this.code = code;
+		this.name = name;
+		this.colorHex = colorHex;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/section/enums/SectionCode.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/enums/SectionCode.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.seat.section.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SectionCode {
+	PREMIUM("테라존(중앙 프리미엄석)"),
+	PURPLE("퍼플석(테이블석)"),
+	EXCITING("익사이팅존"),
+	BLUE("블루석"),
+	ORANGE("오렌지석"),
+	RED("레드석"),
+	NAVY("네이비석"),
+	GREEN("그린석(외야석)");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.section.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.section.entity.Section;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+}

--- a/common-core/src/main/java/com/goormgb/be/domain/club/entity/Club.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/club/entity/Club.java
@@ -1,6 +1,6 @@
 package com.goormgb.be.domain.club.entity;
 
-import com.goormgb.be.domain.statium.entity.Stadium;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;

--- a/common-core/src/main/java/com/goormgb/be/domain/match/entity/Match.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/entity/Match.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.match.enums.SaleStatus;
-import com.goormgb.be.domain.statium.entity.Stadium;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;

--- a/common-core/src/main/java/com/goormgb/be/domain/stadium/entity/Stadium.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/stadium/entity/Stadium.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.domain.statium.entity;
+package com.goormgb.be.domain.stadium.entity;
 
 import com.goormgb.be.global.entity.BaseEntity;
 


### PR DESCRIPTION
## 🔧 작업 내용

- Area 도메인
- Section 도메인
- Block 도메인
- Seat 도메인

## 🧩 구현 상세 (선택)

**Area 도메인**
- 경기장 하위의 상위 구역 정보를 관리하는 Area 엔티티 및 AreaCode enum 추가
- 유니크 `(stadium_id, code)` 동일 경기장 내 동일 AreaCode 중복 생성 방지
- 인덱스 `(stadium_id)` 경기장 기준 Area 목록 조회 최적화

**Section 도메인**
- Area 하위의 색상/존 정보를 관리하는 Section 엔티티 및 SectionCode enum 추가
- 유니크 `(area_id, code)` 동일 Area 내 SectionCode 중복 방지
- 인덱스 `(area_id)` Area 기준 Section 조회 최적화

**Block 도메인**
- Section 하위의 실제 예매 블럭 정보를 관리하는 Block 엔티티 추가
- 시야 방향, 응원석 근접 순위 등 추천 계산에 필요한 속성 반영
- 유니크 `(section_id, block_code)` 동일 Section 내 블럭 코드 중복 방지
- 인덱스 `(section_id)` Section 기준 Block 조회 최적화
- 인덱스 `(viewpoint, home_cheer_rank, away_cheer_rank)` 추천 좌석 필터링 및 정렬 최적화

**Seat 도메인**
- Block 하위의 실제 좌석 정보를 관리하는 Seat 엔티티 및 SeatZone enum 추가
- 유니크 `(block_id, row_no, seat_no)` 좌석 위치 식별
- 유니크 `(block_id, row_no, template_col_no) `준연석 탐색용 좌석 위치 보장
- 인덱스 `(block_id, seat_zone)` 블럭 및 좌석 높이 기준 조회 최적화

### 📌 관련 Jira Issue

- GRGB-231

## 🧪 테스트 방법(선택)

## ❗ 참고 사항

- 다음 브랜치에서 나머지 엔티티 작업 하겠슴다
