### PR TITLE
feat(seat): 온보딩용 블럭 조회 API와 경기장 좌석 시드 데이터 추가 [GRGB-239]

### DIFF
--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -45,10 +45,16 @@ jobs:
           ISSUE_KEY: ${{ steps.jira.outputs.key }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64)
+          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')
+
+          echo "Jira base url: $JIRA_BASE_URL"
+          echo "Issue key: $ISSUE_KEY"
+          echo "PR URL: $PR_URL"
 
           # 리뷰 중(In Review) transition id = 31
           REVIEW_ID="31"
+
+          echo "=== Transition start ==="
 
           curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
@@ -57,12 +63,18 @@ jobs:
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
             -d "{\"transition\":{\"id\":\"$REVIEW_ID\"}}"
 
+          echo "=== Transition success ==="
+
+          echo "=== Comment start ==="
+
           curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/comment" \
             -d "{\"body\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"PR 링크: $PR_URL\"}]}]}}"
+
+          echo "=== Comment success ==="
 
       # PR이 merge 되어 closed 되면 Jira 상태를 "완료 (Done)" 로 전환
       - name: Move to Done on merge
@@ -73,10 +85,15 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           ISSUE_KEY: ${{ steps.jira.outputs.key }}
         run: |
-          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64)
+          AUTH=$(printf "%s:%s" "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64 | tr -d '\n')
+
+          echo "Jira base url: $JIRA_BASE_URL"
+          echo "Issue key: $ISSUE_KEY"
 
           # 완료 (Done) transition id = 41
           DONE_ID="41"
+
+          echo "=== Done transition start ==="
 
           curl --fail -L -s -X POST \
             -H "Authorization: Basic $AUTH" \
@@ -84,3 +101,5 @@ jobs:
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
             -d "{\"transition\":{\"id\":\"$DONE_ID\"}}"
+
+          echo "=== Done transition success ==="

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 .gradle/
 build/
 !gradle/wrapper/gradle-wrapper.jar
+.gradle-user-home/
 
 ### Spring ###
 application-local.properties

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 			"/order/v3/api-docs",
 			"/recommendation/v3/api-docs",
 			"/actuator",
+			"/seat/blocks",
 			"/order/clubs",
 			"/order/matches"
 	);

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
@@ -90,6 +90,7 @@ class JwtAuthenticationFilterTest {
 				"/auth/v3/api-docs",
 				"/queue/v3/api-docs",
 				"/seat/v3/api-docs",
+				"/seat/blocks",
 				"/order/v3/api-docs",
 				"/recommendation/v3/api-docs",
 				"/actuator",

--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'org.springframework.boot'
 dependencies {
     implementation project(':common-core')
     testImplementation(testFixtures(project(':common-core')))
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/entity/Area.java
@@ -1,6 +1,5 @@
 package com.goormgb.be.seat.area.entity;
 
-import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.seat.area.enums.AreaCode;
 
@@ -8,9 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -22,16 +18,12 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "areas",
 	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_area_stadium_code", columnNames = {"stadium_id", "code"})
+		@UniqueConstraint(name = "uk_area_code", columnNames = {"code"})
 	}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Area extends BaseEntity {
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "stadium_id", nullable = false)
-	private Stadium stadium;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "code", nullable = false, length = 50)
@@ -42,11 +34,9 @@ public class Area extends BaseEntity {
 
 	@Builder
 	public Area(
-		Stadium stadium,
 		AreaCode code,
 		String name
 	) {
-		this.stadium = stadium;
 		this.code = code;
 		this.name = name;
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/area/enums/AreaCode.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/area/enums/AreaCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AreaCode {
 	HOME("1루(홈)"),
 	AWAY("3루(어웨이)"),
-	PREMIUM("프리미엄");
+	OUTFIELD("외야"),
+	CENTER("중앙");
 
 	private final String description;
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/block/controller/BlockController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/controller/BlockController.java
@@ -1,0 +1,42 @@
+package com.goormgb.be.seat.block.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.seat.block.dto.BlockListResponse;
+import com.goormgb.be.seat.block.service.BlockService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Block", description = "경기장 블럭 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/blocks")
+public class BlockController {
+
+	private final BlockService blockService;
+
+	@Operation(
+		summary = "전체 블럭 목록 조회",
+		description = """
+			경기장의 전체 블럭 목록을 조회합니다.
+			온보딩 시 선호 블럭(preferredBlockIds) 선택에 사용됩니다.
+			- 내야(Infield): 101 ~ 334번대 구역 및 특수석
+			- 외야(Outfield): 401 ~ 422번대 구역 (그린석)
+			"""
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요")
+	})
+	@GetMapping
+	public ApiResult<BlockListResponse> getAllBlocks() {
+		return ApiResult.ok(blockService.getAllBlocks());
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
@@ -7,7 +7,6 @@ public record BlockItemDto(
 	Long blockId,
 	String blockCode,
 	String sectionName,
-	String sectionColor,
 	String areaName,
 	Viewpoint viewpoint
 ) {
@@ -17,7 +16,6 @@ public record BlockItemDto(
 			block.getId(),
 			block.getBlockCode(),
 			block.getSection().getName(),
-			block.getSection().getColorHex(),
 			block.getArea().getName(),
 			block.getViewpoint()
 		);

--- a/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.seat.block.dto;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.seat.block.entity.Block;
+
+public record BlockItemDto(
+	Long blockId,
+	String blockCode,
+	String sectionName,
+	String sectionColor,
+	String areaName,
+	Viewpoint viewpoint
+) {
+
+	public static BlockItemDto from(Block block) {
+		return new BlockItemDto(
+			block.getId(),
+			block.getBlockCode(),
+			block.getSection().getName(),
+			block.getSection().getColorHex(),
+			block.getArea().getName(),
+			block.getViewpoint()
+		);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockListResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockListResponse.java
@@ -1,0 +1,16 @@
+package com.goormgb.be.seat.block.dto;
+
+import java.util.List;
+
+import com.goormgb.be.seat.block.entity.Block;
+
+public record BlockListResponse(
+	List<BlockItemDto> blocks
+) {
+
+	public static BlockListResponse from(List<Block> blocks) {
+		return new BlockListResponse(
+			blocks.stream().map(BlockItemDto::from).toList()
+		);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
@@ -2,6 +2,7 @@ package com.goormgb.be.seat.block.entity;
 
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.section.entity.Section;
 
 import jakarta.persistence.Column;
@@ -30,6 +31,7 @@ import lombok.NoArgsConstructor;
 	},
 	indexes = {
 		@Index(name = "idx_block_section_id", columnList = "section_id"),
+		@Index(name = "idx_block_area_id", columnList = "area_id"),
 		@Index(name = "idx_block_viewpoint", columnList = "viewpoint"),
 		@Index(name = "idx_block_home_cheer_rank", columnList = "home_cheer_rank"),
 		@Index(name = "idx_block_away_cheer_rank", columnList = "away_cheer_rank")
@@ -38,6 +40,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Block extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "area_id", nullable = false)
+	private Area area;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "section_id", nullable = false)
@@ -58,12 +64,14 @@ public class Block extends BaseEntity {
 
 	@Builder
 	public Block(
+		Area area,
 		Section section,
 		String blockCode,
 		Viewpoint viewpoint,
 		Integer homeCheerRank,
 		Integer awayCheerRank
 	) {
+		this.area = area;
 		this.section = section;
 		this.blockCode = blockCode;
 		this.viewpoint = viewpoint;

--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -1,8 +1,14 @@
 package com.goormgb.be.seat.block.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.goormgb.be.seat.block.entity.Block;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
+
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a ORDER BY b.blockCode ASC")
+	List<Block> findAllWithSectionAndArea();
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/block/service/BlockService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/service/BlockService.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.seat.block.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.seat.block.dto.BlockListResponse;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+	private final BlockRepository blockRepository;
+
+	@Transactional(readOnly = true)
+	public BlockListResponse getAllBlocks() {
+		var blocks = blockRepository.findAllWithSectionAndArea();
+		return BlockListResponse.from(blocks);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -1,0 +1,217 @@
+package com.goormgb.be.seat.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.area.repository.AreaRepository;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.seat.section.repository.SectionRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 잠실야구장 정적 좌석 구조 시드 데이터.
+ * areas → sections → blocks 순서로 삽입하며, 이미 데이터가 존재하면 스킵합니다.
+ */
+@Slf4j
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class SeatDataInitializer implements CommandLineRunner {
+
+	private final AreaRepository areaRepository;
+	private final SectionRepository sectionRepository;
+	private final BlockRepository blockRepository;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		if (blockRepository.count() > 0) {
+			log.info("[SeatDataInitializer] 블럭 데이터 이미 존재 - 시드 스킵");
+			return;
+		}
+
+		log.info("[SeatDataInitializer] 잠실야구장 좌석 구조 시드 데이터 삽입 시작");
+
+		// ── 1. Areas ──
+		Area home = saveArea(AreaCode.HOME, "1루(홈)");
+		Area away = saveArea(AreaCode.AWAY, "3루(어웨이)");
+		Area outfield = saveArea(AreaCode.OUTFIELD, "외야");
+		Area center = saveArea(AreaCode.CENTER, "중앙");
+
+		// ── 2. Sections ──
+		// 1루(홈) 섹션
+		Section homePurple = saveSection(home, SectionCode.PURPLE, "퍼플석(테이블석)", "#8B5CF6");
+		Section homeExciting = saveSection(home, SectionCode.EXCITING, "익사이팅존", "#F59E0B");
+		Section homeBlue = saveSection(home, SectionCode.BLUE, "블루석", "#3B82F6");
+		Section homeOrange = saveSection(home, SectionCode.ORANGE, "오렌지석", "#F97316");
+		Section homeRed = saveSection(home, SectionCode.RED, "레드석", "#EF4444");
+		Section homeNavy = saveSection(home, SectionCode.NAVY, "네이비석", "#1E3A5F");
+
+		// 3루(어웨이) 섹션
+		Section awayPurple = saveSection(away, SectionCode.PURPLE, "퍼플석(테이블석)", "#8B5CF6");
+		Section awayExciting = saveSection(away, SectionCode.EXCITING, "익사이팅존", "#F59E0B");
+		Section awayBlue = saveSection(away, SectionCode.BLUE, "블루석", "#3B82F6");
+		Section awayOrange = saveSection(away, SectionCode.ORANGE, "오렌지석", "#F97316");
+		Section awayRed = saveSection(away, SectionCode.RED, "레드석", "#EF4444");
+		Section awayNavy = saveSection(away, SectionCode.NAVY, "네이비석", "#1E3A5F");
+
+		// 외야 섹션
+		Section green = saveSection(outfield, SectionCode.GREEN, "그린석(외야석)", "#22C55E");
+
+		// 중앙 섹션
+		Section premium = saveSection(center, SectionCode.PREMIUM, "테라존(중앙 프리미엄석)", "#D4AF37");
+
+		// ── 3. Blocks ──
+
+		// ─── 중앙 프리미엄석 ───
+		saveBlock(center, premium, "CP", Viewpoint.CENTER, 50, 50);
+
+		// ─── 익사이팅존 ───
+		saveBlock(home, homeExciting, "EX-1", Viewpoint.INFIELD_1B, 30, 40);
+		saveBlock(away, awayExciting, "EX-3", Viewpoint.INFIELD_3B, 40, 30);
+
+		// ─── 1루(홈) 오렌지석 (응원석) 205~208 ───
+		int rank = 1;
+		for (int i = 205; i <= 208; i++) {
+			saveBlock(home, homeOrange, String.valueOf(i),
+					Viewpoint.INFIELD_1B, rank++, 80 + (i - 205));
+		}
+
+		// ─── 3루(어웨이) 오렌지석 (응원석) 219~222 ───
+		rank = 1;
+		for (int i = 219; i <= 222; i++) {
+			saveBlock(away, awayOrange, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 80 + (i - 219), rank++);
+		}
+
+		// ─── 1루(홈) 퍼플석 (테이블석) 110~113 ───
+		for (int i = 110; i <= 113; i++) {
+			saveBlock(home, homePurple, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 10 + (i - 110), 60 + (i - 110));
+		}
+
+		// ─── 3루(어웨이) 퍼플석 (테이블석) 212~215 ───
+		for (int i = 212; i <= 215; i++) {
+			saveBlock(away, awayPurple, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 60 + (i - 212), 10 + (i - 212));
+		}
+
+		// ─── 1루(홈) 블루석 114~116 ───
+		for (int i = 114; i <= 116; i++) {
+			saveBlock(home, homeBlue, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 14 + (i - 114), 55 + (i - 114));
+		}
+
+		// ─── 1루(홈) 블루석 216~218 (2층) ───
+		for (int i = 216; i <= 218; i++) {
+			saveBlock(home, homeBlue, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 5 + (i - 216), 70 + (i - 216));
+		}
+
+		// ─── 3루(어웨이) 블루석 107~109 ───
+		for (int i = 107; i <= 109; i++) {
+			saveBlock(away, awayBlue, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 55 + (i - 107), 14 + (i - 107));
+		}
+
+		// ─── 3루(어웨이) 블루석 209~211 (2층) ───
+		for (int i = 209; i <= 211; i++) {
+			saveBlock(away, awayBlue, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 70 + (i - 209), 5 + (i - 209));
+		}
+
+		// ─── 1루(홈) 레드석 117~122 ───
+		for (int i = 117; i <= 122; i++) {
+			saveBlock(home, homeRed, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 17 + (i - 117), 45 + (i - 117));
+		}
+
+		// ─── 1루(홈) 레드석 223~226 (2층) ───
+		for (int i = 223; i <= 226; i++) {
+			saveBlock(home, homeRed, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 8 + (i - 223), 65 + (i - 223));
+		}
+
+		// ─── 3루(어웨이) 레드석 101~106 ───
+		for (int i = 101; i <= 106; i++) {
+			saveBlock(away, awayRed, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 45 + (i - 101), 17 + (i - 101));
+		}
+
+		// ─── 3루(어웨이) 레드석 201~204 (2층) ───
+		for (int i = 201; i <= 204; i++) {
+			saveBlock(away, awayRed, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 65 + (i - 201), 8 + (i - 201));
+		}
+
+		// ─── 1루(홈) 네이비석 301~317 ───
+		for (int i = 301; i <= 317; i++) {
+			saveBlock(home, homeNavy, String.valueOf(i),
+					Viewpoint.INFIELD_1B, 23 + (i - 301), 35 + (i - 301));
+		}
+
+		// ─── 3루(어웨이) 네이비석 318~334 ───
+		for (int i = 318; i <= 334; i++) {
+			saveBlock(away, awayNavy, String.valueOf(i),
+					Viewpoint.INFIELD_3B, 35 + (i - 318), 23 + (i - 318));
+		}
+
+		// ─── 외야 그린석 401~407 (1루 방향 → OUTFIELD_R) ───
+		for (int i = 401; i <= 407; i++) {
+			saveBlock(outfield, green, String.valueOf(i),
+					Viewpoint.OUTFIELD_R, 60 + (i - 401), 90 + (i - 401));
+		}
+
+		// ─── 외야 그린석 408~415 (중앙 → OUTFIELD_C) ───
+		for (int i = 408; i <= 415; i++) {
+			saveBlock(outfield, green, String.valueOf(i),
+					Viewpoint.OUTFIELD_C, 70 + (i - 408), 70 + (i - 408));
+		}
+
+		// ─── 외야 그린석 416~422 (3루 방향 → OUTFIELD_L) ───
+		for (int i = 416; i <= 422; i++) {
+			saveBlock(outfield, green, String.valueOf(i),
+					Viewpoint.OUTFIELD_L, 90 + (i - 416), 60 + (i - 416));
+		}
+
+		log.info("[SeatDataInitializer] 시드 데이터 삽입 완료 - 블럭 {}개", blockRepository.count());
+	}
+
+	private Area saveArea(AreaCode code, String name) {
+		return areaRepository.save(Area.builder()
+				.code(code)
+				.name(name)
+				.build());
+	}
+
+	private Section saveSection(Area area, SectionCode code, String name, String colorHex) {
+		return sectionRepository.save(Section.builder()
+				.area(area)
+				.code(code)
+				.name(name)
+				.colorHex(colorHex)
+				.build());
+	}
+
+	private void saveBlock(Area area, Section section,
+			String blockCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
+		blockRepository.save(Block.builder()
+				.area(area)
+				.section(section)
+				.blockCode(blockCode)
+				.viewpoint(viewpoint)
+				.homeCheerRank(homeCheerRank)
+				.awayCheerRank(awayCheerRank)
+				.build());
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -50,26 +50,26 @@ public class SeatDataInitializer implements CommandLineRunner {
 
 		// ── 2. Sections ──
 		// 1루(홈) 섹션
-		Section homePurple = saveSection(home, SectionCode.PURPLE, "퍼플석(테이블석)", "#8B5CF6");
-		Section homeExciting = saveSection(home, SectionCode.EXCITING, "익사이팅존", "#F59E0B");
-		Section homeBlue = saveSection(home, SectionCode.BLUE, "블루석", "#3B82F6");
-		Section homeOrange = saveSection(home, SectionCode.ORANGE, "오렌지석", "#F97316");
-		Section homeRed = saveSection(home, SectionCode.RED, "레드석", "#EF4444");
-		Section homeNavy = saveSection(home, SectionCode.NAVY, "네이비석", "#1E3A5F");
+		Section homePurple = saveSection(home, SectionCode.PURPLE, "퍼플석(테이블석)");
+		Section homeExciting = saveSection(home, SectionCode.EXCITING, "익사이팅존");
+		Section homeBlue = saveSection(home, SectionCode.BLUE, "블루석");
+		Section homeOrange = saveSection(home, SectionCode.ORANGE, "오렌지석");
+		Section homeRed = saveSection(home, SectionCode.RED, "레드석");
+		Section homeNavy = saveSection(home, SectionCode.NAVY, "네이비석");
 
 		// 3루(어웨이) 섹션
-		Section awayPurple = saveSection(away, SectionCode.PURPLE, "퍼플석(테이블석)", "#8B5CF6");
-		Section awayExciting = saveSection(away, SectionCode.EXCITING, "익사이팅존", "#F59E0B");
-		Section awayBlue = saveSection(away, SectionCode.BLUE, "블루석", "#3B82F6");
-		Section awayOrange = saveSection(away, SectionCode.ORANGE, "오렌지석", "#F97316");
-		Section awayRed = saveSection(away, SectionCode.RED, "레드석", "#EF4444");
-		Section awayNavy = saveSection(away, SectionCode.NAVY, "네이비석", "#1E3A5F");
+		Section awayPurple = saveSection(away, SectionCode.PURPLE, "퍼플석(테이블석)");
+		Section awayExciting = saveSection(away, SectionCode.EXCITING, "익사이팅존");
+		Section awayBlue = saveSection(away, SectionCode.BLUE, "블루석");
+		Section awayOrange = saveSection(away, SectionCode.ORANGE, "오렌지석");
+		Section awayRed = saveSection(away, SectionCode.RED, "레드석");
+		Section awayNavy = saveSection(away, SectionCode.NAVY, "네이비석");
 
 		// 외야 섹션
-		Section green = saveSection(outfield, SectionCode.GREEN, "그린석(외야석)", "#22C55E");
+		Section green = saveSection(outfield, SectionCode.GREEN, "그린석(외야석)");
 
 		// 중앙 섹션
-		Section premium = saveSection(center, SectionCode.PREMIUM, "테라존(중앙 프리미엄석)", "#D4AF37");
+		Section premium = saveSection(center, SectionCode.PREMIUM, "테라존(중앙 프리미엄석)");
 
 		// ── 3. Blocks ──
 
@@ -194,12 +194,11 @@ public class SeatDataInitializer implements CommandLineRunner {
 				.build());
 	}
 
-	private Section saveSection(Area area, SectionCode code, String name, String colorHex) {
+	private Section saveSection(Area area, SectionCode code, String name) {
 		return sectionRepository.save(Section.builder()
 				.area(area)
 				.code(code)
 				.name(name)
-				.colorHex(colorHex)
 				.build());
 	}
 

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(
+								"/blocks",
 								"/swagger-ui/**",
 								"/swagger-ui.html",
 								"/swagger-resources/**",

--- a/Seat/src/main/java/com/goormgb/be/seat/section/entity/Section.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/entity/Section.java
@@ -47,19 +47,14 @@ public class Section extends BaseEntity {
 	@Column(name = "name", nullable = false, length = 50)
 	private String name;
 
-	@Column(name = "color_hex", length = 10)
-	private String colorHex;
-
 	@Builder
 	public Section(
 		Area area,
 		SectionCode code,
-		String name,
-		String colorHex
+		String name
 	) {
 		this.area = area;
 		this.code = code;
 		this.name = name;
-		this.colorHex = colorHex;
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/block/controller/BlockControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/controller/BlockControllerTest.java
@@ -1,0 +1,57 @@
+package com.goormgb.be.seat.block.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.goormgb.be.seat.block.service.BlockService;
+import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.support.WebMvcTestSupport;
+
+@WebMvcTest(controllers = BlockController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class BlockControllerTest extends WebMvcTestSupport {
+
+	@MockitoBean
+	private BlockService blockService;
+
+	@Test
+	@DisplayName("GET /blocks - 전체 블럭 목록 조회 성공")
+	void 전체_블럭_목록_조회_성공() throws Exception {
+		// given
+		given(blockService.getAllBlocks()).willReturn(BlockFixture.blockListResponse());
+
+		// when & then
+		mockMvc.perform(get("/blocks"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.blocks").isArray())
+			.andExpect(jsonPath("$.data.blocks.length()").value(3))
+			.andExpect(jsonPath("$.data.blocks[0].blockCode").value("CP"))
+			.andExpect(jsonPath("$.data.blocks[0].sectionName").value("테라존(중앙 프리미엄석)"))
+			.andExpect(jsonPath("$.data.blocks[0].sectionColor").value("#D4AF37"))
+			.andExpect(jsonPath("$.data.blocks[0].areaName").value("중앙"))
+			.andExpect(jsonPath("$.data.blocks[0].viewpoint").value("CENTER"));
+	}
+
+	@Test
+	@DisplayName("GET /blocks - 블럭이 없으면 빈 배열을 반환한다")
+	void 전체_블럭_목록_없음() throws Exception {
+		// given
+		given(blockService.getAllBlocks()).willReturn(BlockFixture.emptyBlockListResponse());
+
+		// when & then
+		mockMvc.perform(get("/blocks"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.data.blocks").isArray())
+			.andExpect(jsonPath("$.data.blocks.length()").value(0));
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/block/controller/BlockControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/controller/BlockControllerTest.java
@@ -36,7 +36,6 @@ class BlockControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.data.blocks.length()").value(3))
 			.andExpect(jsonPath("$.data.blocks[0].blockCode").value("CP"))
 			.andExpect(jsonPath("$.data.blocks[0].sectionName").value("테라존(중앙 프리미엄석)"))
-			.andExpect(jsonPath("$.data.blocks[0].sectionColor").value("#D4AF37"))
 			.andExpect(jsonPath("$.data.blocks[0].areaName").value("중앙"))
 			.andExpect(jsonPath("$.data.blocks[0].viewpoint").value("CENTER"));
 	}

--- a/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
@@ -36,7 +36,6 @@ class BlockServiceTest {
 		assertThat(result.blocks()).hasSize(3);
 		assertThat(result.blocks().get(0).blockCode()).isEqualTo("CP");
 		assertThat(result.blocks().get(0).sectionName()).isEqualTo("테라존(중앙 프리미엄석)");
-		assertThat(result.blocks().get(0).sectionColor()).isEqualTo("#D4AF37");
 		assertThat(result.blocks().get(0).areaName()).isEqualTo("중앙");
 		assertThat(result.blocks().get(0).viewpoint()).isEqualTo(BlockFixture.cpBlock().getViewpoint());
 		then(blockRepository).should().findAllWithSectionAndArea();

--- a/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
@@ -1,0 +1,58 @@
+package com.goormgb.be.seat.block.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.block.dto.BlockListResponse;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.fixture.BlockFixture;
+
+@ExtendWith(MockitoExtension.class)
+class BlockServiceTest {
+
+	@Mock
+	private BlockRepository blockRepository;
+
+	@InjectMocks
+	private BlockService blockService;
+
+	@Test
+	@DisplayName("전체 블럭 목록 조회 시 엔티티를 응답 DTO로 변환한다")
+	void 전체_블럭_목록_조회_성공() {
+		// given
+		given(blockRepository.findAllWithSectionAndArea()).willReturn(BlockFixture.allBlocks());
+
+		// when
+		BlockListResponse result = blockService.getAllBlocks();
+
+		// then
+		assertThat(result.blocks()).hasSize(3);
+		assertThat(result.blocks().get(0).blockCode()).isEqualTo("CP");
+		assertThat(result.blocks().get(0).sectionName()).isEqualTo("테라존(중앙 프리미엄석)");
+		assertThat(result.blocks().get(0).sectionColor()).isEqualTo("#D4AF37");
+		assertThat(result.blocks().get(0).areaName()).isEqualTo("중앙");
+		assertThat(result.blocks().get(0).viewpoint()).isEqualTo(BlockFixture.cpBlock().getViewpoint());
+		then(blockRepository).should().findAllWithSectionAndArea();
+	}
+
+	@Test
+	@DisplayName("전체 블럭이 없으면 빈 응답을 반환한다")
+	void 전체_블럭_목록_없음() {
+		// given
+		given(blockRepository.findAllWithSectionAndArea()).willReturn(java.util.List.of());
+
+		// when
+		BlockListResponse result = blockService.getAllBlocks();
+
+		// then
+		assertThat(result.blocks()).isEmpty();
+		then(blockRepository).should().findAllWithSectionAndArea();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/config/SeatDataInitializerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/config/SeatDataInitializerTest.java
@@ -1,0 +1,122 @@
+package com.goormgb.be.seat.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.area.repository.AreaRepository;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.seat.section.repository.SectionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatDataInitializerTest {
+
+	@Mock
+	private AreaRepository areaRepository;
+
+	@Mock
+	private SectionRepository sectionRepository;
+
+	@Mock
+	private BlockRepository blockRepository;
+
+	@InjectMocks
+	private SeatDataInitializer seatDataInitializer;
+
+	@Test
+	@DisplayName("블럭 데이터가 이미 존재하면 시드 작업을 스킵한다")
+	void 블럭_데이터_존재시_시드_스킵() throws Exception {
+		// given
+		given(blockRepository.count()).willReturn(1L);
+
+		// when
+		seatDataInitializer.run();
+
+		// then
+		then(areaRepository).shouldHaveNoInteractions();
+		then(sectionRepository).shouldHaveNoInteractions();
+		then(blockRepository).should(never()).save(any(Block.class));
+	}
+
+	@Test
+	@DisplayName("블럭 데이터가 없으면 잠실 좌석 구조를 저장한다")
+	void 블럭_데이터_없으면_시드_저장() throws Exception {
+		// given
+		given(blockRepository.count()).willReturn(0L, 107L);
+		given(areaRepository.save(any(Area.class))).willAnswer(invocation -> invocation.getArgument(0));
+		given(sectionRepository.save(any(Section.class))).willAnswer(invocation -> invocation.getArgument(0));
+		given(blockRepository.save(any(Block.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+		ArgumentCaptor<Area> areaCaptor = ArgumentCaptor.forClass(Area.class);
+		ArgumentCaptor<Section> sectionCaptor = ArgumentCaptor.forClass(Section.class);
+		ArgumentCaptor<Block> blockCaptor = ArgumentCaptor.forClass(Block.class);
+
+		// when
+		seatDataInitializer.run();
+
+		// then
+		then(areaRepository).should(times(4)).save(areaCaptor.capture());
+		then(sectionRepository).should(times(14)).save(sectionCaptor.capture());
+		then(blockRepository).should(times(107)).save(blockCaptor.capture());
+		then(blockRepository).should(times(2)).count();
+
+		assertThat(areaCaptor.getAllValues())
+			.extracting(Area::getCode)
+			.containsExactly(AreaCode.HOME, AreaCode.AWAY, AreaCode.OUTFIELD, AreaCode.CENTER);
+
+		assertThat(sectionCaptor.getAllValues())
+			.extracting(Section::getCode)
+			.contains(SectionCode.PREMIUM, SectionCode.GREEN, SectionCode.ORANGE, SectionCode.NAVY);
+
+		List<Block> savedBlocks = blockCaptor.getAllValues();
+		assertThat(savedBlocks)
+			.extracting(Block::getBlockCode)
+			.contains("CP", "205", "219", "408", "422");
+
+		Block premiumBlock = savedBlocks.stream()
+			.filter(block -> "CP".equals(block.getBlockCode()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(premiumBlock.getArea().getCode()).isEqualTo(AreaCode.CENTER);
+		assertThat(premiumBlock.getSection().getCode()).isEqualTo(SectionCode.PREMIUM);
+		assertThat(premiumBlock.getViewpoint()).isEqualTo(Viewpoint.CENTER);
+		assertThat(premiumBlock.getHomeCheerRank()).isEqualTo(50);
+		assertThat(premiumBlock.getAwayCheerRank()).isEqualTo(50);
+
+		Block homeCheerBlock = savedBlocks.stream()
+			.filter(block -> "205".equals(block.getBlockCode()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(homeCheerBlock.getArea().getCode()).isEqualTo(AreaCode.HOME);
+		assertThat(homeCheerBlock.getSection().getCode()).isEqualTo(SectionCode.ORANGE);
+		assertThat(homeCheerBlock.getViewpoint()).isEqualTo(Viewpoint.INFIELD_1B);
+		assertThat(homeCheerBlock.getHomeCheerRank()).isEqualTo(1);
+		assertThat(homeCheerBlock.getAwayCheerRank()).isEqualTo(80);
+
+		Block outfieldCenterBlock = savedBlocks.stream()
+			.filter(block -> "408".equals(block.getBlockCode()))
+			.findFirst()
+			.orElseThrow();
+		assertThat(outfieldCenterBlock.getArea().getCode()).isEqualTo(AreaCode.OUTFIELD);
+		assertThat(outfieldCenterBlock.getSection().getCode()).isEqualTo(SectionCode.GREEN);
+		assertThat(outfieldCenterBlock.getViewpoint()).isEqualTo(Viewpoint.OUTFIELD_C);
+		assertThat(outfieldCenterBlock.getHomeCheerRank()).isEqualTo(70);
+		assertThat(outfieldCenterBlock.getAwayCheerRank()).isEqualTo(70);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
@@ -1,0 +1,121 @@
+package com.goormgb.be.seat.fixture;
+
+import java.util.List;
+
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.dto.BlockItemDto;
+import com.goormgb.be.seat.block.dto.BlockListResponse;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+
+public final class BlockFixture {
+
+	private BlockFixture() {
+	}
+
+	public static Area centerArea() {
+		return Area.builder()
+			.code(AreaCode.CENTER)
+			.name("중앙")
+			.build();
+	}
+
+	public static Area homeArea() {
+		return Area.builder()
+			.code(AreaCode.HOME)
+			.name("1루(홈)")
+			.build();
+	}
+
+	public static Area outfieldArea() {
+		return Area.builder()
+			.code(AreaCode.OUTFIELD)
+			.name("외야")
+			.build();
+	}
+
+	public static Section premiumSection(Area area) {
+		return Section.builder()
+			.area(area)
+			.code(SectionCode.PREMIUM)
+			.name("테라존(중앙 프리미엄석)")
+			.colorHex("#D4AF37")
+			.build();
+	}
+
+	public static Section orangeSection(Area area) {
+		return Section.builder()
+			.area(area)
+			.code(SectionCode.ORANGE)
+			.name("오렌지석")
+			.colorHex("#F97316")
+			.build();
+	}
+
+	public static Section greenSection(Area area) {
+		return Section.builder()
+			.area(area)
+			.code(SectionCode.GREEN)
+			.name("그린석(외야석)")
+			.colorHex("#22C55E")
+			.build();
+	}
+
+	public static Block cpBlock() {
+		Area area = centerArea();
+		Section section = premiumSection(area);
+		return Block.builder()
+			.area(area)
+			.section(section)
+			.blockCode("CP")
+			.viewpoint(Viewpoint.CENTER)
+			.homeCheerRank(50)
+			.awayCheerRank(50)
+			.build();
+	}
+
+	public static Block homeOrangeBlock() {
+		Area area = homeArea();
+		Section section = orangeSection(area);
+		return Block.builder()
+			.area(area)
+			.section(section)
+			.blockCode("205")
+			.viewpoint(Viewpoint.INFIELD_1B)
+			.homeCheerRank(1)
+			.awayCheerRank(81)
+			.build();
+	}
+
+	public static Block outfieldBlock() {
+		Area area = outfieldArea();
+		Section section = greenSection(area);
+		return Block.builder()
+			.area(area)
+			.section(section)
+			.blockCode("408")
+			.viewpoint(Viewpoint.OUTFIELD_C)
+			.homeCheerRank(70)
+			.awayCheerRank(70)
+			.build();
+	}
+
+	public static List<Block> allBlocks() {
+		return List.of(cpBlock(), homeOrangeBlock(), outfieldBlock());
+	}
+
+	public static BlockListResponse blockListResponse() {
+		return BlockListResponse.from(allBlocks());
+	}
+
+	public static BlockListResponse emptyBlockListResponse() {
+		return new BlockListResponse(List.of());
+	}
+
+	public static BlockItemDto cpBlockItemDto() {
+		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "#D4AF37", "중앙", Viewpoint.CENTER);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
@@ -42,7 +42,6 @@ public final class BlockFixture {
 			.area(area)
 			.code(SectionCode.PREMIUM)
 			.name("테라존(중앙 프리미엄석)")
-			.colorHex("#D4AF37")
 			.build();
 	}
 
@@ -51,7 +50,6 @@ public final class BlockFixture {
 			.area(area)
 			.code(SectionCode.ORANGE)
 			.name("오렌지석")
-			.colorHex("#F97316")
 			.build();
 	}
 
@@ -60,7 +58,6 @@ public final class BlockFixture {
 			.area(area)
 			.code(SectionCode.GREEN)
 			.name("그린석(외야석)")
-			.colorHex("#22C55E")
 			.build();
 	}
 
@@ -116,6 +113,6 @@ public final class BlockFixture {
 	}
 
 	public static BlockItemDto cpBlockItemDto() {
-		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "#D4AF37", "중앙", Viewpoint.CENTER);
+		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/support/WebMvcTestSupport.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/support/WebMvcTestSupport.java
@@ -1,0 +1,23 @@
+package com.goormgb.be.seat.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
+
+import tools.jackson.databind.ObjectMapper;
+
+@ActiveProfiles("test")
+public abstract class WebMvcTestSupport {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@MockitoBean
+	protected XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
+}


### PR DESCRIPTION
## 🔧 작업 내용
- 온보딩에서 선호 블럭 선택에 사용할 GET /blocks API를 추가
- 잠실야구장 좌석 구조를 서비스 기동 시 자동 적재하는 시드 초기화 로직을 추가
- 온보딩 블럭 선택 시나리오에 맞게 Area, Block 엔티티 구조 정리
- 블럭 조회 API, 서비스, 시드 초기화 로직에 대한 테스트 코드 추가

  ## 🧩 구현 상세 (선택)
- 응답 DTO에서 블럭 코드, 섹션명, 색상, 구역명, 시야 정보를 함께 반환하도록 했습니다.
- SeatDataInitializer에서 areas -> sections -> blocks 순서로 경기장 좌석 구조 삽입.
- 이미 블럭 데이터가 존재하면 시드 작업을 스킵하도록 처리해 중복 삽입 방지
- Seat 모듈에 Web MVC 테스트 의존성을 추가하고 컨트롤러/서비스/시드삽입 테스트를 작성

### 📌 관련 Jira Issue
- GRGB-239

## 🧪 테스트 방법 (선택)
  - 테스트 대상
    - BlockControllerTest
    - BlockServiceTest
    - SeatDataInitializerTest
- Endpoint / 함수 / 스크립트
    - GET /blocks
    - BlockService#getAllBlocks
    - SeatDataInitializer#run
- 파라미터 및 체크 포인트
    - 블럭 목록 조회 시 정상 응답과 빈 배열 응답을 확인
    - Repository 조회 결과가 DTO로 정상 변환되는지 확인
    - 기존 블럭 데이터 존재 시 시드 스킵 여부 확인
    - 초기 실행 시 Area 4개, Section 14개, Block 107개 저장 여부 확인
    - 대표 블럭 CP, 205, 408의 area/section/viewpoint/rank 값 확인
    - 
<img width="935" height="424" alt="스크린샷 2026-03-13 오전 5 12 01" src="https://github.com/user-attachments/assets/46a21c45-cb10-43f1-b8a8-ddb0d3919570" />
<img width="950" height="450" alt="스크린샷 2026-03-13 오전 5 12 12" src="https://github.com/user-attachments/assets/4a3b588c-4abb-46db-9ada-90fb4e14e339" />
<img width="932" height="411" alt="스크린샷 2026-03-13 오전 5 12 27" src="https://github.com/user-attachments/assets/e5097963-0527-4838-9008-15ba27ef65e3" />


## ❗ 참고 사항
- GET /blocks 응답은 온보딩의 preferredBlockIds 선택 UI에서 사용하는 것을 전제로 설계했습니다.
- 시드 데이터는 잠실야구장 기준 정적 데이터입니다.