### PR TITLE
feat(api-gateway): Micrometer HTTP route 태그 추가로 Grafana 경로별 모니터링 지원 [GRGB-237]

### DIFF
--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -37,7 +37,7 @@ jobs:
       # PR이 열리거나 수정되면 Jira 상태를 "리뷰 중(In Review)" 으로 전환하고
       # Jira 티켓에 PR 링크 댓글 추가
       - name: Move to In Review and comment PR link
-        if: github.event.action != 'closed'
+        if: github.event.action != 'closed' && steps.jira.outputs.key != ''
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
@@ -50,14 +50,14 @@ jobs:
           # 리뷰 중(In Review) transition id = 31
           REVIEW_ID="31"
 
-          curl --fail -s -X POST \
+          curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
             -d "{\"transition\":{\"id\":\"$REVIEW_ID\"}}"
 
-          curl --fail -s -X POST \
+          curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
@@ -66,7 +66,7 @@ jobs:
 
       # PR이 merge 되어 closed 되면 Jira 상태를 "완료 (Done)" 로 전환
       - name: Move to Done on merge
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true && steps.jira.outputs.key != ''
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
@@ -78,7 +78,7 @@ jobs:
           # 완료 (Done) transition id = 41
           DONE_ID="41"
 
-          curl --fail -s -X POST \
+          curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/config/GatewayObservationConfig.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/config/GatewayObservationConfig.java
@@ -11,6 +11,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.config.MeterFilter;
 
 @Configuration
 public class GatewayObservationConfig {
@@ -38,8 +39,16 @@ public class GatewayObservationConfig {
 		};
 	}
 
+	@Bean
+	MeterFilter gatewayRouteCardinalityLimiter() {
+		return MeterFilter.maximumAllowableTags(
+				"spring.cloud.gateway.requests", "route", 100,
+				MeterFilter.deny()
+		);
+	}
+
 	static String normalizePath(String path) {
-		if (path == null || path.isEmpty()) {
+		if (path == null || path.isBlank()) {
 			return UNKNOWN;
 		}
 		String normalized = UUID_SEGMENT.matcher(path).replaceAll("{uuid}");

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/config/GatewayObservationConfig.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/config/GatewayObservationConfig.java
@@ -1,0 +1,49 @@
+package com.goormgb.be.apigateway.config;
+
+import java.util.regex.Pattern;
+
+import org.springframework.cloud.gateway.filter.headers.observation.DefaultGatewayObservationConvention;
+import org.springframework.cloud.gateway.filter.headers.observation.GatewayContext;
+import org.springframework.cloud.gateway.filter.headers.observation.GatewayObservationConvention;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+
+@Configuration
+public class GatewayObservationConfig {
+
+	private static final Pattern NUMERIC_SEGMENT = Pattern.compile("(?<=/)\\d+(?=/|$)");
+	private static final Pattern UUID_SEGMENT = Pattern.compile(
+			"(?<=/)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?=/|$)");
+	private static final String ROUTE_TAG = "route";
+	private static final String UNKNOWN = "/unknown";
+
+	@Bean
+	GatewayObservationConvention routeTagGatewayObservationConvention() {
+		return new DefaultGatewayObservationConvention() {
+
+			@Override
+			public KeyValues getLowCardinalityKeyValues(GatewayContext context) {
+				KeyValues defaults = super.getLowCardinalityKeyValues(context);
+				ServerHttpRequest request = context.getRequest();
+				if (request == null) {
+					return defaults.and(KeyValue.of(ROUTE_TAG, UNKNOWN));
+				}
+				String path = request.getURI().getPath();
+				return defaults.and(KeyValue.of(ROUTE_TAG, normalizePath(path)));
+			}
+		};
+	}
+
+	static String normalizePath(String path) {
+		if (path == null || path.isEmpty()) {
+			return UNKNOWN;
+		}
+		String normalized = UUID_SEGMENT.matcher(path).replaceAll("{uuid}");
+		normalized = NUMERIC_SEGMENT.matcher(normalized).replaceAll("{id}");
+		return normalized;
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/metrics/MetricsCommonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/metrics/MetricsCommonConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 
 @Configuration
 public class MetricsCommonConfig {
@@ -15,6 +16,14 @@ public class MetricsCommonConfig {
 		return registry -> registry.config().commonTags(
 				"service", environment.getProperty("spring.application.name", "unknown"),
 				"env", environment.getProperty("spring.profiles.active", "local")
+		);
+	}
+
+	@Bean
+	public MeterFilter httpRouteCardinalityLimiter() {
+		return MeterFilter.maximumAllowableTags(
+				"spring.cloud.gateway.requests", "route", 100,
+				MeterFilter.deny()
 		);
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/metrics/MetricsCommonConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/metrics/MetricsCommonConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.config.MeterFilter;
 
 @Configuration
 public class MetricsCommonConfig {
@@ -16,14 +15,6 @@ public class MetricsCommonConfig {
 		return registry -> registry.config().commonTags(
 				"service", environment.getProperty("spring.application.name", "unknown"),
 				"env", environment.getProperty("spring.profiles.active", "local")
-		);
-	}
-
-	@Bean
-	public MeterFilter httpRouteCardinalityLimiter() {
-		return MeterFilter.maximumAllowableTags(
-				"spring.cloud.gateway.requests", "route", 100,
-				MeterFilter.deny()
 		);
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- API Gateway 메트릭에 정규화된 요청 경로(`route`) 태그를 추가하여 Grafana에서 엔드포인트별 모니터링 가능하도록 개선
- 기존 `/**`, `/auth/**`로 뭉쳐 보이던 메트릭을 `/auth/token/refresh`, `/order/clubs/{id}` 등 실제 경로 단위로 식별 가능하게 변경
- cardinality 폭증 방어를 위한 경로 정규화 및 MeterFilter 적용

## 🧩 구현 상세
- **원인**: Spring Cloud Gateway 의 `DefaultGatewayObservationConvention`이 실제 요청 경로를 High Cardinality Key로만 기록하여 Prometheus 메트릭에 포함되지 않았음
- **해결**: `GatewayObservationConvention`을 커스터마이징하여 정규화된 경로를 Low Cardinality Key(`route`)로 추가
- 숫자 path segment → `{id}`, UUID → `{uuid}`로 정규화하여 태그 수 제한
- `MeterFilter.maximumAllowableTags()`로 `route` 태그 최대 100개 제한 (이중 방어)

### 📌 관련 Jira Issue
- GRGB-237

## 🧪 테스트 방법
1. API Gateway 기동 후 요청 실행
   - `curl http://localhost:8085/auth/token/refresh`
   - `curl http://localhost:8085/order/clubs/123`
2. Prometheus 엔드포인트 확인
   - `curl -s
  http://localhost:8085/actuator/prometheus | grep
  spring_cloud_gateway`
3. `route` 태그에 정규화된 경로(`/auth/token/refresh`, `/order/clubs/{id}`)가 표시되는지 확인

## ❗ 참고 사항
- 기존 메트릭 태그(`route.id`, `method`, `status`)는 그대로 유지되므로 기존 Grafana 쿼리에 영향 없음
- `route` 태그가 새로 추가되는 것이므로 클라우드팀에서 Grafana 대시보드 쿼리에 `route` 태그를 활용하면 됨
- 상세 원인 분석 문서: https://www.notion.so/GRGB-237-Grafana-Micrometer-HTTP-route-3219e3e335cc8034a07fd4fcdc0127ed?source=copy_link
- dev에서 그라파타 확인을 위해 바로 PR 리뷰 승인 없이 바로 merge 하도록 하곘습니다!

cc. @212clab @jjyeah 