### PR TITLE
refactor(onboarding): 온보딩 선호도 테이블 3개 정규화 및 API 재설계 [GRGB-232]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceController.java
@@ -32,10 +32,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/onboarding")
 public class OnboardingPreferenceController {
-	final private OnboardingPreferenceService onboardingPreferenceService;
 
-	@Operation(summary = "온보딩 선호도 조회", description = "로그인한 유저의 온보딩 좌석 선호도를 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth"))
+	private final OnboardingPreferenceService onboardingPreferenceService;
+
+	@Operation(
+		summary = "온보딩 선호도 조회",
+		description = "로그인한 유저의 온보딩 좌석 선호도를 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
@@ -47,16 +51,24 @@ public class OnboardingPreferenceController {
 		@AuthenticationPrincipal Long userId
 	) {
 		var preferences = onboardingPreferenceService.getPreferences(userId);
-
 		return ApiResult.ok(preferences);
 	}
 
-	@Operation(summary = "온보딩 선호도 생성", description = "온보딩 좌석 선호도를 최초 생성합니다. 선호도 3개를 우선순위(1~3) 순서로 입력해야 합니다.",
-		security = @SecurityRequirement(name = "BearerAuth"))
+	@Operation(
+		summary = "온보딩 선호도 생성",
+		description = """
+			온보딩 좌석 선호도를 최초 생성합니다.
+			- favoriteClubId, cheerProximityPref, preferredBlockIds(1~10개)는 필수입니다.
+			- preferredBlockIds는 경기장 실제 구역 번호입니다. (예: 내야 101~334, 외야 401~422)
+			- preferences 배열은 1~3개, 각 항목에 priority와 viewpoint 필수입니다.
+			- seatHeight, section 등 옵셔널 필드는 1순위 항목에 넣으면 됩니다. 미입력 시 기본값(ANY/NORMAL) 적용.
+			""",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "201", description = "생성 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "409", description = "이미 선호도가 존재함", content = @Content)
+		@ApiResponse(responseCode = "409", description = "이미 온보딩이 완료됨", content = @Content)
 	})
 	@PostMapping("/preferences")
 	@ResponseStatus(HttpStatus.CREATED)
