### PR TITLE
hotfix(api-gateway): CORS 와일드카드 패턴 매칭 지원으로 localhost 허용 수정

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/CorsGlobalFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/CorsGlobalFilter.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -39,12 +40,15 @@ public class CorsGlobalFilter implements WebFilter, Ordered {
 		return chain.filter(exchange);
 	}
 
+	private static final AntPathMatcher MATCHER = new AntPathMatcher();
+
 	private boolean isAllowed(String origin) {
 		if ("*".equals(allowedOrigins)) {
 			return true;
 		}
 		for (String allowed : allowedOrigins.split(",")) {
-			if (origin.equalsIgnoreCase(allowed.trim())) {
+			String pattern = allowed.trim();
+			if (origin.equalsIgnoreCase(pattern) || MATCHER.match(pattern, origin)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## 🔧 작업 내용
ALLOWED_ORIGINS 환경변수에 http://localhost:* 같은 와일드카드 패턴을 설정해도 equalsIgnoreCase 정확 일치 비교로 인해 CORS 헤더가 누락되던 문제를 AntPathMatcher 기반 패턴 매칭으로 수정