### PR TITLE
Grgb 241/queue domain setting [GRGB-241]

### DIFF
--- a/Queue/build.gradle
+++ b/Queue/build.gradle
@@ -5,12 +5,22 @@ dependencies {
     implementation project(':common-core')
     testImplementation(testFixtures(project(':common-core')))
 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // 필수: JSON 로깅
     implementation "net.logstash.logback:logstash-logback-encoder:7.4"
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
 
     runtimeOnly 'org.postgresql:postgresql'
 }

--- a/Queue/src/main/java/com/goormgb/be/queue/config/QueuePollingProperties.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/QueuePollingProperties.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.queue.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "queue.polling")
+public record QueuePollingProperties(
+	long readyMs,
+	long fastMs,
+	long mediumMs,
+	long slowMs,
+	long fastRankThreshold,
+	long mediumRankThreshold
+) {
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/config/QueueProperties.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/QueueProperties.java
@@ -1,0 +1,26 @@
+package com.goormgb.be.queue.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "queue")
+public record QueueProperties(
+	Long readyTtlSeconds,
+	Integer promotionBatchSize,
+	Long promotionIntervalMs,
+	String activeMatchKey,
+	String waitKeyPrefix,
+	String readyKeyPrefix,
+	String preferenceKeyPrefix
+) {
+	public String waitKey(Long matchId) {
+		return waitKeyPrefix + ":" + matchId;
+	}
+
+	public String readyKey(Long matchId, Long userId) {
+		return readyKeyPrefix + ":" + matchId + ":" + userId;
+	}
+
+	public String preferenceKey(Long matchId, Long userId) {
+		return preferenceKeyPrefix + ":" + matchId + ":" + userId;
+	}
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/config/QueueProperties.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/QueueProperties.java
@@ -4,13 +4,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "queue")
 public record QueueProperties(
-	Long readyTtlSeconds,
-	Integer promotionBatchSize,
-	Long promotionIntervalMs,
+	long readyTtlSeconds,
+	int promotionBatchSize,
+	long promotionIntervalMs,
 	String activeMatchKey,
 	String waitKeyPrefix,
 	String readyKeyPrefix,
-	String preferenceKeyPrefix
+	String preferenceKeyPrefix,
+	String expiredKeyPrefix
 ) {
 	public String waitKey(Long matchId) {
 		return waitKeyPrefix + ":" + matchId;
@@ -22,5 +23,9 @@ public record QueueProperties(
 
 	public String preferenceKey(Long matchId, Long userId) {
 		return preferenceKeyPrefix + ":" + matchId + ":" + userId;
+	}
+
+	public String expiredKey(Long matchId, Long userId) {
+		return expiredKeyPrefix + ":" + matchId + ":" + userId;
 	}
 }

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SchedulerConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.queue.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/dto/request/QueueEnterRequest.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/dto/request/QueueEnterRequest.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.queue.queue.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record QueueEnterRequest(
+	boolean recommendationEnabled,
+
+	@Min(1)
+	@Max(10)
+	int ticketCount,
+
+	@Size(max = 10)
+	List<Long> preferredBlockIds
+) {
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/dto/response/QueueStatusResponse.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/dto/response/QueueStatusResponse.java
@@ -1,0 +1,20 @@
+package com.goormgb.be.queue.queue.dto.response;
+
+import com.goormgb.be.queue.queue.enums.QueueStatus;
+
+public record QueueStatusResponse(
+	QueueStatus status,
+	Long rank,
+	Long totalWaitingCount,
+	String admissionToken,
+	Long expiresIn,
+	Long pollingMs
+) {
+	public static QueueStatusResponse waiting(long rank, long totalWaitingCount, long pollingMs) {
+		return new QueueStatusResponse(QueueStatus.WAITING, rank, totalWaitingCount, null, null, pollingMs);
+	}
+
+	public static QueueStatusResponse ready(String admissionToken, long expiresIn) {
+		return new QueueStatusResponse(QueueStatus.READY, null, null, admissionToken, expiresIn, null);
+	}
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/enums/QueueStatus.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/enums/QueueStatus.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.queue.queue.enums;
+
+public enum QueueStatus {
+	WAITING,
+	READY,
+	EXPIRED,
+	ENTERED
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/model/ReadyTokenPayload.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/model/ReadyTokenPayload.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.queue.queue.model;
+
+import java.time.Instant;
+
+public record ReadyTokenPayload(
+	Long userId,
+	Long matchId,
+	String admissionToken,
+	Instant issuedAt,
+	Instant expiresAt
+) {
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/model/SeatPreferenceCache.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/model/SeatPreferenceCache.java
@@ -1,0 +1,14 @@
+package com.goormgb.be.queue.queue.model;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SeatPreferenceCache(
+	Long userId,
+	Long matchId,
+	boolean recommendationEnabled,
+	int ticketCount,
+	List<Long> preferredBlockIds,
+	Instant enteredAt
+) {
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/policy/QueuePollingPolicy.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/policy/QueuePollingPolicy.java
@@ -1,0 +1,27 @@
+package com.goormgb.be.queue.queue.policy;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.queue.config.QueuePollingProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QueuePollingPolicy {
+	private final QueuePollingProperties properties;
+
+	public long forReady() {
+		return properties.readyMs();
+	}
+
+	public long forWaiting(long rank) {
+		if (rank <= 0 || rank <= properties.fastRankThreshold()) {
+			return properties.fastMs();
+		}
+		if (rank <= properties.mediumRankThreshold()) {
+			return properties.mediumMs();
+		}
+		return properties.slowMs();
+	}
+}

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/policy/QueuePollingPolicy.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/policy/QueuePollingPolicy.java
@@ -16,7 +16,7 @@ public class QueuePollingPolicy {
 	}
 
 	public long forWaiting(long rank) {
-		if (rank <= 0 || rank <= properties.fastRankThreshold()) {
+        if (rank <= properties.fastRankThreshold()) {
 			return properties.fastMs();
 		}
 		if (rank <= properties.mediumRankThreshold()) {

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/repository/QueueRedisRepository.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/repository/QueueRedisRepository.java
@@ -1,0 +1,182 @@
+package com.goormgb.be.queue.queue.repository;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goormgb.be.queue.config.QueueProperties;
+import com.goormgb.be.queue.queue.model.ReadyTokenPayload;
+import com.goormgb.be.queue.queue.model.SeatPreferenceCache;
+
+@Repository
+public class QueueRedisRepository {
+
+	private final StringRedisTemplate redisTemplate;
+	private final QueueProperties queueProperties;
+	private final ObjectMapper redisObjectMapper;
+
+	public QueueRedisRepository(
+		StringRedisTemplate redisTemplate,
+		QueueProperties queueProperties,
+		@Qualifier("redisObjectMapper") ObjectMapper redisObjectMapper
+	) {
+		this.redisTemplate = redisTemplate;
+		this.queueProperties = queueProperties;
+		this.redisObjectMapper = redisObjectMapper;
+	}
+
+	public void saveSeatPreference(SeatPreferenceCache preference) {
+		setJson(
+			queueProperties.preferenceKey(preference.matchId(), preference.userId()),
+			preference
+		);
+	}
+
+	public void saveSeatPreference(SeatPreferenceCache preference, Duration ttl) {
+		setJson(
+			queueProperties.preferenceKey(preference.matchId(), preference.userId()),
+			preference,
+			ttl
+		);
+	}
+
+	public SeatPreferenceCache getSeatPreference(Long matchId, Long userId) {
+		return getJson(queueProperties.preferenceKey(matchId, userId), SeatPreferenceCache.class);
+	}
+
+	public void addToWaitingQueue(Long matchId, Long userId, long enteredAtMillis) {
+		redisTemplate.opsForZSet().add(queueProperties.waitKey(matchId), String.valueOf(userId), enteredAtMillis);
+	}
+
+	public boolean isUserInWaitingQueue(Long matchId, Long userId) {
+		return redisTemplate.opsForZSet().score(queueProperties.waitKey(matchId), String.valueOf(userId)) != null;
+	}
+
+	public long getWaitingRank(Long matchId, Long userId) {
+		Long rank = redisTemplate.opsForZSet().rank(queueProperties.waitKey(matchId), String.valueOf(userId));
+		if (rank == null) {
+			return -1L;
+		}
+		return rank + 1;
+	}
+
+	public long getWaitingCount(Long matchId) {
+		Long count = redisTemplate.opsForZSet().zCard(queueProperties.waitKey(matchId));
+		return count == null ? 0L : count;
+	}
+
+	public List<Long> popWaitingUsers(Long matchId, long count) {
+		Set<ZSetOperations.TypedTuple<String>> entries =
+			redisTemplate.opsForZSet().popMin(queueProperties.waitKey(matchId), count);
+
+		if (entries == null || entries.isEmpty()) {
+			return List.of();
+		}
+
+		return entries.stream()
+			.map(ZSetOperations.TypedTuple::getValue)
+			.map(Long::valueOf)
+			.toList();
+	}
+
+	public void removeFromWaitingQueue(Long matchId, Long userId) {
+		redisTemplate.opsForZSet().remove(queueProperties.waitKey(matchId), String.valueOf(userId));
+	}
+
+	public void saveReadyToken(ReadyTokenPayload payload) {
+		setJson(
+			queueProperties.readyKey(payload.matchId(), payload.userId()),
+			payload,
+			Duration.ofSeconds(queueProperties.readyTtlSeconds())
+		);
+	}
+
+	public ReadyTokenPayload getReadyToken(Long matchId, Long userId) {
+		return getJson(queueProperties.readyKey(matchId, userId), ReadyTokenPayload.class);
+	}
+
+	public boolean hasReadyToken(Long matchId, Long userId) {
+		Boolean exists = redisTemplate.hasKey(queueProperties.readyKey(matchId, userId));
+		return Boolean.TRUE.equals(exists);
+	}
+
+	public boolean isAlreadyQueued(Long matchId, Long userId) {
+		return isUserInWaitingQueue(matchId, userId) || hasReadyToken(matchId, userId);
+	}
+
+	public long getReadyTokenTtlSeconds(Long matchId, Long userId) {
+		Long ttlSeconds = redisTemplate.getExpire(queueProperties.readyKey(matchId, userId));
+		if (ttlSeconds == null) {
+			return -2L;
+		}
+		return ttlSeconds;
+	}
+
+	public void deleteReadyToken(Long matchId, Long userId) {
+		redisTemplate.delete(queueProperties.readyKey(matchId, userId));
+	}
+
+	public void addActiveMatch(Long matchId) {
+		redisTemplate.opsForSet().add(queueProperties.activeMatchKey(), String.valueOf(matchId));
+	}
+
+	public void removeActiveMatch(Long matchId) {
+		redisTemplate.opsForSet().remove(queueProperties.activeMatchKey(), String.valueOf(matchId));
+	}
+
+	public Set<Long> getActiveMatches() {
+		Set<String> matches = redisTemplate.opsForSet().members(queueProperties.activeMatchKey());
+		if (matches == null || matches.isEmpty()) {
+			return Set.of();
+		}
+
+		return matches.stream()
+			.map(Long::valueOf)
+			.collect(java.util.stream.Collectors.toUnmodifiableSet());
+	}
+
+	public void markExpired(Long matchId, Long userId, Duration ttl) {
+		redisTemplate.opsForValue().set(queueProperties.expiredKey(matchId, userId), "1", ttl);
+	}
+
+	public boolean isExpired(Long matchId, Long userId) {
+		Boolean exists = redisTemplate.hasKey(queueProperties.expiredKey(matchId, userId));
+		return Boolean.TRUE.equals(exists);
+	}
+
+	private void setJson(String key, Object value) {
+		try {
+			redisTemplate.opsForValue().set(key, redisObjectMapper.writeValueAsString(value));
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Failed to serialize Redis value for key: " + key, e);
+		}
+	}
+
+	private void setJson(String key, Object value, Duration ttl) {
+		try {
+			redisTemplate.opsForValue().set(key, redisObjectMapper.writeValueAsString(value), ttl);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Failed to serialize Redis value for key: " + key, e);
+		}
+	}
+
+	private <T> T getJson(String key, Class<T> type) {
+		String raw = redisTemplate.opsForValue().get(key);
+		if (raw == null) {
+			return null;
+		}
+
+		try {
+			return redisObjectMapper.readValue(raw, type);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("Failed to deserialize Redis value for key: " + key, e);
+		}
+	}
+}

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -38,6 +38,14 @@ queue:
   wait-key-prefix: queue:wait
   ready-key-prefix: queue:ready
   preference-key-prefix: seat:preference
+  expired-key-prefix: queue:expired
+  polling:
+    ready-ms: 1000
+    fast-ms: 1500
+    medium-ms: 3000
+    slow-ms: 5000
+    fast-rank-threshold: 100
+    medium-rank-threshold: 1000
 
   security:
     jwt:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -30,6 +30,20 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+queue:
+  ready-ttl-seconds: 30
+  promotion-batch-size: 100
+  promotion-interval-ms: 1000
+  active-match-key: queue:match
+  wait-key-prefix: queue:wait
+  ready-key-prefix: queue:ready
+  preference-key-prefix: seat:preference
+
+  security:
+    jwt:
+      admission-secret: ${ADMISSION_JWT_SECRET}
+      issuer: queue-service
+
 springdoc:
   swagger-ui:
     urls:


### PR DESCRIPTION
 ## 🔧 작업 내용

  - Queue 서비스 초기 골격을 구성.
  - Redis ZSET 기반 대기열 구현을 위한 설정, 모델, polling 정책, Redis Repository를 추가.
  - 이후 Service, Controller, Scheduler 구현 전에 필요한 Redis 키 구조와 접근 방식을 먼저 정리.

  ## 🧩 구현 상세

  - application.yaml에 대기열 운영 설정을 추가.
      - READY TTL, promotion 주기, Redis key prefix, polling 정책 등
  - QueueProperties, QueuePollingProperties를 통해 설정값을 코드와 분리.
  - QueuePollingPolicy를 추가해 rank 기반 동적 polling 간격 정책을 구성.
  - QueueRedisRepository를 구현해 아래 Redis 연산을 캡슐화.
      - 대기열 진입 정보 저장
      - WAITING ZSET 등록 / 순위 조회 / 인원 수 조회
      - READY 토큰 저장 및 TTL 조회
      - 활성 경기 관리
      - expired marker 관리
  - Redis 공통 로직은 아직 Repository 하나에서만 쓰이므로 별도 RedisSupport 없이 Repository 내부 helper로 유지.

  ### 📌 관련 Jira Issue

  - GRGB-241

  ## 🧪 테스트 방법(선택)

  - QueueRedisRepository 메서드 단위 확인
  - Redis에 아래 key가 의도대로 저장/조회되는지 확인
      - queue:wait:{matchId}
      - queue:ready:{matchId}:{userId}
      - seat:preference:{matchId}:{userId}
      - queue:match
      - queue:expired:{matchId}:{userId}
  - 확인 포인트
      - ZSET rank가 1-based로 반환되는지
      - READY TTL 조회가 정상 동작하는지
      - 중복 진입 체크가 WAITING/READY 모두 반영되는지

  ## ❗ 참고 사항

  - 현재 범위는 Queue 서비스의 초기 설정 및 Redis Repository까지입니다.
  - Service, Controller, Scheduler, admissionToken 발급/검증 로직은 후속 작업 예정입니다.
