### PR TITLE
feat(order-core): 마이페이지 도메인 DB 설계 및 엔티티 구현 [GRGB-242]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/config/CancellationFeePolicyInitializer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/config/CancellationFeePolicyInitializer.java
@@ -1,0 +1,71 @@
+package com.goormgb.be.ordercore.cancellation.config;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
+import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 취소 수수료 정책 시드 데이터.
+ *
+ * 정책 (불변):
+ *   - 경기 당일 (D-0)        : 취소 불가
+ *   - 경기 D-1 ~ D-6         : 티켓 금액의 10% + 예매 대행 수수료 환불 불가
+ *   - 경기 D-7 이상           : 취소 수수료 없음. 예매 당일 취소 시에만 예매 대행 수수료 환불
+ */
+@Slf4j
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class CancellationFeePolicyInitializer implements CommandLineRunner {
+
+	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		if (cancellationFeePolicyRepository.count() > 0) {
+			log.info("[CancellationFeePolicyInitializer] 취소 수수료 정책 데이터 이미 존재 - 시드 스킵");
+			return;
+		}
+
+		log.info("[CancellationFeePolicyInitializer] 취소 수수료 정책 시드 데이터 삽입 시작");
+
+		cancellationFeePolicyRepository.saveAll(List.of(
+			CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(0)
+				.daysBeforeMatchMax(0)
+				.cancellable(false)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(false)
+				.build(),
+
+			CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(1)
+				.daysBeforeMatchMax(6)
+				.cancellable(true)
+				.ticketFeeRate(new BigDecimal("0.100"))
+				.bookingFeeRefundable(false)
+				.build(),
+
+			CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(7)
+				.daysBeforeMatchMax(null)
+				.cancellable(true)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(true)
+				.build()
+		));
+
+		log.info("[CancellationFeePolicyInitializer] 취소 수수료 정책 시드 데이터 삽입 완료");
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/entity/CancellationFeePolicy.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/entity/CancellationFeePolicy.java
@@ -1,0 +1,64 @@
+package com.goormgb.be.ordercore.cancellation.entity;
+
+import java.math.BigDecimal;
+
+import com.goormgb.be.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 취소 수수료 정책 (시드 데이터로 고정 운영, 런타임 변경 금지)
+ *
+ * 시드 데이터:
+ *   days_min=0,  days_max=0,    cancellable=false, fee_rate=0.000, booking_fee_refundable=false  → 경기 당일: 취소 불가
+ *   days_min=1,  days_max=6,    cancellable=true,  fee_rate=0.100, booking_fee_refundable=false  → D-1~D-6: 10% + 예매 대행 수수료 환불 불가
+ *   days_min=7,  days_max=null, cancellable=true,  fee_rate=0.000, booking_fee_refundable=true   → D-7+: 무료, 예매 당일 취소 시에만 예매 대행 수수료 환불
+ */
+@Entity
+@Table(name = "cancellation_fee_policies")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CancellationFeePolicy extends BaseEntity {
+
+	@Column(name = "days_before_match_min", nullable = false)
+	private Integer daysBeforeMatchMin;
+
+	/**
+	 * null이면 상한 없음 (D-N 이상 모두 적용)
+	 */
+	@Column(name = "days_before_match_max")
+	private Integer daysBeforeMatchMax;
+
+	@Column(name = "cancellable", nullable = false)
+	private Boolean cancellable;
+
+	@Column(name = "ticket_fee_rate", nullable = false, precision = 5, scale = 3)
+	private BigDecimal ticketFeeRate;
+
+	/**
+	 * true이더라도 예매 당일 취소 시에만 실제 환불 (애플리케이션 레벨 검증 필요)
+	 */
+	@Column(name = "booking_fee_refundable", nullable = false)
+	private Boolean bookingFeeRefundable;
+
+	@Builder
+	public CancellationFeePolicy(
+		Integer daysBeforeMatchMin,
+		Integer daysBeforeMatchMax,
+		Boolean cancellable,
+		BigDecimal ticketFeeRate,
+		Boolean bookingFeeRefundable
+	) {
+		this.daysBeforeMatchMin = daysBeforeMatchMin;
+		this.daysBeforeMatchMax = daysBeforeMatchMax;
+		this.cancellable = cancellable;
+		this.ticketFeeRate = ticketFeeRate;
+		this.bookingFeeRefundable = bookingFeeRefundable;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/repository/CancellationFeePolicyRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/cancellation/repository/CancellationFeePolicyRepository.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.ordercore.cancellation.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
+
+public interface CancellationFeePolicyRepository extends JpaRepository<CancellationFeePolicy, Long> {
+
+	@Query("""
+		SELECT c FROM CancellationFeePolicy c
+		WHERE c.daysBeforeMatchMin <= :daysLeft
+		  AND (c.daysBeforeMatchMax IS NULL OR c.daysBeforeMatchMax >= :daysLeft)
+		""")
+	Optional<CancellationFeePolicy> findByDaysLeft(@Param("daysLeft") int daysLeft);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
@@ -1,0 +1,77 @@
+package com.goormgb.be.ordercore.inquiry.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.ordercore.inquiry.enums.InquiryCategory;
+import com.goormgb.be.ordercore.inquiry.enums.InquiryStatus;
+import com.goormgb.be.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "inquiries",
+	indexes = {
+		@Index(name = "idx_inquiries_user_id", columnList = "user_id"),
+		@Index(name = "idx_inquiries_user_id_created_at", columnList = "user_id, created_at"),
+		@Index(name = "idx_inquiries_status", columnList = "status")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inquiry extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "category", nullable = false, length = 30)
+	private InquiryCategory category;
+
+	@Column(name = "title", nullable = false, length = 200)
+	private String title;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 20)
+	private InquiryStatus status;
+
+	@Column(name = "phone_number", length = 20)
+	private String phoneNumber;
+
+	@Builder
+	public Inquiry(
+		User user,
+		InquiryCategory category,
+		String title,
+		String content,
+		String phoneNumber
+	) {
+		this.user = user;
+		this.category = category;
+		this.title = title;
+		this.content = content;
+		this.status = InquiryStatus.REGISTERED;
+		this.phoneNumber = phoneNumber;
+	}
+
+	public void updateStatus(InquiryStatus status) {
+		this.status = status;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/InquiryAnswer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/InquiryAnswer.java
@@ -1,0 +1,48 @@
+package com.goormgb.be.ordercore.inquiry.entity;
+
+import java.time.Instant;
+
+import com.goormgb.be.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "inquiry_answers",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_inquiry_answers_inquiry_id", columnNames = {"inquiry_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InquiryAnswer extends BaseEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "inquiry_id", nullable = false, unique = true)
+	private Inquiry inquiry;
+
+	@Lob
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "answered_at", nullable = false)
+	private Instant answeredAt;
+
+	@Builder
+	public InquiryAnswer(Inquiry inquiry, String content) {
+		this.inquiry = inquiry;
+		this.content = content;
+		this.answeredAt = Instant.now();
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/enums/InquiryCategory.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/enums/InquiryCategory.java
@@ -1,0 +1,17 @@
+package com.goormgb.be.ordercore.inquiry.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryCategory {
+
+	BOOKING("예매/상품"),
+	PAYMENT("결제/수수료"),
+	DELIVERY("배송/반송"),
+	SYSTEM_ERROR("시스템 오류"),
+	ETC("기타");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/enums/InquiryStatus.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/enums/InquiryStatus.java
@@ -1,0 +1,16 @@
+package com.goormgb.be.ordercore.inquiry.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryStatus {
+
+	REGISTERED("접수 완료"),
+	PENDING("처리 중"),
+	ANSWERED("답변 완료"),
+	CLOSED("종료");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryAnswerRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryAnswerRepository.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.inquiry.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.inquiry.entity.InquiryAnswer;
+
+public interface InquiryAnswerRepository extends JpaRepository<InquiryAnswer, Long> {
+
+	Optional<InquiryAnswer> findByInquiryId(Long inquiryId);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.inquiry.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.inquiry.entity.Inquiry;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+
+	Page<Inquiry> findByUserId(Long userId, Pageable pageable);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -1,0 +1,113 @@
+package com.goormgb.be.ordercore.order.entity;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "orders",
+	indexes = {
+		@Index(name = "idx_orders_user_id", columnList = "user_id"),
+		@Index(name = "idx_orders_match_id", columnList = "match_id"),
+		@Index(name = "idx_orders_user_id_status", columnList = "user_id, status"),
+		@Index(name = "idx_orders_user_id_created_at", columnList = "user_id, created_at"),
+		@Index(name = "idx_orders_status", columnList = "status")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+	private static final int DEFAULT_BOOKING_FEE = 2000;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "match_id", nullable = false)
+	private Match match;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 30)
+	private OrderStatus status;
+
+	@Column(name = "total_amount", nullable = false)
+	private Integer totalAmount;
+
+	@Column(name = "booking_fee", nullable = false)
+	private Integer bookingFee;
+
+	@Column(name = "cancellation_fee", nullable = false)
+	private Integer cancellationFee;
+
+	@Column(name = "refunded_amount")
+	private Integer refundedAmount;
+
+	@Column(name = "cancelled_at")
+	private Instant cancelledAt;
+
+	@Column(name = "orderer_name", nullable = false, length = 50)
+	private String ordererName;
+
+	@Column(name = "orderer_email", nullable = false, length = 255)
+	private String ordererEmail;
+
+	@Column(name = "orderer_phone", nullable = false, length = 20)
+	private String ordererPhone;
+
+	@Column(name = "orderer_birth_date", nullable = false)
+	private LocalDate ordererBirthDate;
+
+	@Builder
+	public Order(
+		User user,
+		Match match,
+		Integer totalAmount,
+		String ordererName,
+		String ordererEmail,
+		String ordererPhone,
+		LocalDate ordererBirthDate
+	) {
+		this.user = user;
+		this.match = match;
+		this.status = OrderStatus.PAYMENT_PENDING;
+		this.totalAmount = totalAmount;
+		this.bookingFee = DEFAULT_BOOKING_FEE;
+		this.cancellationFee = 0;
+		this.ordererName = ordererName;
+		this.ordererEmail = ordererEmail;
+		this.ordererPhone = ordererPhone;
+		this.ordererBirthDate = ordererBirthDate;
+	}
+
+	public void updateStatus(OrderStatus status) {
+		this.status = status;
+	}
+
+	public void cancel(Integer cancellationFee, Integer refundedAmount) {
+		this.status = OrderStatus.CANCEL_REQUESTED;
+		this.cancellationFee = cancellationFee;
+		this.refundedAmount = refundedAmount;
+		this.cancelledAt = Instant.now();
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
@@ -1,0 +1,81 @@
+package com.goormgb.be.ordercore.order.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.domain.ticket.enums.TicketType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "order_seats",
+	indexes = {
+		@Index(name = "idx_order_seats_order_id", columnList = "order_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_order_seats_match_seat_id", columnNames = {"match_seat_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderSeat extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@Column(name = "match_seat_id", nullable = false)
+	private Long matchSeatId;
+
+	@Column(name = "block_id", nullable = false)
+	private Long blockId;
+
+	@Column(name = "section_id", nullable = false)
+	private Long sectionId;
+
+	@Column(name = "row_no", nullable = false)
+	private Integer rowNo;
+
+	@Column(name = "seat_no", nullable = false)
+	private Integer seatNo;
+
+	@Column(name = "price", nullable = false)
+	private Integer price;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "ticket_type", nullable = false, length = 30)
+	private TicketType ticketType;
+
+	@Builder
+	public OrderSeat(
+		Order order,
+		Long matchSeatId,
+		Long blockId,
+		Long sectionId,
+		Integer rowNo,
+		Integer seatNo,
+		Integer price,
+		TicketType ticketType
+	) {
+		this.order = order;
+		this.matchSeatId = matchSeatId;
+		this.blockId = blockId;
+		this.sectionId = sectionId;
+		this.rowNo = rowNo;
+		this.seatNo = seatNo;
+		this.price = price;
+		this.ticketType = ticketType;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/enums/OrderStatus.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/enums/OrderStatus.java
@@ -1,0 +1,18 @@
+package com.goormgb.be.ordercore.order.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+	PAYMENT_PENDING("입금 대기"),
+	PAID("결제 완료"),
+	CANCEL_REQUESTED("취소 요청"),
+	CANCELLED("취소 완료"),
+	REFUND_PROCESSING("환불 처리 중"),
+	REFUND_COMPLETED("환불 완료");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.ordercore.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.order.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.order.entity.OrderSeat;
+
+public interface OrderSeatRepository extends JpaRepository<OrderSeat, Long> {
+
+	List<OrderSeat> findByOrderId(Long orderId);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
@@ -1,0 +1,52 @@
+package com.goormgb.be.ordercore.payment.entity;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "cash_receipts",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_cash_receipts_payment_id", columnNames = {"payment_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashReceipt extends BaseEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "payment_id", nullable = false, unique = true)
+	private Payment payment;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "purpose", nullable = false, length = 30)
+	private CashReceiptPurpose purpose;
+
+	/**
+	 * PERSONAL_DEDUCTION: 현금영수증용 전화번호
+	 * BUSINESS_EXPENSE: 사업자번호
+	 */
+	@Column(name = "number", nullable = false, length = 50)
+	private String number;
+
+	@Builder
+	public CashReceipt(Payment payment, CashReceiptPurpose purpose, String number) {
+		this.payment = payment;
+		this.purpose = purpose;
+		this.number = number;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
@@ -1,0 +1,97 @@
+package com.goormgb.be.ordercore.payment.entity;
+
+import java.time.Instant;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "payments",
+	indexes = {
+		@Index(name = "idx_payments_status", columnList = "status")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_payments_order_id", columnNames = {"order_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false, unique = true)
+	private Order order;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "payment_method", nullable = false, length = 30)
+	private PaymentMethod paymentMethod;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false, length = 30)
+	private PaymentStatus status;
+
+	@Column(name = "paid_at")
+	private Instant paidAt;
+
+	// 무통장 입금 전용 필드 (VIRTUAL_ACCOUNT 선택 시에만 값 존재)
+	@Column(name = "virtual_account_bank", length = 50)
+	private String virtualAccountBank;
+
+	@Column(name = "virtual_account_number", length = 50)
+	private String virtualAccountNumber;
+
+	@Column(name = "virtual_account_holder", length = 50)
+	private String virtualAccountHolder;
+
+	@Column(name = "deposit_deadline")
+	private Instant depositDeadline;
+
+	@Builder
+	public Payment(
+		Order order,
+		PaymentMethod paymentMethod,
+		String virtualAccountBank,
+		String virtualAccountNumber,
+		String virtualAccountHolder,
+		Instant depositDeadline
+	) {
+		this.order = order;
+		this.paymentMethod = paymentMethod;
+		this.status = PaymentStatus.PENDING;
+		this.virtualAccountBank = virtualAccountBank;
+		this.virtualAccountNumber = virtualAccountNumber;
+		this.virtualAccountHolder = virtualAccountHolder;
+		this.depositDeadline = depositDeadline;
+	}
+
+	public void complete() {
+		this.status = PaymentStatus.COMPLETED;
+		this.paidAt = Instant.now();
+	}
+
+	public void cancel() {
+		this.status = PaymentStatus.CANCELLED;
+	}
+
+	public void refund() {
+		this.status = PaymentStatus.REFUNDED;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/CashReceiptPurpose.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/CashReceiptPurpose.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.ordercore.payment.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CashReceiptPurpose {
+
+	PERSONAL_DEDUCTION("개인소득공제"),
+	BUSINESS_EXPENSE("사업자지출증빙");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentMethod.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentMethod.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.ordercore.payment.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentMethod {
+
+	VIRTUAL_ACCOUNT("무통장 입금"),
+	TOSS_PAY("토스페이"),
+	KAKAO_PAY("카카오페이");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentStatus.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentStatus.java
@@ -1,0 +1,16 @@
+package com.goormgb.be.ordercore.payment.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+
+	PENDING("대기"),
+	COMPLETED("완료"),
+	CANCELLED("취소"),
+	REFUNDED("환불");
+
+	private final String description;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/CashReceiptRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/CashReceiptRepository.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.payment.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.payment.entity.CashReceipt;
+
+public interface CashReceiptRepository extends JpaRepository<CashReceipt, Long> {
+
+	Optional<CashReceipt> findByPaymentId(Long paymentId);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/PaymentRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/PaymentRepository.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.payment.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.payment.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+	Optional<Payment> findByOrderId(Long orderId);
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/entity/QrToken.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/entity/QrToken.java
@@ -1,0 +1,63 @@
+package com.goormgb.be.ordercore.qrtoken.entity;
+
+import java.time.Instant;
+
+import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "qr_tokens",
+	indexes = {
+		@Index(name = "idx_qr_tokens_order_id", columnList = "order_id"),
+		@Index(name = "idx_qr_tokens_user_id", columnList = "user_id"),
+		@Index(name = "idx_qr_tokens_expires_at", columnList = "expires_at")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_qr_tokens_qr_token", columnNames = {"qr_token"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QrToken extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "qr_token", nullable = false, unique = true, length = 512)
+	private String qrToken;
+
+	@Column(name = "expires_at", nullable = false)
+	private Instant expiresAt;
+
+	@Builder
+	public QrToken(Order order, User user, String qrToken, Instant expiresAt) {
+		this.order = order;
+		this.user = user;
+		this.qrToken = qrToken;
+		this.expiresAt = expiresAt;
+	}
+
+	public boolean isExpired() {
+		return Instant.now().isAfter(this.expiresAt);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/repository/QrTokenRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/repository/QrTokenRepository.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.ordercore.qrtoken.repository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
+
+public interface QrTokenRepository extends JpaRepository<QrToken, Long> {
+
+	Optional<QrToken> findByOrderIdAndExpiresAtAfter(Long orderId, Instant now);
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
@@ -1,0 +1,150 @@
+package com.goormgb.be.seat.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.seat.pricePolicy.entity.PricePolicy;
+import com.goormgb.be.seat.pricePolicy.enums.DayType;
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.seat.pricePolicy.repository.PricePolicyRepository;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.seat.section.repository.SectionRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 잠실야구장 입장권 가격 시드 데이터.
+ * SeatDataInitializer(@Order(1)) 이후 실행되어 sections를 참조함.
+ *
+ * 가격 정책 (불변):
+ *   - 중앙석(PREMIUM)  : 80,000 / 80,000
+ *   - 테이블석(PURPLE)  : 52,000 / 58,000
+ *   - 익사이팅존(EXCITING): 28,000 / 33,000
+ *   - 블루석(BLUE)     : 22,000 / 24,000  (장애인 50% 할인)
+ *   - 오렌지석(ORANGE)  : 20,000 / 22,000  (장애인 50% 할인)
+ *   - 레드석(RED)      : 17,000 / 19,000  (장애인 50% 할인)
+ *   - 네이비석(NAVY)   : 14,000 / 14,000  (장애인 50% 할인)
+ *   - 외야(GREEN)      : 일반 9,000/10,000 | 청소년·군경 7,000/8,000 | 어린이·유공자·경로·장애인 4,500/5,000
+ *
+ * 주말 기준: 금요일, 토요일, 일요일, 공휴일
+ */
+@Slf4j
+@Component
+@Order(2)
+@RequiredArgsConstructor
+public class PricePolicyInitializer implements CommandLineRunner {
+
+	private static final Long JAMSIL_STADIUM_ID = 1L;
+
+	private final SectionRepository sectionRepository;
+	private final PricePolicyRepository pricePolicyRepository;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		if (pricePolicyRepository.count() > 0) {
+			log.info("[PricePolicyInitializer] 가격 정책 데이터 이미 존재 - 시드 스킵");
+			return;
+		}
+
+		log.info("[PricePolicyInitializer] 잠실야구장 입장권 가격 시드 데이터 삽입 시작");
+
+		List<Section> sections = sectionRepository.findAll();
+		List<PricePolicy> policies = new ArrayList<>();
+
+		for (Section section : sections) {
+			policies.addAll(buildPolicies(section));
+		}
+
+		pricePolicyRepository.saveAll(policies);
+		log.info("[PricePolicyInitializer] 가격 정책 시드 데이터 삽입 완료 - {}건", policies.size());
+	}
+
+	private List<PricePolicy> buildPolicies(Section section) {
+		Long sectionId = section.getId();
+		SectionCode code = section.getCode();
+		List<PricePolicy> result = new ArrayList<>();
+
+		switch (code) {
+			case PREMIUM -> {
+				// 중앙석: 80,000 (주중=주말 동일)
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 80_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 80_000));
+			}
+			case PURPLE -> {
+				// 테이블석: 52,000 / 58,000
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 52_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 58_000));
+			}
+			case EXCITING -> {
+				// 익사이팅존: 28,000 / 33,000
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 28_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 33_000));
+			}
+			case BLUE -> {
+				// 블루석: 22,000 / 24,000 | 장애인 50%: 11,000 / 12,000
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 22_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 24_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 11_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 12_000));
+			}
+			case ORANGE -> {
+				// 오렌지석: 20,000 / 22,000 | 장애인 50%: 10,000 / 11,000
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 20_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 22_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 10_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 11_000));
+			}
+			case RED -> {
+				// 레드석: 17,000 / 19,000 | 장애인 50%: 8,500 / 9,500
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 17_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 19_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 8_500));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 9_500));
+			}
+			case NAVY -> {
+				// 네이비석: 14,000 (주중=주말) | 장애인 50%: 7,000
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 14_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 14_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 7_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 7_000));
+			}
+			case GREEN -> {
+				// 외야 지정석: 일반 / 청소년·군경 / 어린이·유공자·경로·장애인
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.ADULT, 9_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.ADULT, 10_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.YOUTH, 7_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.YOUTH, 8_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.MILITARY, 7_000));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.MILITARY, 8_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.CHILD, 4_500));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.CHILD, 5_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.VETERAN, 4_500));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.VETERAN, 5_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.SENIOR, 4_500));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.SENIOR, 5_000));
+				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 4_500));
+				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 5_000));
+			}
+		}
+
+		return result;
+	}
+
+	private PricePolicy policy(Long sectionId, DayType dayType, TicketType ticketType, int price) {
+		return PricePolicy.builder()
+			.stadiumId(JAMSIL_STADIUM_ID)
+			.sectionId(sectionId)
+			.dayType(dayType)
+			.ticketType(ticketType)
+			.price(price)
+			.build();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
@@ -133,6 +133,7 @@ public class PricePolicyInitializer implements CommandLineRunner {
 				result.add(policy(sectionId, DayType.WEEKDAY, TicketType.DISABLED, 4_500));
 				result.add(policy(sectionId, DayType.WEEKEND, TicketType.DISABLED, 5_000));
 			}
+			default -> log.warn("[PricePolicyInitializer] 가격 정책 미정의 섹션 코드: {} (section_id={}). 가격 정책을 추가해 주세요.", code, sectionId);
 		}
 
 		return result;

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
@@ -2,7 +2,7 @@ package com.goormgb.be.seat.pricePolicy.entity;
 
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.seat.pricePolicy.enums.DayType;
-import com.goormgb.be.seat.pricePolicy.enums.TicketType;
+import com.goormgb.be.domain.ticket.enums.TicketType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
@@ -1,8 +1,13 @@
 package com.goormgb.be.seat.section.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+
