### PR TITLE
feat(seat): match seat 데이터 생성 로직 구현 [GRGB-241]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/config/RowPattern.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RowPattern.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.config;
+
+public record RowPattern(
+	int rowNo,
+	int seatCount,
+	int startTemplateColNo
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SchedulerConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.seat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -1,5 +1,8 @@
 package com.goormgb.be.seat.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -221,15 +224,22 @@ public class SeatDataInitializer implements CommandLineRunner {
 	}
 
 	private void saveSeats(Block block) {
+		List<Seat> seats = new ArrayList<>();
+
 		for (RowPattern pattern : SeatLayoutPatterns.STANDARD) {
-			saveRow(
-				block,
-				pattern.rowNo(),
-				pattern.seatCount(),
-				pattern.startTemplateColNo(),
-				resolveSeatZone(pattern.rowNo())
-			);
+			SeatZone seatZone = resolveSeatZone(pattern.rowNo());
+			for (int i = 0; i < pattern.seatCount(); i++) {
+				seats.add(Seat.builder()
+					.block(block)
+					.rowNo(pattern.rowNo())
+					.seatNo(i + 1)
+					.templateColNo(pattern.startTemplateColNo() + i)
+					.seatZone(seatZone)
+					.build());
+			}
 		}
+
+		seatRepository.saveAll(seats);
 	}
 
 	private SeatZone resolveSeatZone(int rowNo) {
@@ -240,25 +250,5 @@ public class SeatDataInitializer implements CommandLineRunner {
 			return SeatZone.MID;
 		}
 		return SeatZone.HIGH;
-	}
-
-	private void saveRow(
-		Block block,
-		int rowNo,
-		int seatCount,
-		int startTemplateColNo,
-		SeatZone seatZone
-	) {
-		for (int i = 0; i < seatCount; i++) {
-			seatRepository.save(
-				Seat.builder()
-					.block(block)
-					.rowNo(rowNo)
-					.seatNo(i + 1)
-					.templateColNo(startTemplateColNo + i)
-					.seatZone(seatZone)
-					.build()
-			);
-		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -11,6 +11,9 @@ import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.area.repository.AreaRepository;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.seat.entity.Seat;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seat.repository.SeatRepository;
 import com.goormgb.be.seat.section.entity.Section;
 import com.goormgb.be.seat.section.enums.SectionCode;
 import com.goormgb.be.seat.section.repository.SectionRepository;
@@ -31,6 +34,7 @@ public class SeatDataInitializer implements CommandLineRunner {
 	private final AreaRepository areaRepository;
 	private final SectionRepository sectionRepository;
 	private final BlockRepository blockRepository;
+	private final SeatRepository seatRepository;
 
 	@Override
 	@Transactional
@@ -84,104 +88,104 @@ public class SeatDataInitializer implements CommandLineRunner {
 		int rank = 1;
 		for (int i = 205; i <= 208; i++) {
 			saveBlock(home, homeOrange, String.valueOf(i),
-					Viewpoint.INFIELD_1B, rank++, 80 + (i - 205));
+				Viewpoint.INFIELD_1B, rank++, 80 + (i - 205));
 		}
 
 		// ─── 3루(어웨이) 오렌지석 (응원석) 219~222 ───
 		rank = 1;
 		for (int i = 219; i <= 222; i++) {
 			saveBlock(away, awayOrange, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 80 + (i - 219), rank++);
+				Viewpoint.INFIELD_3B, 80 + (i - 219), rank++);
 		}
 
 		// ─── 1루(홈) 퍼플석 (테이블석) 110~113 ───
 		for (int i = 110; i <= 113; i++) {
 			saveBlock(home, homePurple, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 10 + (i - 110), 60 + (i - 110));
+				Viewpoint.INFIELD_1B, 10 + (i - 110), 60 + (i - 110));
 		}
 
 		// ─── 3루(어웨이) 퍼플석 (테이블석) 212~215 ───
 		for (int i = 212; i <= 215; i++) {
 			saveBlock(away, awayPurple, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 60 + (i - 212), 10 + (i - 212));
+				Viewpoint.INFIELD_3B, 60 + (i - 212), 10 + (i - 212));
 		}
 
 		// ─── 1루(홈) 블루석 114~116 ───
 		for (int i = 114; i <= 116; i++) {
 			saveBlock(home, homeBlue, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 14 + (i - 114), 55 + (i - 114));
+				Viewpoint.INFIELD_1B, 14 + (i - 114), 55 + (i - 114));
 		}
 
 		// ─── 1루(홈) 블루석 216~218 (2층) ───
 		for (int i = 216; i <= 218; i++) {
 			saveBlock(home, homeBlue, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 5 + (i - 216), 70 + (i - 216));
+				Viewpoint.INFIELD_1B, 5 + (i - 216), 70 + (i - 216));
 		}
 
 		// ─── 3루(어웨이) 블루석 107~109 ───
 		for (int i = 107; i <= 109; i++) {
 			saveBlock(away, awayBlue, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 55 + (i - 107), 14 + (i - 107));
+				Viewpoint.INFIELD_3B, 55 + (i - 107), 14 + (i - 107));
 		}
 
 		// ─── 3루(어웨이) 블루석 209~211 (2층) ───
 		for (int i = 209; i <= 211; i++) {
 			saveBlock(away, awayBlue, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 70 + (i - 209), 5 + (i - 209));
+				Viewpoint.INFIELD_3B, 70 + (i - 209), 5 + (i - 209));
 		}
 
 		// ─── 1루(홈) 레드석 117~122 ───
 		for (int i = 117; i <= 122; i++) {
 			saveBlock(home, homeRed, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 17 + (i - 117), 45 + (i - 117));
+				Viewpoint.INFIELD_1B, 17 + (i - 117), 45 + (i - 117));
 		}
 
 		// ─── 1루(홈) 레드석 223~226 (2층) ───
 		for (int i = 223; i <= 226; i++) {
 			saveBlock(home, homeRed, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 8 + (i - 223), 65 + (i - 223));
+				Viewpoint.INFIELD_1B, 8 + (i - 223), 65 + (i - 223));
 		}
 
 		// ─── 3루(어웨이) 레드석 101~106 ───
 		for (int i = 101; i <= 106; i++) {
 			saveBlock(away, awayRed, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 45 + (i - 101), 17 + (i - 101));
+				Viewpoint.INFIELD_3B, 45 + (i - 101), 17 + (i - 101));
 		}
 
 		// ─── 3루(어웨이) 레드석 201~204 (2층) ───
 		for (int i = 201; i <= 204; i++) {
 			saveBlock(away, awayRed, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 65 + (i - 201), 8 + (i - 201));
+				Viewpoint.INFIELD_3B, 65 + (i - 201), 8 + (i - 201));
 		}
 
 		// ─── 1루(홈) 네이비석 301~317 ───
 		for (int i = 301; i <= 317; i++) {
 			saveBlock(home, homeNavy, String.valueOf(i),
-					Viewpoint.INFIELD_1B, 23 + (i - 301), 35 + (i - 301));
+				Viewpoint.INFIELD_1B, 23 + (i - 301), 35 + (i - 301));
 		}
 
 		// ─── 3루(어웨이) 네이비석 318~334 ───
 		for (int i = 318; i <= 334; i++) {
 			saveBlock(away, awayNavy, String.valueOf(i),
-					Viewpoint.INFIELD_3B, 35 + (i - 318), 23 + (i - 318));
+				Viewpoint.INFIELD_3B, 35 + (i - 318), 23 + (i - 318));
 		}
 
 		// ─── 외야 그린석 401~407 (1루 방향 → OUTFIELD_R) ───
 		for (int i = 401; i <= 407; i++) {
 			saveBlock(outfield, green, String.valueOf(i),
-					Viewpoint.OUTFIELD_R, 60 + (i - 401), 90 + (i - 401));
+				Viewpoint.OUTFIELD_R, 60 + (i - 401), 90 + (i - 401));
 		}
 
 		// ─── 외야 그린석 408~415 (중앙 → OUTFIELD_C) ───
 		for (int i = 408; i <= 415; i++) {
 			saveBlock(outfield, green, String.valueOf(i),
-					Viewpoint.OUTFIELD_C, 70 + (i - 408), 70 + (i - 408));
+				Viewpoint.OUTFIELD_C, 70 + (i - 408), 70 + (i - 408));
 		}
 
 		// ─── 외야 그린석 416~422 (3루 방향 → OUTFIELD_L) ───
 		for (int i = 416; i <= 422; i++) {
 			saveBlock(outfield, green, String.valueOf(i),
-					Viewpoint.OUTFIELD_L, 90 + (i - 416), 60 + (i - 416));
+				Viewpoint.OUTFIELD_L, 90 + (i - 416), 60 + (i - 416));
 		}
 
 		log.info("[SeatDataInitializer] 시드 데이터 삽입 완료 - 블럭 {}개", blockRepository.count());
