### PR TITLE
feat(seats): match seat domain 생성 [GRGB-235]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/entity/MatchSeat.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/entity/MatchSeat.java
@@ -46,8 +46,8 @@ import lombok.NoArgsConstructor;
 
 		// 예매 가능 좌석 조회
 		@Index(
-			name = "idx_match_seats_match_id_block_id_sale_status",
-			columnList = "match_id, block_id, sale_status"
+			name = "idx_match_seats_match_id_block_id_sale_status_row_no_seat_no",
+			columnList = "match_id, block_id, sale_status, row_no, seat_no"
 		),
 
 		// 추천 좌석 조회

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/entity/MatchSeat.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/entity/MatchSeat.java
@@ -1,0 +1,132 @@
+package com.goormgb.be.seat.matchSeat.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "match_seats",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_match_seats_match_id_seat_id",
+			columnNames = {"match_id", "seat_id"}
+		)
+	},
+	indexes = {
+		// 경기 전체 좌석 조회
+		@Index(
+			name = "idx_match_seats_match_id",
+			columnList = "match_id"
+		),
+
+		// 좌석맵 렌더링
+		@Index(
+			name = "idx_match_seats_match_id_block_id_row_no_seat_no",
+			columnList = "match_id, block_id, row_no, seat_no"
+		),
+
+		// 연석 탐색
+		@Index(
+			name = "idx_match_seats_match_id_block_id_row_no_template_col_no",
+			columnList = "match_id, block_id, row_no, template_col_no"
+		),
+
+		// 예매 가능 좌석 조회
+		@Index(
+			name = "idx_match_seats_match_id_block_id_sale_status",
+			columnList = "match_id, block_id, sale_status"
+		),
+
+		// 추천 좌석 조회
+		@Index(
+			name = "idx_match_seats_match_id_section_id_sale_status_seat_zone",
+			columnList = "match_id, section_id, sale_status, seat_zone"
+		)
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchSeat extends BaseEntity {
+
+	@Column(name = "match_id", nullable = false)
+	private Long matchId;
+
+	@Column(name = "seat_id", nullable = false)
+	private Long seatId;
+
+	@Column(name = "area_id", nullable = false)
+	private Long areaId;
+
+	@Column(name = "section_id", nullable = false)
+	private Long sectionId;
+
+	@Column(name = "block_id", nullable = false)
+	private Long blockId;
+
+	@Column(name = "row_no", nullable = false)
+	private Integer rowNo;
+
+	@Column(name = "seat_no", nullable = false)
+	private Integer seatNo;
+
+	@Column(name = "template_col_no", nullable = false)
+	private Integer templateColNo;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "seat_zone", nullable = false, length = 10)
+	private SeatZone seatZone;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "sale_status", nullable = false, length = 20)
+	private MatchSeatSaleStatus saleStatus;
+
+	@Builder
+	public MatchSeat(
+		Long matchId,
+		Long seatId,
+		Long areaId,
+		Long sectionId,
+		Long blockId,
+		Integer rowNo,
+		Integer seatNo,
+		Integer templateColNo,
+		SeatZone seatZone,
+		MatchSeatSaleStatus saleStatus
+	) {
+		this.matchId = matchId;
+		this.seatId = seatId;
+		this.areaId = areaId;
+		this.sectionId = sectionId;
+		this.blockId = blockId;
+		this.rowNo = rowNo;
+		this.seatNo = seatNo;
+		this.templateColNo = templateColNo;
+		this.seatZone = seatZone;
+		this.saleStatus = saleStatus;
+	}
+
+	public void markSold() {
+		this.saleStatus = MatchSeatSaleStatus.SOLD;
+	}
+
+	public void markBlocked() {
+		this.saleStatus = MatchSeatSaleStatus.BLOCKED;
+	}
+
+	public void markAvailable() {
+		this.saleStatus = MatchSeatSaleStatus.AVAILABLE;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/enums/MatchSeatSaleStatus.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/enums/MatchSeatSaleStatus.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.seat.matchSeat.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchSeatSaleStatus {
+
+	AVAILABLE("예매 가능"),
+	SOLD("판매 완료"),
+	BLOCKED("판매 차단");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.matchSeat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+
+public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
@@ -8,14 +8,30 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "price_policies")
+@Table(
+	name = "price_policies",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_price_policies_stadium_id_section_id_day_type_ticket_type",
+			columnNames = {"stadium_id", "section_id", "day_type", "ticket_type"}
+		)
+	},
+	indexes = {
+		@Index(
+			name = "idx_price_policies_section_id",
+			columnList = "section_id"
+		)
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PricePolicy extends BaseEntity {

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
@@ -1,0 +1,58 @@
+package com.goormgb.be.seat.pricePolicy.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.pricePolicy.enums.DayType;
+import com.goormgb.be.seat.pricePolicy.enums.TicketType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "price_policies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PricePolicy extends BaseEntity {
+
+	@Column(name = "stadium_id", nullable = false)
+	private Long stadiumId;
+
+	@Column(name = "section_id", nullable = false)
+	private Long sectionId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "day_type", nullable = false, length = 20)
+	private DayType dayType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "ticket_type", nullable = false, length = 30)
+	private TicketType ticketType;
+
+	@Column(name = "price", nullable = false)
+	private Integer price;
+
+	@Builder
+	public PricePolicy(
+		Long stadiumId,
+		Long sectionId,
+		DayType dayType,
+		TicketType ticketType,
+		Integer price
+	) {
+		this.stadiumId = stadiumId;
+		this.sectionId = sectionId;
+		this.dayType = dayType;
+		this.ticketType = ticketType;
+		this.price = price;
+	}
+
+	public void updatePrice(Integer price) {
+		this.price = price;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/enums/DayType.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/enums/DayType.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.seat.pricePolicy.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DayType {
+
+	WEEKDAY("평일"),
+	WEEKEND("주말");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/enums/TicketType.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/enums/TicketType.java
@@ -1,0 +1,18 @@
+package com.goormgb.be.seat.pricePolicy.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketType {
+
+	ADULT("일반"),
+	YOUTH("청소년"),
+	CHILD("어린이"),
+	SENIOR("경로"),
+	VETERAN("국가유공자"),
+	DISABLED("장애인");
+
+	private final String description;
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/repository/PricePolicyRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/repository/PricePolicyRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.pricePolicy.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.pricePolicy.entity.PricePolicy;
+
+public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/entity/SeatHold.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/entity/SeatHold.java
@@ -1,0 +1,86 @@
+package com.goormgb.be.seat.seatHold.entity;
+
+import java.time.Instant;
+
+import com.goormgb.be.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "seat_holds",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_seat_holds_match_seat_id",
+			columnNames = {"match_seat_id"}
+		)
+	},
+	indexes = {
+		@Index(
+			name = "idx_seat_holds_match_id",
+			columnList = "match_id"
+		),
+		@Index(
+			name = "idx_seat_holds_user_id",
+			columnList = "user_id"
+		),
+		@Index(
+			name = "idx_seat_holds_expires_at",
+			columnList = "expires_at"
+		)
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatHold extends BaseEntity {
+
+	@Column(name = "match_seat_id", nullable = false)
+	private Long matchSeatId;
+
+	@Column(name = "match_id", nullable = false)
+	private Long matchId;
+
+	@Column(name = "seat_id", nullable = false)
+	private Long seatId;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Builder
+	public SeatHold(
+		Long matchSeatId,
+		Long matchId,
+		Long seatId,
+		Long userId,
+		Instant expiresAt
+	) {
+		this.matchSeatId = matchSeatId;
+		this.matchId = matchId;
+		this.seatId = seatId;
+		this.userId = userId;
+		this.expiresAt = expiresAt;
+	}
+
+	public boolean isExpired(Instant now) {
+		return this.expiresAt.isBefore(now);
+	}
+
+	public boolean isOwnedBy(Long userId) {
+		return this.userId.equals(userId);
+	}
+
+	public void extendHold(Instant expiresAt) {
+		this.expiresAt = expiresAt;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.seatHold.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+
+public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
+}


### PR DESCRIPTION
## 🔧 작업 내용

- `matchSeat` 도메인 생성
- `seatHold` 도메인 생성
- `pricePolicy` 도메인 생성

## 🧩 구현 상세 (선택)

**matchSeat 도메인**
- 경기별 판매 좌석 스냅샷 테이블 match_seats 생성
- 좌석 위치(`areaId`, `sectionId`, `blockId`, `rowNo`, `seatNo`, `templateColNo`)와 상태(`saleStatus`) 관리
> price 제거
> → 좌석 가격은 권종(ticketType)에 따라 달라지므로 pricePolicy에서 관리

**seatHold 도메인**
- 예매하기 시점에 서버가 확보한 좌석을 임시 선점하기 위한 seat_holds 생성
- `expiresAt` 기준으로 선점 만료 관리 (`Instant` 사용)

**pricePolicy 도메인**
- `section` 기준 권종별 가격 정책 관리
- `dayType`, `ticketType` enum 적용
> effective_from, effective_to 제외
> → 현재는 단일 가격 정책만 사용하여 기간 관리 필요 없음

### 📌 관련 Jira Issue

- GRGB-235

## ❗ 참고 사항

- 내일부터 기능 관련 개발 들어가겠슴다
- 지피티랑 얘기하면서 빠진 컬럼들이 있는데 필요한 컬럼이면 말씀해주십쇼