+	List<Section> findByCode(SectionCode code);
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/ticket/enums/TicketType.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/ticket/enums/TicketType.java
@@ -1,4 +1,4 @@
-package com.goormgb.be.seat.pricePolicy.enums;
+package com.goormgb.be.domain.ticket.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +9,7 @@ public enum TicketType {
 
 	ADULT("일반"),
 	YOUTH("청소년"),
+	MILITARY("군경"),
 	CHILD("어린이"),
 	SENIOR("경로"),
 	VETERAN("국가유공자"),


### PR DESCRIPTION
## 🔧 작업 내용
 - 마이페이지 기능 구현을 위한 ERD 설계 및 Order-Core 도메인 엔티티 전체 구현
- 마이페이지를 설계하다보니 주문서 작성 → 결제 → 취소/환불 흐름 전체가 마이페이지와 직결되어 있어, 주문/결제 도메인까지 이번 작업 범위에 포함했습니다!

생각보다 설계 결정이 많아 작업이 지연되었습니다,,, 
마이페이지 기능 작업이 많을 것 같아서 Service/Controller로 분리해서 PR이 올라갈 수도 있을 것 같습니다.

**이번 PR에서 다루는 범위**
- Order-Core 도메인 엔티티 + Repository 구현
- Seat 모듈 가격 시드 데이터 추가
- TicketType enum 공통화 (common-core 이동)

## 🧩 구현 상세
### ERD 설계 주요 결정

  - **현금영수증 별도 테이블 분리** (`cash_receipts`): `payments`에 인라인으로 두지 않고 분리.
미신청 시 row 없음 → null 컬럼 없는 구조, `purpose` 값에 따라 `number`의 의미(전화번호/사업자번호)가 달라지는 구조
- **예매자 정보를 `orders`에 포함**: 로그인 유저 정보와 별개로 주문서 작성 시
직접 입력받는 값 (`orderer_name`, `orderer_email`, `orderer_phone`, `orderer_birth_date`)
- **취소 수수료 정책 테이블** (`cancellation_fee_policies`): 정책을 하드코딩하지 않고 DB 시드로 관리. `daysBeforeMatchMax = null` 로 상한 없음(D-7+) 표현
- **예매 대행 수수료** (`booking_fee`): `orders`에 고정 2,000원 컬럼으로 분리. `total_amount`와 별도 추적하여 환불 계산 시 명시적으로 처리

### TicketType 공통화 이유
`TicketType`이 Seat(가격 정책)과 Order-Core(주문 좌석) 두 모듈에서 동일하게 필요해  `common-core`로 이동했습니다!

### 시드 데이터
앱 시작 시 자동 삽입 (`CommandLineRunner`)
- `PricePolicyInitializer` (@Order(2), Seat): 잠실야구장 전 좌석 주중/주말 가격 (섹션 × 권종)
- `CancellationFeePolicyInitializer` (@Order(1), Order-Core): 취소 수수료 3구간 정책

### 📌 관련 Jira Issue
- GRGB-242

## ❗ 참고 사항
- **후속 PR 예정**
  - `feat(order-core): 주문/결제 Service + Controller 구현`
  - `feat(order-core): 마이페이지 Service + Controller 구현` 

- `TicketType` 참조 모듈(Seat, Order-Core) import 경로 변경됨 → 빌드 확인 필요
- `CancellationFeePolicy.daysBeforeMatchMax = null` 은 상한 없음을 의미. `bookingFeeRefundable = true`인 경우에도 예매 당일 취소 여부는 애플리케이션 레벨에서 추가 검증 필요