@@ -69,6 +81,9 @@ public class OnboardingPreferenceController {
 					  "marketingConsent": {
 					    "marketingAgreed": true
 					  },
+					  "favoriteClubId": 1,
+					  "cheerProximityPref": "NEAR",
+					  "preferredBlockIds": [205, 206, 207, 114, 115],
 					  "preferences": [
 					    {
 					      "priority": 1,
@@ -83,25 +98,11 @@ public class OnboardingPreferenceController {
 					    },
 					    {
 					      "priority": 2,
-					      "viewpoint": "INFIELD_1B",
-					      "seatHeight": "MID",
-					      "section": "CENTER_SIDE",
-					      "seatPositionPref": "ANY",
-					      "environmentPref": "ANY",
-					      "moodPref": "ANY",
-					      "obstructionSensitivity": "NORMAL",
-					      "priceMode": "ANY"
+					      "viewpoint": "INFIELD_1B"
 					    },
 					    {
 					      "priority": 3,
-					      "viewpoint": "OUTFIELD_L",
-					      "seatHeight": "HIGH",
-					      "section": "CORNER",
-					      "seatPositionPref": "ANY",
-					      "environmentPref": "ANY",
-					      "moodPref": "ANY",
-					      "obstructionSensitivity": "ANY",
-					      "priceMode": "ANY"
+					      "viewpoint": "OUTFIELD_L"
 					    }
 					  ]
 					}
@@ -109,12 +110,14 @@ public class OnboardingPreferenceController {
 		@RequestBody OnboardingPreferenceCreateRequest request
 	) {
 		var response = onboardingPreferenceService.createPreferences(userId, request);
-
 		return ApiResult.ok(response);
 	}
 
-	@Operation(summary = "온보딩 선호도 수정", description = "기존 온보딩 좌석 선호도를 전체 교체(PUT)합니다.",
-		security = @SecurityRequirement(name = "BearerAuth"))
+	@Operation(
+		summary = "온보딩 선호도 수정",
+		description = "기존 온보딩 좌석 선호도를 전체 교체(PUT)합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "수정 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
@@ -128,11 +131,14 @@ public class OnboardingPreferenceController {
 			content = @Content(mediaType = "application/json",
 				examples = @ExampleObject(value = """
 					{
+					  "favoriteClubId": 2,
+					  "cheerProximityPref": "FAR",
+					  "preferredBlockIds": [318, 319, 412, 413],
 					  "preferences": [
 					    {
 					      "priority": 1,
 					      "viewpoint": "INFIELD_3B",
-					      "seatHeight": "LOW",
+					      "seatHeight": "MID",
 					      "section": "CENTER_SIDE",
 					      "seatPositionPref": "ANY",
 					      "environmentPref": "ANY",
@@ -144,25 +150,11 @@ public class OnboardingPreferenceController {
 					    },
 					    {
 					      "priority": 2,
-					      "viewpoint": "CENTER",
-					      "seatHeight": "MID",
-					      "section": "MIDDLE",
-					      "seatPositionPref": "AISLE",
-					      "environmentPref": "SHADE",
-					      "moodPref": "CHEERFUL",
-					      "obstructionSensitivity": "NET_SENSITIVE",
-					      "priceMode": "ANY"
+					      "viewpoint": "CENTER"
 					    },
 					    {
 					      "priority": 3,
-					      "viewpoint": "OUTFIELD_R",
-					      "seatHeight": "ANY",
-					      "section": "CORNER",
-					      "seatPositionPref": "ANY",
-					      "environmentPref": "ANY",
-					      "moodPref": "ANY",
-					      "obstructionSensitivity": "ANY",
-					      "priceMode": "ANY"
+					      "viewpoint": "OUTFIELD_R"
 					    }
 					  ]
 					}
@@ -170,12 +162,14 @@ public class OnboardingPreferenceController {
 		@RequestBody OnboardingPreferenceUpdateRequest request
 	) {
 		onboardingPreferenceService.updatePreferences(userId, request);
-
 		return ApiResult.ok();
 	}
 
-	@Operation(summary = "온보딩 완료 여부 조회", description = "로그인한 유저의 온보딩 완료 여부 및 완료 시각을 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth"))
+	@Operation(
+		summary = "온보딩 완료 여부 조회",
+		description = "로그인한 유저의 온보딩 완료 여부 및 완료 시각을 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/OnboardingPreferenceItemDto.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/OnboardingPreferenceItemDto.java
@@ -1,7 +1,5 @@
 package com.goormgb.be.ordercore.onboarding.dto;
 
-import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.domain.onboarding.enums.EnvironmentPref;
 import com.goormgb.be.domain.onboarding.enums.MoodPref;
 import com.goormgb.be.domain.onboarding.enums.ObstructionSensitivity;
@@ -11,10 +9,8 @@ import com.goormgb.be.domain.onboarding.enums.SeatPositionPref;
 import com.goormgb.be.domain.onboarding.enums.Section;
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 
-public record OnboardingPreferenceDto(
+public record OnboardingPreferenceItemDto(
 	Integer priority,
-	Long favoriteClubId,
-	CheerProximityPref cheerProximityPref,
 	Viewpoint viewpoint,
 	SeatHeight seatHeight,
 	Section section,
@@ -26,23 +22,4 @@ public record OnboardingPreferenceDto(
 	Integer priceMin,
 	Integer priceMax
 ) {
-
-	public static OnboardingPreferenceDto from(OnboardingPreference entity) {
-		return new OnboardingPreferenceDto(
-			entity.getPriority(),
-			entity.getFavoriteClub().getId(),
-			entity.getCheerProximityPref(),
-			entity.getViewpoint(),
-			entity.getSeatHeight(),
-			entity.getSection(),
-			entity.getSeatPositionPref(),
-			entity.getEnvironmentPref(),
-			entity.getMoodPref(),
-			entity.getObstructionSensitivity(),
-			entity.getPriceMode(),
-			entity.getPriceMin(),
-			entity.getPriceMax()
-		);
-	}
-
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/ViewpointPriorityDto.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/ViewpointPriorityDto.java
@@ -1,0 +1,16 @@
+package com.goormgb.be.ordercore.onboarding.dto;
+
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+
+public record ViewpointPriorityDto(
+	Integer priority,
+	Viewpoint viewpoint
+) {
+	public static ViewpointPriorityDto from(OnboardingViewpointPriority entity) {
+		return new ViewpointPriorityDto(
+			entity.getPriority(),
+			entity.getViewpoint()
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/request/OnboardingPreferenceCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/request/OnboardingPreferenceCreateRequest.java
@@ -2,11 +2,15 @@ package com.goormgb.be.ordercore.onboarding.dto.request;
 
 import java.util.List;
 
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 
 public record OnboardingPreferenceCreateRequest(
-		MarketingConsent marketingConsent,
-		List<OnboardingPreferenceDto> preferences
+	MarketingConsent marketingConsent,
+	Long favoriteClubId,
+	CheerProximityPref cheerProximityPref,
+	List<Long> preferredBlockIds,
+	List<OnboardingPreferenceItemDto> preferences
 ) {
 	public record MarketingConsent(Boolean marketingAgreed) {
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/request/OnboardingPreferenceUpdateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/request/OnboardingPreferenceUpdateRequest.java
@@ -2,9 +2,13 @@ package com.goormgb.be.ordercore.onboarding.dto.request;
 
 import java.util.List;
 
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 
 public record OnboardingPreferenceUpdateRequest(
-		List<OnboardingPreferenceDto> preferences
+	Long favoriteClubId,
+	CheerProximityPref cheerProximityPref,
+	List<Long> preferredBlockIds,
+	List<OnboardingPreferenceItemDto> preferences
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingPreferenceGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/dto/response/OnboardingPreferenceGetResponse.java
@@ -3,16 +3,47 @@ package com.goormgb.be.ordercore.onboarding.dto.response;
 import java.util.List;
 
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 
 public record OnboardingPreferenceGetResponse(
-	List<OnboardingPreferenceDto> preferences
+	Long favoriteClubId,
+	String favoriteClubName,
+	CheerProximityPref cheerProximityPref,
+	List<Long> preferredBlockIds,
+	List<OnboardingPreferenceItemDto> preferences
 ) {
-	public static OnboardingPreferenceGetResponse from(List<OnboardingPreference> entities) {
-		List<OnboardingPreferenceDto> preferences = entities.stream()
-			.map(OnboardingPreferenceDto::from)
+	public static OnboardingPreferenceGetResponse from(
+		OnboardingPreference preference,
+		List<OnboardingViewpointPriority> viewpointPriorities,
+		List<OnboardingPreferredBlock> preferredBlocks
+	) {
+		List<OnboardingPreferenceItemDto> items = viewpointPriorities.stream()
+			.map(vp -> new OnboardingPreferenceItemDto(
+				vp.getPriority(),
+				vp.getViewpoint(),
+				preference.getSeatHeight(),
+				preference.getSection(),
+				preference.getSeatPositionPref(),
+				preference.getEnvironmentPref(),
+				preference.getMoodPref(),
+				preference.getObstructionSensitivity(),
+				preference.getPriceMode(),
+				preference.getPriceMin(),
+				preference.getPriceMax()
+			))
 			.toList();
 
-		return new OnboardingPreferenceGetResponse(preferences);
+		return new OnboardingPreferenceGetResponse(
+			preference.getFavoriteClub().getId(),
+			preference.getFavoriteClub().getKoName(),
+			preference.getCheerProximityPref(),
+			preferredBlocks.stream()
+				.map(OnboardingPreferredBlock::getBlockId)
+				.toList(),
+			items
+		);
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/service/OnboardingPreferenceService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/service/OnboardingPreferenceService.java
@@ -8,15 +8,21 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.club.repository.ClubRepository;
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.domain.onboarding.enums.SeatHeight;
-import com.goormgb.be.domain.onboarding.enums.Section;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.PriceMode;
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceCreateRequest;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceUpdateRequest;
 import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceCreateResponse;
@@ -30,44 +36,56 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class OnboardingPreferenceService {
+
 	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
+	private final OnboardingViewpointPriorityRepository viewpointPriorityRepository;
+	private final OnboardingPreferredBlockRepository preferredBlockRepository;
+	private final ClubRepository clubRepository;
 	private final UserRepository userRepository;
 
 	@Transactional(readOnly = true)
 	public OnboardingStatusGetResponse getOnboardingStatus(Long userId) {
 		var user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
-
 		return OnboardingStatusGetResponse.from(user);
 	}
 
 	@Transactional(readOnly = true)
 	public OnboardingPreferenceGetResponse getPreferences(Long userId) {
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
+		userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 
-		var preferences = onboardingPreferenceRepository.findAllByUserIdOrderByPriorityAsc(userId);
+		var preference = onboardingPreferenceRepository.findByUserIdOrThrow(userId, ErrorCode.PREFERENCE_NOT_FOUND);
+		var viewpointPriorities = viewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId);
+		var preferredBlocks = preferredBlockRepository.findAllByUserId(userId);
 
-		return OnboardingPreferenceGetResponse.from(preferences);
+		return OnboardingPreferenceGetResponse.from(preference, viewpointPriorities, preferredBlocks);
 	}
 
 	@Transactional
-	public OnboardingPreferenceCreateResponse createPreferences(Long userId,
-		OnboardingPreferenceCreateRequest request) {
+	public OnboardingPreferenceCreateResponse createPreferences(
+		Long userId,
+		OnboardingPreferenceCreateRequest request
+	) {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 
-		// 온보딩 완료 여부 검증
 		Preconditions.validate(!user.isCompletedOnboarding(), ErrorCode.ONBOARDING_ALREADY_COMPLETED);
 
 		// 검증
+		validateFavoriteClub(request.favoriteClubId());
+		validateCheerProximityPref(request.cheerProximityPref());
 		validatePreferences(request.preferences());
+		validatePreferredBlocks(request.preferredBlockIds());
+
+		// 1순위 항목에서 옵셔널 필드 추출
+		OnboardingPreferenceItemDto firstPref = request.preferences().get(0);
+		validatePrice(firstPref.priceMode(), firstPref.priceMin(), firstPref.priceMax());
 
 		// 저장
-		var entities = request
-			.preferences()
-			.stream()
-			.map(preference -> toEntity(user, preference))
-			.toList();
+		Club club = clubRepository.findById(request.favoriteClubId())
+			.orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND));
 
-		onboardingPreferenceRepository.saveAll(entities);
+		savePreference(user, club, request.cheerProximityPref(), firstPref);
+		saveViewpointPriorities(user, request.preferences());
+		savePreferredBlocks(user, request.preferredBlockIds());
 
 		// 마케팅 동의
 		applyMarketingConsent(user, request.marketingConsent());
@@ -83,102 +101,143 @@ public class OnboardingPreferenceService {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 
 		// 검증
+		validateFavoriteClub(request.favoriteClubId());
+		validateCheerProximityPref(request.cheerProximityPref());
 		validatePreferences(request.preferences());
+		validatePreferredBlocks(request.preferredBlockIds());
 
-		// 저장
-		replacePreferences(userId, request.preferences());
+		OnboardingPreferenceItemDto firstPref = request.preferences().get(0);
+		validatePrice(firstPref.priceMode(), firstPref.priceMin(), firstPref.priceMax());
 
-		// 온보딩 수정 완료
+		Club club = clubRepository.findById(request.favoriteClubId())
+			.orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND));
+
+		// preference: update 또는 신규 생성
+		var existingPreference = onboardingPreferenceRepository.findByUserId(userId);
+		if (existingPreference.isPresent()) {
+			existingPreference.get().update(
+				club,
+				request.cheerProximityPref(),
+				firstPref.seatHeight(),
+				firstPref.section(),
+				firstPref.seatPositionPref(),
+				firstPref.environmentPref(),
+				firstPref.moodPref(),
+				firstPref.obstructionSensitivity(),
+				firstPref.priceMode(),
+				firstPref.priceMin(),
+				firstPref.priceMax()
+			);
+		} else {
+			savePreference(user, club, request.cheerProximityPref(), firstPref);
+		}
+
+		// viewpoint priorities: delete + insert
+		viewpointPriorityRepository.deleteAllByUserId(userId);
+		saveViewpointPriorities(user, request.preferences());
+
+		// preferred blocks: delete + insert
+		preferredBlockRepository.deleteAllByUserId(userId);
+		savePreferredBlocks(user, request.preferredBlockIds());
+
 		user.completeOnboarding();
 	}
 
-	private void replacePreferences(Long userId, List<OnboardingPreferenceDto> preferences) {
-		var existingPreferences = onboardingPreferenceRepository.findAllByUserIdOrderByPriorityAsc(userId);
+	// ── 저장 헬퍼 ──
 
-		for (OnboardingPreferenceDto pref : preferences) {
-			OnboardingPreference preferenceToUpdate = existingPreferences
-				.stream()
-				.filter(p -> p
-					.getPriority()
-					.equals(pref.priority()))
-				.findFirst()
-				.orElseThrow(() -> new CustomException(ErrorCode.PREFERENCE_NOT_FOUND_FOR_UPDATE));
-
-			preferenceToUpdate.update(
-				pref.cheerProximityPref(),
-				pref.viewpoint(),
-				pref.seatHeight(),
-				pref.section(),
-				pref.seatPositionPref(),
-				pref.environmentPref(),
-				pref.moodPref(),
-				pref.obstructionSensitivity(),
-				pref.priceMode(),
-				pref.priceMin(),
-				pref.priceMax()
-			);
-		}
+	private void savePreference(User user, Club club, CheerProximityPref cheerProximityPref,
+		OnboardingPreferenceItemDto pref) {
+		onboardingPreferenceRepository.save(
+			OnboardingPreference.builder()
+				.user(user)
+				.favoriteClub(club)
+				.cheerProximityPref(cheerProximityPref)
+				.seatHeight(pref.seatHeight())
+				.section(pref.section())
+				.seatPositionPref(pref.seatPositionPref())
+				.environmentPref(pref.environmentPref())
+				.moodPref(pref.moodPref())
+				.obstructionSensitivity(pref.obstructionSensitivity())
+				.priceMode(pref.priceMode())
+				.priceMin(pref.priceMin())
+				.priceMax(pref.priceMax())
+				.build()
+		);
 	}
 
-	private void validatePreferences(List<OnboardingPreferenceDto> preferences) {
-		Preconditions.validate(preferences != null, ErrorCode.ONBOARDING_NOT_COMPLETED);
-		Preconditions.validate(preferences
-			.size() == 3, ErrorCode.MISSING_REQUIRED_PREFERENCE_FIELD);
+	private void saveViewpointPriorities(User user, List<OnboardingPreferenceItemDto> preferences) {
+		var entities = preferences.stream()
+			.map(pref -> OnboardingViewpointPriority.builder()
+				.user(user)
+				.priority(pref.priority())
+				.viewpoint(pref.viewpoint())
+				.build())
+			.toList();
 
-		// 우선순위 검증
-		validatePriority(preferences);
-
-		// 필수 값 검증
-		validateRequiredFields(preferences);
-
-		// 가격 검증
-		validatePrice(preferences);
+		viewpointPriorityRepository.saveAll(entities);
 	}
 
-	private void validatePriority(List<OnboardingPreferenceDto> preferences) {
+	private void savePreferredBlocks(User user, List<Long> blockIds) {
+		var entities = blockIds.stream()
+			.map(blockId -> OnboardingPreferredBlock.builder()
+				.user(user)
+				.blockId(blockId)
+				.build())
+			.toList();
+
+		preferredBlockRepository.saveAll(entities);
+	}
+
+	// ── 검증 ──
+
+	private void validateFavoriteClub(Long favoriteClubId) {
+		Preconditions.validate(favoriteClubId != null, ErrorCode.MISSING_REQUIRED_PREFERENCE_FIELD);
+		Preconditions.validate(clubRepository.existsById(favoriteClubId), ErrorCode.CLUB_NOT_FOUND);
+	}
+
+	private void validateCheerProximityPref(CheerProximityPref cheerProximityPref) {
+		Preconditions.validate(cheerProximityPref != null, ErrorCode.MISSING_REQUIRED_PREFERENCE_FIELD);
+	}
+
+	private void validatePreferences(List<OnboardingPreferenceItemDto> preferences) {
+		Preconditions.validate(
+			preferences != null && !preferences.isEmpty() && preferences.size() <= 3,
+			ErrorCode.INVALID_VIEWPOINT_PRIORITY_COUNT
+		);
+
+		// priority 연속성 검증 (1부터 시작, 연속)
 		Set<Integer> priorities = preferences.stream()
-			.map(OnboardingPreferenceDto::priority)
+			.map(OnboardingPreferenceItemDto::priority)
 			.collect(Collectors.toSet());
 
-		Preconditions.validate(priorities.size() == 3, ErrorCode.INVALID_PREFERENCE_RANK);
-		Preconditions.validate(priorities.containsAll(List.of(1, 2, 3)), ErrorCode.INVALID_PREFERENCE_PRIORITY_VALUE);
-	}
+		for (int i = 1; i <= preferences.size(); i++) {
+			Preconditions.validate(priorities.contains(i), ErrorCode.INVALID_VIEWPOINT_PRIORITY_SEQUENCE);
+		}
 
-	private void validateRequiredFields(List<OnboardingPreferenceDto> preferences) {
+		// viewpoint 중복 검증
 		Set<Viewpoint> viewpoints = new HashSet<>();
-		Set<SeatHeight> seatHeights = new HashSet<>();
-		Set<Section> sections = new HashSet<>();
-
-		for (OnboardingPreferenceDto dto : preferences) {
-			Preconditions.validate(dto.viewpoint() != null && dto.seatHeight() != null && dto.section() != null,
-				ErrorCode.MISSING_REQUIRED_PREFERENCE_FIELD);
-
-			Preconditions.validate(viewpoints.add(dto.viewpoint()), ErrorCode.DUPLICATE_PREFERENCE_VIEWPOINT);
-			Preconditions.validate(seatHeights.add(dto.seatHeight()), ErrorCode.DUPLICATE_PREFERENCE_SEAT_HEIGHT);
-			Preconditions.validate(sections.add(dto.section()), ErrorCode.DUPLICATE_PREFERENCE_SECTION);
+		for (OnboardingPreferenceItemDto pref : preferences) {
+			Preconditions.validate(pref.viewpoint() != null, ErrorCode.MISSING_REQUIRED_PREFERENCE_FIELD);
+			Preconditions.validate(viewpoints.add(pref.viewpoint()), ErrorCode.DUPLICATE_PREFERENCE_VIEWPOINT);
 		}
 	}
 
-	private void validatePrice(List<OnboardingPreferenceDto> preferences) {
-		// TODO: 가격 정책 정해지면 구현
+	private void validatePreferredBlocks(List<Long> blockIds) {
+		Preconditions.validate(
+			blockIds != null && !blockIds.isEmpty() && blockIds.size() <= 10,
+			ErrorCode.INVALID_PREFERRED_BLOCK_COUNT
+		);
+
+		Set<Long> uniqueBlockIds = new HashSet<>(blockIds);
+		Preconditions.validate(uniqueBlockIds.size() == blockIds.size(), ErrorCode.DUPLICATE_PREFERRED_BLOCK);
 	}
 
-	private OnboardingPreference toEntity(User user, OnboardingPreferenceDto preference) {
-		return OnboardingPreference
-			.builder()
-			.user(user)
-			.priority(preference.priority())
-			.viewpoint(preference.viewpoint())
-			.seatHeight(preference.seatHeight())
-			.section(preference.section())
-			.seatPositionPref(preference.seatPositionPref())
-			.environmentPref(preference.environmentPref())
-			.moodPref(preference.moodPref())
-			.obstructionSensitivity(preference.obstructionSensitivity())
-			.priceMode(preference.priceMode())
-			.priceMin(preference.priceMin())
-			.priceMax(preference.priceMax())
-			.build();
+	private void validatePrice(PriceMode priceMode, Integer priceMin, Integer priceMax) {
+		if (priceMode == PriceMode.RANGE) {
+			if (priceMin != null && priceMax != null) {
+				Preconditions.validate(priceMin <= priceMax, ErrorCode.INVALID_PRICE_RANGE);
+			}
+		}
 	}
 
 	private void applyMarketingConsent(User user, OnboardingPreferenceCreateRequest.MarketingConsent marketingConsent) {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceDtoFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceDtoFixture.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.ordercore.fixture.onboarding;
 
-import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import java.util.List;
+
 import com.goormgb.be.domain.onboarding.enums.EnvironmentPref;
 import com.goormgb.be.domain.onboarding.enums.MoodPref;
 import com.goormgb.be.domain.onboarding.enums.ObstructionSensitivity;
@@ -9,64 +10,47 @@ import com.goormgb.be.domain.onboarding.enums.SeatHeight;
 import com.goormgb.be.domain.onboarding.enums.SeatPositionPref;
 import com.goormgb.be.domain.onboarding.enums.Section;
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 
 public final class OnboardingPreferenceDtoFixture {
 
 	private OnboardingPreferenceDtoFixture() {
 	}
 
-	public static OnboardingPreferenceDto createFirst() {
-		return new OnboardingPreferenceDto(
-			1,
-			1L,
-			CheerProximityPref.NEAR,
-			Viewpoint.CENTER,
-			SeatHeight.LOW,
-			Section.CENTER_SIDE,
-			SeatPositionPref.AISLE,
-			EnvironmentPref.SHADE,
-			MoodPref.CHEERFUL,
-			ObstructionSensitivity.NORMAL,
-			PriceMode.RANGE,
-			30000,
-			80000
+	public static List<OnboardingPreferenceItemDto> createThreePreferences() {
+		return List.of(
+			new OnboardingPreferenceItemDto(
+				1, Viewpoint.CENTER,
+				SeatHeight.LOW, Section.CENTER_SIDE,
+				SeatPositionPref.AISLE, EnvironmentPref.SHADE,
+				MoodPref.CHEERFUL, ObstructionSensitivity.NORMAL,
+				PriceMode.RANGE, 30000, 80000
+			),
+			new OnboardingPreferenceItemDto(
+				2, Viewpoint.INFIELD_1B,
+				null, null, null, null, null, null, null, null, null
+			),
+			new OnboardingPreferenceItemDto(
+				3, Viewpoint.OUTFIELD_L,
+				null, null, null, null, null, null, null, null, null
+			)
 		);
 	}
 
-	public static OnboardingPreferenceDto createSecond() {
-		return new OnboardingPreferenceDto(
-			2,
-			1L,
-			CheerProximityPref.ANY,
-			Viewpoint.INFIELD_1B,
-			SeatHeight.MID,
-			Section.MIDDLE,
-			SeatPositionPref.ANY,
-			EnvironmentPref.SUN_OK,
-			MoodPref.QUIET,
-			ObstructionSensitivity.NET_SENSITIVE,
-			PriceMode.ANY,
-			null,
-			null
+	public static List<OnboardingPreferenceItemDto> createTwoPreferences() {
+		return List.of(
+			new OnboardingPreferenceItemDto(
+				1, Viewpoint.CENTER,
+				null, null, null, null, null, null, PriceMode.ANY, null, null
+			),
+			new OnboardingPreferenceItemDto(
+				2, Viewpoint.INFIELD_1B,
+				null, null, null, null, null, null, null, null, null
+			)
 		);
 	}
 
-	public static OnboardingPreferenceDto createThird() {
-		return new OnboardingPreferenceDto(
-			3,
-			1L,
-			CheerProximityPref.FAR,
-			Viewpoint.OUTFIELD_L,
-			SeatHeight.HIGH,
-			Section.CORNER,
-			SeatPositionPref.MIDDLE,
-			EnvironmentPref.ANY,
-			MoodPref.ANY,
-			ObstructionSensitivity.RAIL_PILLAR_SENSITIVE,
-			PriceMode.RANGE,
-			10000,
-			50000
-		);
+	public static List<Long> createPreferredBlockIds() {
+		return List.of(1L, 5L, 12L, 23L, 45L);
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceRequestFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceRequestFixture.java
@@ -1,8 +1,6 @@
 package com.goormgb.be.ordercore.fixture.onboarding;
 
-import java.util.List;
-
-import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceDto;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceCreateRequest;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceUpdateRequest;
 
@@ -12,32 +10,31 @@ public final class OnboardingPreferenceRequestFixture {
 	}
 
 	public static OnboardingPreferenceCreateRequest createCreateRequest() {
-		List<OnboardingPreferenceDto> preferences = List.of(
-				OnboardingPreferenceDtoFixture.createFirst(),
-				OnboardingPreferenceDtoFixture.createSecond(),
-				OnboardingPreferenceDtoFixture.createThird()
-		);
 		return new OnboardingPreferenceCreateRequest(
-				new OnboardingPreferenceCreateRequest.MarketingConsent(true),
-				preferences
+			new OnboardingPreferenceCreateRequest.MarketingConsent(true),
+			1L,
+			CheerProximityPref.NEAR,
+			OnboardingPreferenceDtoFixture.createPreferredBlockIds(),
+			OnboardingPreferenceDtoFixture.createThreePreferences()
 		);
 	}
 
 	public static OnboardingPreferenceCreateRequest createCreateRequestWithoutMarketing() {
-		List<OnboardingPreferenceDto> preferences = List.of(
-				OnboardingPreferenceDtoFixture.createFirst()
-		);
 		return new OnboardingPreferenceCreateRequest(
-				new OnboardingPreferenceCreateRequest.MarketingConsent(false),
-				preferences
+			new OnboardingPreferenceCreateRequest.MarketingConsent(false),
+			1L,
+			CheerProximityPref.NEAR,
+			OnboardingPreferenceDtoFixture.createPreferredBlockIds(),
+			OnboardingPreferenceDtoFixture.createTwoPreferences()
 		);
 	}
 
 	public static OnboardingPreferenceUpdateRequest createUpdateRequest() {
-		List<OnboardingPreferenceDto> preferences = List.of(
-				OnboardingPreferenceDtoFixture.createFirst(),
-				OnboardingPreferenceDtoFixture.createSecond()
+		return new OnboardingPreferenceUpdateRequest(
+			2L,
+			CheerProximityPref.FAR,
+			OnboardingPreferenceDtoFixture.createPreferredBlockIds(),
+			OnboardingPreferenceDtoFixture.createTwoPreferences()
 		);
-		return new OnboardingPreferenceUpdateRequest(preferences);
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/onboarding/controller/OnboardingPreferenceControllerTest.java
@@ -20,10 +20,19 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.EnvironmentPref;
+import com.goormgb.be.domain.onboarding.enums.MoodPref;
+import com.goormgb.be.domain.onboarding.enums.ObstructionSensitivity;
+import com.goormgb.be.domain.onboarding.enums.PriceMode;
+import com.goormgb.be.domain.onboarding.enums.SeatHeight;
+import com.goormgb.be.domain.onboarding.enums.SeatPositionPref;
+import com.goormgb.be.domain.onboarding.enums.Section;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
-import com.goormgb.be.ordercore.fixture.onboarding.OnboardingPreferenceDtoFixture;
 import com.goormgb.be.ordercore.fixture.onboarding.OnboardingPreferenceRequestFixture;
+import com.goormgb.be.ordercore.onboarding.dto.OnboardingPreferenceItemDto;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceCreateRequest;
 import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceUpdateRequest;
 import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceCreateResponse;
@@ -40,8 +49,8 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 
 	private void setAuthentication(Long userId) {
 		SecurityContextHolder.getContext().setAuthentication(
-				new UsernamePasswordAuthenticationToken(userId, null,
-						List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+			new UsernamePasswordAuthenticationToken(userId, null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER"))));
 	}
 
 	@Test
@@ -52,24 +61,43 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		setAuthentication(userId);
 
 		OnboardingPreferenceGetResponse response = new OnboardingPreferenceGetResponse(
-				List.of(
-						OnboardingPreferenceDtoFixture.createFirst(),
-						OnboardingPreferenceDtoFixture.createSecond(),
-						OnboardingPreferenceDtoFixture.createThird()
+			1L,
+			"LG 트윈스",
+			CheerProximityPref.NEAR,
+			List.of(1L, 5L, 12L),
+			List.of(
+				new OnboardingPreferenceItemDto(
+					1, Viewpoint.CENTER,
+					SeatHeight.LOW, Section.CENTER_SIDE,
+					SeatPositionPref.AISLE, EnvironmentPref.SHADE,
+					MoodPref.CHEERFUL, ObstructionSensitivity.NORMAL,
+					PriceMode.RANGE, 30000, 80000
+				),
+				new OnboardingPreferenceItemDto(
+					2, Viewpoint.INFIELD_1B,
+					SeatHeight.LOW, Section.CENTER_SIDE,
+					SeatPositionPref.AISLE, EnvironmentPref.SHADE,
+					MoodPref.CHEERFUL, ObstructionSensitivity.NORMAL,
+					PriceMode.RANGE, 30000, 80000
 				)
+			)
 		);
 
 		given(onboardingPreferenceService.getPreferences(userId)).willReturn(response);
 
 		// when & then
 		mockMvc.perform(get("/onboarding/preferences"))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value("OK"))
-				.andExpect(jsonPath("$.message").value("성공"))
-				.andExpect(jsonPath("$.data.preferences").isArray())
-				.andExpect(jsonPath("$.data.preferences.length()").value(3))
-				.andExpect(jsonPath("$.data.preferences[0].priority").value(1))
-				.andExpect(jsonPath("$.data.preferences[0].viewpoint").value("CENTER"));
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.favoriteClubId").value(1))
+			.andExpect(jsonPath("$.data.cheerProximityPref").value("NEAR"))
+			.andExpect(jsonPath("$.data.preferredBlockIds").isArray())
+			.andExpect(jsonPath("$.data.preferredBlockIds.length()").value(3))
+			.andExpect(jsonPath("$.data.preferences").isArray())
+			.andExpect(jsonPath("$.data.preferences.length()").value(2))
+			.andExpect(jsonPath("$.data.preferences[0].priority").value(1))
+			.andExpect(jsonPath("$.data.preferences[0].viewpoint").value("CENTER"));
 	}
 
 	@Test
@@ -80,12 +108,12 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		setAuthentication(userId);
 
 		given(onboardingPreferenceService.getPreferences(userId))
-				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+			.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		// when & then
 		mockMvc.perform(get("/onboarding/preferences"))
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
 	}
 
 	@Test
@@ -99,23 +127,23 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 
 		Instant now = LocalDateTime.of(2026, 2, 22, 12, 0, 0).toInstant(ZoneOffset.UTC);
 		OnboardingPreferenceCreateResponse response = new OnboardingPreferenceCreateResponse(
-				true, now, true, now
+			true, now, true, now
 		);
 
 		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
-				.willReturn(response);
+			.willReturn(response);
 
 		// when & then
 		mockMvc.perform(post("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.code").value("OK"))
-				.andExpect(jsonPath("$.message").value("성공"))
-				.andExpect(jsonPath("$.data.onboardingStatus").value(true))
-				.andExpect(jsonPath("$.data.marketingConsent").value(true))
-				.andExpect(jsonPath("$.data.onboardingCompletedAt").exists())
-				.andExpect(jsonPath("$.data.marketingConsentedAt").exists());
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.onboardingStatus").value(true))
+			.andExpect(jsonPath("$.data.marketingConsent").value(true))
+			.andExpect(jsonPath("$.data.onboardingCompletedAt").exists())
+			.andExpect(jsonPath("$.data.marketingConsentedAt").exists());
 	}
 
 	@Test
@@ -128,14 +156,14 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		OnboardingPreferenceCreateRequest request = OnboardingPreferenceRequestFixture.createCreateRequest();
 
 		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
-				.willThrow(new CustomException(ErrorCode.ONBOARDING_ALREADY_COMPLETED));
+			.willThrow(new CustomException(ErrorCode.ONBOARDING_ALREADY_COMPLETED));
 
 		// when & then
 		mockMvc.perform(post("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isConflict())
-				.andExpect(jsonPath("$.message").value("이미 온보딩이 완료되었습니다."));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.message").value("이미 온보딩이 완료되었습니다."));
 	}
 
 	@Test
@@ -148,14 +176,14 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		OnboardingPreferenceCreateRequest request = OnboardingPreferenceRequestFixture.createCreateRequest();
 
 		given(onboardingPreferenceService.createPreferences(eq(userId), any(OnboardingPreferenceCreateRequest.class)))
-				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+			.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		// when & then
 		mockMvc.perform(post("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
 	}
 
 	@Test
@@ -168,36 +196,15 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
 
 		willDoNothing().given(onboardingPreferenceService)
-				.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
+			.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
 
 		// when & then
 		mockMvc.perform(put("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value("OK"))
-				.andExpect(jsonPath("$.message").value("성공"));
-	}
-
-	@Test
-	@DisplayName("PUT /onboarding/preferences - 수정할 선호도를 찾을 수 없음 404")
-	void 선호도_수정_수정할_선호도_없음() throws Exception {
-		// given
-		Long userId = 1L;
-		setAuthentication(userId);
-
-		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
-
-		willThrow(new CustomException(ErrorCode.PREFERENCE_NOT_FOUND_FOR_UPDATE))
-				.given(onboardingPreferenceService)
-				.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
-
-		// when & then
-		mockMvc.perform(put("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.message").value("수정할 선호도 정보를 찾을 수 없습니다."));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"));
 	}
 
 	@Test
@@ -210,14 +217,14 @@ class OnboardingPreferenceControllerTest extends WebMvcTestSupport {
 		OnboardingPreferenceUpdateRequest request = OnboardingPreferenceRequestFixture.createUpdateRequest();
 
 		willThrow(new CustomException(ErrorCode.USER_NOT_FOUND))
-				.given(onboardingPreferenceService)
-				.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
+			.given(onboardingPreferenceService)
+			.updatePreferences(eq(userId), any(OnboardingPreferenceUpdateRequest.class));
 
 		// when & then
 		mockMvc.perform(put("/onboarding/preferences")
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(request)))
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingPreference.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingPreference.java
@@ -1,7 +1,6 @@
 package com.goormgb.be.domain.onboarding.entity;
 
 import com.goormgb.be.domain.club.entity.Club;
-import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.domain.onboarding.enums.EnvironmentPref;
 import com.goormgb.be.domain.onboarding.enums.MoodPref;
@@ -10,7 +9,7 @@ import com.goormgb.be.domain.onboarding.enums.PriceMode;
 import com.goormgb.be.domain.onboarding.enums.SeatHeight;
 import com.goormgb.be.domain.onboarding.enums.SeatPositionPref;
 import com.goormgb.be.domain.onboarding.enums.Section;
-import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
@@ -30,14 +29,17 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-	name = "onboarding_preferences",
-	uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"user_id", "priority"})
-	},
-	indexes = {
-		@Index(name = "idx_onboarding_preferences_user_id", columnList = "user_id"),
-		@Index(name = "idx_onboarding_preferences_favorite_club_id", columnList = "favorite_club_id")
-	}
+		name = "onboarding_preferences",
+		uniqueConstraints = {
+				@UniqueConstraint(
+						name = "uk_onboarding_preferences_user_id",
+						columnNames = {"user_id"}
+				)
+		},
+		indexes = {
+				@Index(name = "idx_onboarding_preferences_user_id", columnList = "user_id"),
+				@Index(name = "idx_onboarding_preferences_favorite_club_id", columnList = "favorite_club_id")
+		}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,8 +49,7 @@ public class OnboardingPreference extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(name = "priority", nullable = false)
-	private Integer priority;
+	// ── 추천 알고리즘에 사용되는 필수 필드 ──
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "favorite_club_id", nullable = false)
@@ -58,17 +59,15 @@ public class OnboardingPreference extends BaseEntity {
 	@Column(name = "cheer_proximity_pref", nullable = false, length = 20)
 	private CheerProximityPref cheerProximityPref = CheerProximityPref.ANY;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "viewpoint", nullable = false, length = 30)
-	private Viewpoint viewpoint;
+	// ── 추천 미사용 - 옵셔널 필드 (입력 안 하면 기본값 ANY/NORMAL) ──
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "seat_height", nullable = false, length = 20)
-	private SeatHeight seatHeight;
+	private SeatHeight seatHeight = SeatHeight.ANY;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "section", nullable = false, length = 20)
-	private Section section;
+	private Section section = Section.ANY;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "seat_position_pref", nullable = false, length = 20)
@@ -98,62 +97,54 @@ public class OnboardingPreference extends BaseEntity {
 
 	@Builder
 	public OnboardingPreference(
-		User user,
-		Integer priority,
-		Club favoriteClub,
-		CheerProximityPref cheerProximityPref,
-		Viewpoint viewpoint,
-		SeatHeight seatHeight,
-		Section section,
-		SeatPositionPref seatPositionPref,
-		EnvironmentPref environmentPref,
-		MoodPref moodPref,
-		ObstructionSensitivity obstructionSensitivity,
-		PriceMode priceMode,
-		Integer priceMin,
-		Integer priceMax
+			User user,
+			Club favoriteClub,
+			CheerProximityPref cheerProximityPref,
+			SeatHeight seatHeight,
+			Section section,
+			SeatPositionPref seatPositionPref,
+			EnvironmentPref environmentPref,
+			MoodPref moodPref,
+			ObstructionSensitivity obstructionSensitivity,
+			PriceMode priceMode,
+			Integer priceMin,
+			Integer priceMax
 	) {
 		this.user = user;
-		this.priority = priority;
 		this.favoriteClub = favoriteClub;
-		update(
-			cheerProximityPref,
-			viewpoint,
-			seatHeight,
-			section,
-			seatPositionPref,
-			environmentPref,
-			moodPref,
-			obstructionSensitivity,
-			priceMode,
-			priceMin,
-			priceMax
-		);
-	}
-
-	public void update(
-		CheerProximityPref cheerProximityPref,
-		Viewpoint viewpoint,
-		SeatHeight seatHeight,
-		Section section,
-		SeatPositionPref seatPositionPref,
-		EnvironmentPref environmentPref,
-		MoodPref moodPref,
-		ObstructionSensitivity obstructionSensitivity,
-		PriceMode priceMode,
-		Integer priceMin,
-		Integer priceMax
-	) {
-		this.cheerProximityPref =
-			cheerProximityPref != null ? cheerProximityPref : CheerProximityPref.ANY;
-		this.viewpoint = viewpoint;
-		this.seatHeight = seatHeight;
-		this.section = section;
+		this.cheerProximityPref = cheerProximityPref != null ? cheerProximityPref : CheerProximityPref.ANY;
+		this.seatHeight = seatHeight != null ? seatHeight : SeatHeight.ANY;
+		this.section = section != null ? section : Section.ANY;
 		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
 		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
 		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
-		this.obstructionSensitivity =
-			obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
+		this.obstructionSensitivity = obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
+		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
+		this.priceMin = priceMin;
+		this.priceMax = priceMax;
+	}
+
+	public void update(
+			Club favoriteClub,
+			CheerProximityPref cheerProximityPref,
+			SeatHeight seatHeight,
+			Section section,
+			SeatPositionPref seatPositionPref,
+			EnvironmentPref environmentPref,
+			MoodPref moodPref,
+			ObstructionSensitivity obstructionSensitivity,
+			PriceMode priceMode,
+			Integer priceMin,
+			Integer priceMax
+	) {
+		this.favoriteClub = favoriteClub;
+		this.cheerProximityPref = cheerProximityPref != null ? cheerProximityPref : CheerProximityPref.ANY;
+		this.seatHeight = seatHeight != null ? seatHeight : SeatHeight.ANY;
+		this.section = section != null ? section : Section.ANY;
+		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
+		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
+		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
+		this.obstructionSensitivity = obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
 		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
 		this.priceMin = priceMin;
 		this.priceMax = priceMax;

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingPreference.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingPreference.java
@@ -1,5 +1,7 @@
 package com.goormgb.be.domain.onboarding.entity;
 
+import java.util.Objects;
+
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.domain.onboarding.enums.EnvironmentPref;
@@ -112,16 +114,8 @@ public class OnboardingPreference extends BaseEntity {
 	) {
 		this.user = user;
 		this.favoriteClub = favoriteClub;
-		this.cheerProximityPref = cheerProximityPref != null ? cheerProximityPref : CheerProximityPref.ANY;
-		this.seatHeight = seatHeight != null ? seatHeight : SeatHeight.ANY;
-		this.section = section != null ? section : Section.ANY;
-		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
-		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
-		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
-		this.obstructionSensitivity = obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
-		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
-		this.priceMin = priceMin;
-		this.priceMax = priceMax;
+		applyOptionalFields(cheerProximityPref, seatHeight, section, seatPositionPref,
+			environmentPref, moodPref, obstructionSensitivity, priceMode, priceMin, priceMax);
 	}
 
 	public void update(
@@ -138,14 +132,30 @@ public class OnboardingPreference extends BaseEntity {
 			Integer priceMax
 	) {
 		this.favoriteClub = favoriteClub;
-		this.cheerProximityPref = cheerProximityPref != null ? cheerProximityPref : CheerProximityPref.ANY;
-		this.seatHeight = seatHeight != null ? seatHeight : SeatHeight.ANY;
-		this.section = section != null ? section : Section.ANY;
-		this.seatPositionPref = seatPositionPref != null ? seatPositionPref : SeatPositionPref.ANY;
-		this.environmentPref = environmentPref != null ? environmentPref : EnvironmentPref.ANY;
-		this.moodPref = moodPref != null ? moodPref : MoodPref.ANY;
-		this.obstructionSensitivity = obstructionSensitivity != null ? obstructionSensitivity : ObstructionSensitivity.NORMAL;
-		this.priceMode = priceMode != null ? priceMode : PriceMode.ANY;
+		applyOptionalFields(cheerProximityPref, seatHeight, section, seatPositionPref,
+			environmentPref, moodPref, obstructionSensitivity, priceMode, priceMin, priceMax);
+	}
+
+	private void applyOptionalFields(
+			CheerProximityPref cheerProximityPref,
+			SeatHeight seatHeight,
+			Section section,
+			SeatPositionPref seatPositionPref,
+			EnvironmentPref environmentPref,
+			MoodPref moodPref,
+			ObstructionSensitivity obstructionSensitivity,
+			PriceMode priceMode,
+			Integer priceMin,
+			Integer priceMax
+	) {
+		this.cheerProximityPref = Objects.requireNonNullElse(cheerProximityPref, CheerProximityPref.ANY);
+		this.seatHeight = Objects.requireNonNullElse(seatHeight, SeatHeight.ANY);
+		this.section = Objects.requireNonNullElse(section, Section.ANY);
+		this.seatPositionPref = Objects.requireNonNullElse(seatPositionPref, SeatPositionPref.ANY);
+		this.environmentPref = Objects.requireNonNullElse(environmentPref, EnvironmentPref.ANY);
+		this.moodPref = Objects.requireNonNullElse(moodPref, MoodPref.ANY);
+		this.obstructionSensitivity = Objects.requireNonNullElse(obstructionSensitivity, ObstructionSensitivity.NORMAL);
+		this.priceMode = Objects.requireNonNullElse(priceMode, PriceMode.ANY);
 		this.priceMin = priceMin;
 		this.priceMax = priceMax;
 	}

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingViewpointPriority.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/entity/OnboardingViewpointPriority.java
@@ -1,0 +1,60 @@
+package com.goormgb.be.domain.onboarding.entity;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "onboarding_viewpoint_priorities",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_viewpoint_priority_user_id_priority",
+			columnNames = {"user_id", "priority"}
+		),
+		@UniqueConstraint(
+			name = "uk_viewpoint_priority_user_id_viewpoint",
+			columnNames = {"user_id", "viewpoint"}
+		)
+	},
+	indexes = {
+		@Index(name = "idx_viewpoint_priority_user_id", columnList = "user_id")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OnboardingViewpointPriority extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "priority", nullable = false)
+	private Integer priority;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "viewpoint", nullable = false, length = 30)
+	private Viewpoint viewpoint;
+
+	@Builder
+	public OnboardingViewpointPriority(User user, Integer priority, Viewpoint viewpoint) {
+		this.user = user;
+		this.priority = priority;
+		this.viewpoint = viewpoint;
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferenceRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferenceRepository.java
@@ -1,6 +1,5 @@
 package com.goormgb.be.domain.onboarding.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,22 +7,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 
 public interface OnboardingPreferenceRepository extends JpaRepository<OnboardingPreference, Long> {
-	List<OnboardingPreference> findAllByUserId(Long userId);
 
-	List<OnboardingPreference> findAllByUserIdOrderByPriorityAsc(Long userId);
+	Optional<OnboardingPreference> findByUserId(Long userId);
 
-	Optional<OnboardingPreference> findByUserIdAndPriority(Long userId, Integer priority);
+	boolean existsByUserId(Long userId);
 
-	Optional<OnboardingPreference> findByUserIdAndViewpoint(Long userId, Viewpoint viewpoint);
+	void deleteByUserId(Long userId);
 
-	boolean existsByUserIdAndPriority(Long userId, Integer priority);
-
-	boolean existsByUserIdAndViewpoint(Long userId, Viewpoint viewpoint);
-
-	void deleteAllByUserId(Long userId);
+	default OnboardingPreference findByUserIdOrThrow(Long userId, ErrorCode errorCode) {
+		return findByUserId(userId).orElseThrow(() -> new CustomException(errorCode));
+	}
 
 	default OnboardingPreference findByIdOrThrow(Long id, ErrorCode errorCode) {
 		return findById(id).orElseThrow(() -> new CustomException(errorCode));

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
@@ -1,9 +1,16 @@
 package com.goormgb.be.domain.onboarding.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
 
 public interface OnboardingPreferredBlockRepository extends JpaRepository<OnboardingPreferredBlock, Long> {
 
+	List<OnboardingPreferredBlock> findAllByUserId(Long userId);
+
+	long countByUserId(Long userId);
+
+	void deleteAllByUserId(Long userId);
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingViewpointPriorityRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingViewpointPriorityRepository.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.domain.onboarding.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+
+public interface OnboardingViewpointPriorityRepository extends JpaRepository<OnboardingViewpointPriority, Long> {
+
+	List<OnboardingViewpointPriority> findAllByUserIdOrderByPriorityAsc(Long userId);
+
+	void deleteAllByUserId(Long userId);
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -31,6 +31,11 @@ public enum ErrorCode {
 	MISSING_REQUIRED_PREFERENCE_FIELD(HttpStatus.BAD_REQUEST, "필수 선호 항목이 누락되었습니다."),
 	PREFERENCE_NOT_FOUND_FOR_UPDATE(HttpStatus.NOT_FOUND, "수정할 선호도 정보를 찾을 수 없습니다."),
 	INVALID_MARKETING_CONSENT(HttpStatus.BAD_REQUEST, "마케팅 동의 정보를 찾을 수 없습니다."),
+	INVALID_VIEWPOINT_PRIORITY_COUNT(HttpStatus.BAD_REQUEST, "선호하는 관람 포인트는 최소 1개에서 최대 3개까지 선택해야 합니다."),
+	INVALID_VIEWPOINT_PRIORITY_SEQUENCE(HttpStatus.BAD_REQUEST, "선호하는 관람 포인트의 우선순위는 1부터 연속이어야 합니다."),
+	INVALID_PREFERRED_BLOCK_COUNT(HttpStatus.BAD_REQUEST, "선호 블럭은 최소 1개에서 최대 10개까지 선택해야 합니다."),
+	DUPLICATE_PREFERRED_BLOCK(HttpStatus.BAD_REQUEST, "선호 블럭이 중복됩니다."),
+	PREFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "온보딩 선호도 정보를 찾을 수 없습니다."),
 
 	// Auth
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## 🔧 작업 내용
- 추천 알고리즘의 데이터 접근 패턴(블럭 우선순위 → 뷰포인트 → 응원 근접도)에 최적화된 테이블 설계
=>  온보딩 선호도를 단일 테이블에서 3개 테이블 
(preferences, viewpoint_priorities, preferred_blocks)로 정규화

- 프론트엔드에서 사용하는 기존 API `preferences[]` 배열 구조를 유지하면서 백엔드만 정규화 구조로 전환

## 🧩 구현 상세
### common-core 엔티티 재설계
- `OnboardingPreference`: priority/viewpoint 제거,
   user_id UNIQUE(유저당 1건), 옵셔널 필드에 기본값 + NOT NULL 적용
- `OnboardingViewpointPriority`: 신규 엔티티
(user_id, priority 1~3, viewpoint)
  - 온보딩 ErrorCode 5개 추가

### Order-Core API 재설계
- `OnboardingPreferenceItemDto` 신규 생성:
  preferences[] 배열 아이템 (priority, viewpoint + 옵셔널 필드)
- Request DTO: favoriteClubId, cheerProximityPref, preferredBlockIds 상위 필드 추가
- Response DTO: 3개 테이블 데이터를 기존 preferences[] 배열 형태로 재조합 (프론트 호환)
- Service: preferences[0]에서 옵셔널 필드 추출 →
  preferences 테이블, 각 항목의 priority/viewpoint →
  viewpoint_priorities 테이블
- 검증: 뷰포인트 1~3개 연속성, 블럭 1~10개 중복, 가격 범위 등

  ### 테이블 구조 변경
  | AS-IS | TO-BE |
  |---|---|
  | onboarding_preferences (N건/유저, priority별 1건)
  | onboarding_preferences (1건/유저, 옵셔널 필드만) |
  | - | onboarding_viewpoint_priorities (1~3건/유저) |
  | onboarding_preferred_blocks (변경 없음) |
  onboarding_preferred_blocks (변경 없음) |

  ### 📌 관련 Jira Issue
  - GRGB-232

## 🧪 테스트 방법
- `GET /onboarding/preferences` — preferences[] 배열 + preferredBlockIds 정상 응답
- `POST /onboarding/preferences` — 3개 테이블 동시 저장, 이미 온보딩 완료 시 409
- `PUT /onboarding/preferences` — viewpoint_priorities/preferred_blocks delete+insert 확인
- 존재하지 않는 사용자 404 에러 케이스
- 테스트 Fixture를 새 DTO 구조에 맞게 전면 재작성 완료

## ❗ 참고 사항
- 프론트엔드 변경 최소화: `preferences[]` 배열 구조 유지, 상위에 `favoriteClubId`, `cheerProximityPref`, `preferredBlockIds` 필드만 추가
- DB 마이그레이션 스크립트는 후속 작업에서 진행 예정
- Seat 모듈 블럭 조회 API(`GET /blocks`)는 별도 PR로 분리 예정
- 쳐내야될 작업이 많아서, 도메인 단위로 크게크게 PR 올릴 예정입니다! 그에 맞게 커밋은 최대한 쪼개볼게요
----
### 세줄요약
- 온보딩 수정된 기획대로 전부 추가 및 수정됨
- 다만 추천 알고리즘에 온보딩 데이터 사용하기 쉽게 엔티티 구조랑 테이블 몇개 분리함
- 프론트에서 최대한 API 그대로 사용가능하도록 설계(여기랑 seat 블럭 조회하는 부분 작업하느라 시간이 오래 걸렸네요..)