@@ -189,28 +193,72 @@ public class SeatDataInitializer implements CommandLineRunner {
 
 	private Area saveArea(AreaCode code, String name) {
 		return areaRepository.save(Area.builder()
-				.code(code)
-				.name(name)
-				.build());
+			.code(code)
+			.name(name)
+			.build());
 	}
 
 	private Section saveSection(Area area, SectionCode code, String name) {
 		return sectionRepository.save(Section.builder()
-				.area(area)
-				.code(code)
-				.name(name)
-				.build());
+			.area(area)
+			.code(code)
+			.name(name)
+			.build());
 	}
 
 	private void saveBlock(Area area, Section section,
-			String blockCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
-		blockRepository.save(Block.builder()
-				.area(area)
-				.section(section)
-				.blockCode(blockCode)
-				.viewpoint(viewpoint)
-				.homeCheerRank(homeCheerRank)
-				.awayCheerRank(awayCheerRank)
-				.build());
+		String blockCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
+		Block block = blockRepository.save(Block.builder()
+			.area(area)
+			.section(section)
+			.blockCode(blockCode)
+			.viewpoint(viewpoint)
+			.homeCheerRank(homeCheerRank)
+			.awayCheerRank(awayCheerRank)
+			.build());
+
+		saveSeats(block);
+	}
+
+	private void saveSeats(Block block) {
+		for (RowPattern pattern : SeatLayoutPatterns.STANDARD) {
+			saveRow(
+				block,
+				pattern.rowNo(),
+				pattern.seatCount(),
+				pattern.startTemplateColNo(),
+				resolveSeatZone(pattern.rowNo())
+			);
+		}
+	}
+
+	private SeatZone resolveSeatZone(int rowNo) {
+		if (rowNo <= 3) {
+			return SeatZone.LOW;
+		}
+		if (rowNo <= 7) {
+			return SeatZone.MID;
+		}
+		return SeatZone.HIGH;
+	}
+
+	private void saveRow(
+		Block block,
+		int rowNo,
+		int seatCount,
+		int startTemplateColNo,
+		SeatZone seatZone
+	) {
+		for (int i = 0; i < seatCount; i++) {
+			seatRepository.save(
+				Seat.builder()
+					.block(block)
+					.rowNo(rowNo)
+					.seatNo(i + 1)
+					.templateColNo(startTemplateColNo + i)
+					.seatZone(seatZone)
+					.build()
+			);
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -34,6 +34,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SeatDataInitializer implements CommandLineRunner {
 
+	private static final Integer LOW_ZONE_MAX_ROW = 3;
+	private static final Integer MID_ZONE_MAX_ROW = 7;
+
 	private final AreaRepository areaRepository;
 	private final SectionRepository sectionRepository;
 	private final BlockRepository blockRepository;
@@ -243,10 +246,10 @@ public class SeatDataInitializer implements CommandLineRunner {
 	}
 
 	private SeatZone resolveSeatZone(int rowNo) {
-		if (rowNo <= 3) {
+		if (rowNo <= LOW_ZONE_MAX_ROW) {
 			return SeatZone.LOW;
 		}
-		if (rowNo <= 7) {
+		if (rowNo <= MID_ZONE_MAX_ROW) {
 			return SeatZone.MID;
 		}
 		return SeatZone.HIGH;

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatLayoutPatterns.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatLayoutPatterns.java
@@ -1,0 +1,35 @@
+package com.goormgb.be.seat.config;
+
+import java.util.List;
+
+public class SeatLayoutPatterns {
+
+	private SeatLayoutPatterns() {
+	}
+
+	public static final List<RowPattern> STANDARD = List.of(
+		new RowPattern(1, 14, 1),
+		new RowPattern(2, 14, 1),
+		new RowPattern(3, 14, 1),
+		new RowPattern(4, 7, 5),
+		new RowPattern(5, 7, 5),
+		new RowPattern(6, 7, 5),
+		new RowPattern(7, 7, 5),
+		new RowPattern(8, 14, 1),
+		new RowPattern(9, 14, 1),
+		new RowPattern(10, 14, 1),
+		new RowPattern(11, 14, 1),
+		new RowPattern(12, 14, 1),
+		new RowPattern(13, 14, 1),
+		new RowPattern(14, 14, 1),
+		new RowPattern(15, 14, 1),
+		new RowPattern(16, 14, 1),
+		new RowPattern(17, 14, 1),
+		new RowPattern(18, 14, 1),
+		new RowPattern(19, 14, 1),
+		new RowPattern(20, 14, 1),
+		new RowPattern(21, 14, 1),
+		new RowPattern(22, 14, 1)
+	);
+
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/TimeConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.seat.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+	@Bean
+	public Clock systemClock() {
+		return Clock.systemUTC();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 
 public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
+	boolean existsByMatchId(Long matchId);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.seat.matchSeat.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.matchSeat.service.MatchSeatPreparationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchSeatScheduler {
+
+	private final MatchSeatPreparationService matchSeatPreparationService;
+
+	/**
+	 * 매일 자정 00:00: 경기 7일 전이 된 UPCOMING 경기에 대해 match_seats 데이터를 미리 생성한다.
+	 */
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void prepareMatchSeats() {
+		matchSeatPreparationService.prepareMatchSeats();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
@@ -1,0 +1,90 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.seat.seat.dto.SeatTemplateProjection;
+import com.goormgb.be.seat.seat.repository.SeatRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchSeatPreparationService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private final MatchRepository matchRepository;
+	private final SeatRepository seatRepository;
+	private final Clock clock;
+	private final MatchSeatPreparationTransactionalService transactionalService;
+
+	public void prepareMatchSeats() {
+
+		// KST 기준 현재 시각
+		ZonedDateTime nowKst = ZonedDateTime.now(clock)
+			.withZoneSameInstant(KST);
+
+		// 오늘 기준 +7일 날짜
+		LocalDate targetDate = nowKst.toLocalDate().plusDays(7);
+
+		// 7일 뒤 날짜의 00:00 ~ 다음날 00:00 범위
+		Instant targetStart = targetDate
+			.atStartOfDay(KST)
+			.toInstant();
+
+		Instant targetEnd = targetDate
+			.plusDays(1)
+			.atStartOfDay(KST)
+			.toInstant();
+
+		// 생성 대상 경기 조회
+		List<Match> matchesToPrepare =
+			matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+				SaleStatus.UPCOMING,
+				targetStart,
+				targetEnd
+			);
+
+		if (matchesToPrepare.isEmpty()) {
+			log.info("[MatchSeatPreparationService] 생성 대상 경기 없음");
+			return;
+		}
+
+		// 좌석 템플릿 조회
+		List<SeatTemplateProjection> templates = seatRepository.findAllSeatTemplates();
+
+		if (templates.isEmpty()) {
+			log.warn("[MatchSeatPreparationService] 기본 좌석 템플릿이 없어 매치 좌석 생성 스킵");
+			return;
+		}
+
+		int preparedMatchCount = 0;
+
+		for (Match match : matchesToPrepare) {
+			try {
+				boolean prepared = transactionalService.prepareSingleMatchSeats(match.getId(), templates);
+				if (prepared) {
+					preparedMatchCount++;
+				}
+			} catch (Exception e) {
+				log.error("[MatchSeatPreparationService] matchId={} 매치 좌석 생성 실패", match.getId(), e);
+			}
+		}
+
+		if (preparedMatchCount > 0) {
+			log.info("[MatchSeatPreparationService] 매치 좌석 생성 완료: {}건", preparedMatchCount);
+		}
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationTransactionalService.java
@@ -1,0 +1,53 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seat.dto.SeatTemplateProjection;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MatchSeatPreparationTransactionalService {
+
+	private static final int BATCH_SIZE = 1000;
+
+	private final MatchSeatRepository matchSeatRepository;
+
+	@Transactional
+	public boolean prepareSingleMatchSeats(Long matchId, List<SeatTemplateProjection> templates) {
+		if (matchSeatRepository.existsByMatchId(matchId)) {
+			return false;
+		}
+
+		for (int start = 0; start < templates.size(); start += BATCH_SIZE) {
+			int end = Math.min(start + BATCH_SIZE, templates.size());
+
+			List<MatchSeat> batch = templates.subList(start, end)
+				.stream()
+				.map(template -> MatchSeat.builder()
+					.matchId(matchId)
+					.seatId(template.getSeatId())
+					.areaId(template.getAreaId())
+					.sectionId(template.getSectionId())
+					.blockId(template.getBlockId())
+					.rowNo(template.getRowNo())
+					.seatNo(template.getSeatNo())
+					.templateColNo(template.getTemplateColNo())
+					.seatZone(template.getSeatZone())
+					.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+					.build())
+				.toList();
+
+			matchSeatRepository.saveAll(batch);
+		}
+
+		return true;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seat/dto/SeatTemplateProjection.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seat/dto/SeatTemplateProjection.java
@@ -1,0 +1,21 @@
+package com.goormgb.be.seat.seat.dto;
+
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+public interface SeatTemplateProjection {
+	Long getSeatId();
+
+	Long getAreaId();
+
+	Long getSectionId();
+
+	Long getBlockId();
+
+	Integer getRowNo();
+
+	Integer getSeatNo();
+
+	Integer getTemplateColNo();
+
+	SeatZone getSeatZone();
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/seat/repository/SeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seat/repository/SeatRepository.java
@@ -1,0 +1,27 @@
+package com.goormgb.be.seat.seat.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.goormgb.be.seat.seat.dto.SeatTemplateProjection;
+import com.goormgb.be.seat.seat.entity.Seat;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+	@Query("""
+			select
+				s.id as seatId,
+				b.area.id as areaId,
+				b.section.id as sectionId,
+				b.id as blockId,
+				s.rowNo as rowNo,
+				s.seatNo as seatNo,
+				s.templateColNo as templateColNo,
+				s.seatZone as seatZone
+			from Seat s
+			join s.block b
+		""")
+	List<SeatTemplateProjection> findAllSeatTemplates();
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatSchedulerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatSchedulerTest.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.seat.matchSeat.scheduler;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.service.MatchSeatPreparationService;
+
+@ExtendWith(MockitoExtension.class)
+class MatchSeatSchedulerTest {
+
+	@Mock
+	private MatchSeatPreparationService matchSeatPreparationService;
+
+	@InjectMocks
+	private MatchSeatScheduler matchSeatScheduler;
+
+	@Test
+	@DisplayName("스케줄러 실행 시 matchSeatPreparationService를 호출한다")
+	void prepareMatchSeats_callsService() {
+		// when
+		matchSeatScheduler.prepareMatchSeats();
+
+		// then
+		verify(matchSeatPreparationService, times(1)).prepareMatchSeats();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -36,7 +35,6 @@ class MatchSeatPreparationServiceTest {
 
 	private Clock clock;
 
-	@InjectMocks
 	private MatchSeatPreparationService matchSeatPreparationService;
 
 	@BeforeEach

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
@@ -1,0 +1,148 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.seat.seat.dto.SeatTemplateProjection;
+import com.goormgb.be.seat.seat.repository.SeatRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchSeatPreparationServiceTest {
+
+	@Mock
+	private MatchRepository matchRepository;
+
+	@Mock
+	private SeatRepository seatRepository;
+
+	@Mock
+	private MatchSeatPreparationTransactionalService transactionalService;
+
+	private Clock clock;
+
+	@InjectMocks
+	private MatchSeatPreparationService matchSeatPreparationService;
+
+	@BeforeEach
+	void setUp() {
+		clock = Clock.fixed(
+			Instant.parse("2026-03-13T00:00:00Z"),
+			ZoneId.of("UTC")
+		);
+
+		matchSeatPreparationService = new MatchSeatPreparationService(
+			matchRepository,
+			seatRepository,
+			clock,
+			transactionalService
+		);
+	}
+
+	@Test
+	@DisplayName("생성 대상 경기가 없으면 종료한다")
+	void prepareMatchSeats_noMatches() {
+		// given
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING), any(), any()
+		)).thenReturn(List.of());
+
+		// when
+		matchSeatPreparationService.prepareMatchSeats();
+
+		// then
+		verify(seatRepository, never()).findAllSeatTemplates();
+		verify(transactionalService, never()).prepareSingleMatchSeats(any(), any());
+	}
+
+	@Test
+	@DisplayName("좌석 템플릿이 없으면 종료한다")
+	void prepareMatchSeats_noTemplates() {
+		// given
+		Match match = org.mockito.Mockito.mock(Match.class);
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING), any(), any()
+		)).thenReturn(List.of(match));
+
+		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of());
+
+		// when
+		matchSeatPreparationService.prepareMatchSeats();
+
+		// then
+		verify(transactionalService, never()).prepareSingleMatchSeats(any(), any());
+	}
+
+	@Test
+	@DisplayName("대상 경기마다 match seat 생성을 시도한다")
+	void prepareMatchSeats_callsTransactionalServiceForEachMatch() {
+		// given
+		Match match1 = org.mockito.Mockito.mock(Match.class);
+		Match match2 = org.mockito.Mockito.mock(Match.class);
+
+		when(match1.getId()).thenReturn(1L);
+		when(match2.getId()).thenReturn(2L);
+
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING), any(), any()
+		)).thenReturn(List.of(match1, match2));
+
+		SeatTemplateProjection template = org.mockito.Mockito.mock(SeatTemplateProjection.class);
+		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
+
+		when(transactionalService.prepareSingleMatchSeats(eq(1L), any())).thenReturn(true);
+		when(transactionalService.prepareSingleMatchSeats(eq(2L), any())).thenReturn(true);
+
+		// when
+		matchSeatPreparationService.prepareMatchSeats();
+
+		// then
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(1L), any());
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(2L), any());
+	}
+
+	@Test
+	@DisplayName("한 경기 생성 실패해도 다음 경기는 계속 처리한다")
+	void prepareMatchSeats_continueWhenOneMatchFails() {
+		// given
+		Match match1 = org.mockito.Mockito.mock(Match.class);
+		Match match2 = org.mockito.Mockito.mock(Match.class);
+
+		when(match1.getId()).thenReturn(1L);
+		when(match2.getId()).thenReturn(2L);
+
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING), any(), any()
+		)).thenReturn(List.of(match1, match2));
+
+		SeatTemplateProjection template = org.mockito.Mockito.mock(SeatTemplateProjection.class);
+		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
+
+		doThrow(new RuntimeException("DB 오류"))
+			.when(transactionalService).prepareSingleMatchSeats(eq(1L), any());
+
+		when(transactionalService.prepareSingleMatchSeats(eq(2L), any())).thenReturn(true);
+
+		// when
+		matchSeatPreparationService.prepareMatchSeats();
+
+		// then
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(1L), any());
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(2L), any());
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationTransactionalServiceTest.java
@@ -1,0 +1,112 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seat.dto.SeatTemplateProjection;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+@ExtendWith(MockitoExtension.class)
+class MatchSeatPreparationTransactionalServiceTest {
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+
+	@InjectMocks
+	private MatchSeatPreparationTransactionalService transactionalService;
+
+	@Test
+	@DisplayName("이미 match seat가 존재하면 생성하지 않고 false를 반환한다")
+	void prepareSingleMatchSeats_returnsFalseWhenAlreadyExists() {
+		// given
+		Long matchId = 1L;
+		when(matchSeatRepository.existsByMatchId(matchId)).thenReturn(true);
+
+		// when
+		boolean result = transactionalService.prepareSingleMatchSeats(matchId, List.of());
+
+		// then
+		assertThat(result).isFalse();
+		verify(matchSeatRepository, never()).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("템플릿 수가 2500개면 1000개 단위로 3번 saveAll 호출한다")
+	void prepareSingleMatchSeats_savesInBatches() {
+		// given
+		Long matchId = 1L;
+		when(matchSeatRepository.existsByMatchId(matchId)).thenReturn(false);
+
+		List<SeatTemplateProjection> templates = new ArrayList<>();
+		for (long i = 1; i <= 2500; i++) {
+			templates.add(new FakeSeatTemplateProjection(i));
+		}
+
+		// when
+		boolean result = transactionalService.prepareSingleMatchSeats(matchId, templates);
+
+		// then
+		assertThat(result).isTrue();
+		verify(matchSeatRepository, times(3)).saveAll(anyList());
+	}
+
+	private static class FakeSeatTemplateProjection implements SeatTemplateProjection {
+		private final Long seatId;
+
+		private FakeSeatTemplateProjection(Long seatId) {
+			this.seatId = seatId;
+		}
+
+		@Override
+		public Long getSeatId() {
+			return seatId;
+		}
+
+		@Override
+		public Long getAreaId() {
+			return 10L;
+		}
+
+		@Override
+		public Long getSectionId() {
+			return 20L;
+		}
+
+		@Override
+		public Long getBlockId() {
+			return 30L;
+		}
+
+		@Override
+		public Integer getRowNo() {
+			return 1;
+		}
+
+		@Override
+		public Integer getSeatNo() {
+			return 1;
+		}
+
+		@Override
+		public Integer getTemplateColNo() {
+			return 1;
+		}
+
+		@Override
+		public SeatZone getSeatZone() {
+			return SeatZone.LOW;
+		}
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -62,4 +62,10 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		@Param("start") Instant start,
 		@Param("end") Instant end
 	);
+
+	List<Match> findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+		SaleStatus saleStatus,
+		Instant start,
+		Instant end
+	);
 }


### PR DESCRIPTION
## 🔧 작업 내용

- seat 시드 데이터 생성
- matchSeat Scheduler 구현

## 🧩 구현 상세 (선택)

**seat 시드 데이터 생성**
- `block` 당 좌석이 만들어져야해서 `saveBlock` 함수에 `saveSeat` 함수 추가
- 모든 좌석의 템플릿이 동일하다고 했을 때 사용할 수 있는 `RowPattern`, `SeatLayoutPattern`구현
> rowNo 1 - 3 → LOW 구역, seatNo 1 - 14
> rowNo 4 - 7 → MID 구역, seatNo 1 - 7
> rowNo 8 - 22 -> HIGH 구역, seatNo 1 - 14

<img width="289" height="63" alt="image" src="https://github.com/user-attachments/assets/dc9cbf89-e75e-4119-a336-8fa29372bd26" />


**matchSeat Scheduler 구현**
- 경기 시작 7일전 오전 12시에 좌석 데이터를 만드는 스케줄러
- `matchSeatPreparationService`에서 matchSeat 데이터로 만들 경기와 데이터를 뽑음
- `matchSeatPreparationTransactionalService` 경기마다 Batch 1000개씩 insert 시작
- 에러 발생 시 트랜잭션 범위를 경기마다로 잡아서 중복된 데이터를 방지


### 📌 관련 Jira Issue

- GRGB-241

## 🧪 테스트 방법(선택)

<img width="1054" height="357" alt="스크린샷 2026-03-13 오후 5 05 47" src="https://github.com/user-attachments/assets/9677dd95-3c19-4e5e-9c9f-6f5a2f979f37" />

<img width="1190" height="451" alt="image" src="https://github.com/user-attachments/assets/b779f965-e474-42a5-b26f-0f4540c0a0e5" />

<img width="1216" height="378" alt="image" src="https://github.com/user-attachments/assets/47ba65f0-5904-4387-bc51-ad134d1c5506" />

## ❗ 참고 사항

- 테스트 코드는 통과되는데 실제 스케줄러가 동작하는 건 12시가 되어야 알 수 있어서 나중에 문제생기면 그때 고치는걸로...
