### PR TITLE
fix(gateway): 코드 리뷰 반영 - auth-guard StripPrefix 제거 [GRGB-236]

### DIFF
--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -15,8 +15,6 @@ spring:
               uri: ${AUTH_GUARD_URL}
               predicates:
                 - Path=/auth/**
-              filters:
-                - StripPrefix=1
             - id: queue
               uri: ${QUEUE_URL}
               predicates:


### PR DESCRIPTION
## 🔧 작업내용
- #120 PR의 Gemini 코드리뷰 반영
- auth-guard 라우드의 `StripPrefix=1` 필터 제거
- auth-guard 는 `server.servlet.context-path: /auth` 설정으로 `/auth` prefix를 자체 처리하므로 StripPrefix 불필요.


### 📌 관련 Jira Issue
- GRGB-236
- 관련 깃허브 이슈 #119 