### PR TITLE
fix(gateway): CORS 누락 및 Auth 라우팅 404 Hotfix [GRGB-236]

### DIFF
--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -8,25 +8,15 @@ spring:
     gateway:
       server:
         webflux:
-          globalcors:
-            corsConfigurations:
-              '[/**]':
-                allowedOriginPatterns:
-                  - "${ALLOWED_ORIGINS}"
-                allowedMethods:
-                  - GET
-                  - POST
-                  - PUT
-                  - DELETE
-                  - OPTIONS
-                allowedHeaders:
-                  - "*"
-                allowCredentials: true
+          default-filters:
+            - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials, RETAIN_FIRST
           routes:
             - id: auth-guard
               uri: ${AUTH_GUARD_URL}
               predicates:
                 - Path=/auth/**
+              filters:
+                - StripPrefix=1
             - id: queue
               uri: ${QUEUE_URL}
               predicates:


### PR DESCRIPTION
 ## 🔧 작업 내용
  - 프론트엔드에서 에러 응답(4xx/5xx) 수신 시 CORS 헤더 누락으로 원인 파악 불가 문제 해결
- `/auth/token/refresh` 호출 시 404 반환되던 라우팅 경로 불일치 문제 해결
  - API Gateway의 CORS 처리를 `globalcors` 설정에서 `CorsGlobalFilter`로 일원화

  ## 🧩 구현 상세

  **CORS 수정**
- 기존 `globalcors` 설정은 정상 라우팅된 응답에만 CORS
  헤더를 추가
- `JwtAuthenticationFilter`(order: -1)가 직접 에러 응답을
   write하는 경우 response가 먼저 커밋되어 CORS 헤더 누락
  발생
- `CorsGlobalFilter`를 `Ordered.HIGHEST_PRECEDENCE`로
  등록 → 모든 응답(에러 포함)에 CORS 헤더 선보장
- `DedupeResponseHeader` default-filter 추가로 중복 헤더
  방지

  **라우팅 수정**
- Auth-Guard 컨트롤러는 `/token/refresh`, `/kakao/**` 등 `/auth` prefix 없이 매핑
- API Gateway가 `/auth/**` → Auth-Guard로 전달 시prefix를 그대로 포함해 전송 → 404
- auth-guard 라우트에 `StripPrefix=1` 추가 → `/auth/token/refresh` → `/token/refresh` 로 전달
- 다른 서비스(queue, seat, order, recommendation)는 자체 prefix로 매핑되어 있어 StripPrefix 불필요

  ### 📌 관련 Issue
  - #119 
  - GRGB-236

  ## 🧪 테스트 방법
  - `POST /auth/token/refresh` — 200 응답 및 CORS 헤더 확인
  - 만료 토큰으로 인증 필요 API 호출 — 401 응답에
  `Access-Control-Allow-Origin` 헤더 포함 확인
  - `OPTIONS /auth/**` preflight 요청 — 200 응답 확인

  ## ❗ 참고 사항
  - `ALLOWED_ORIGINS` 환경변수 설정 필수 (기존과 동일)
  - 다른 서비스 라우트의 StripPrefix 필요 여부는 추후 확인필요
