### PR TITLE
feat(order-core): 주문·결제 API 구현 및 테스트 작성 [GRGB-243]

### DIFF
--- a/.github/workflows/jira-pr-sync.yml
+++ b/.github/workflows/jira-pr-sync.yml
@@ -56,23 +56,43 @@ jobs:
 
           echo "=== Transition start ==="
 
-          curl --fail -L -s -X POST \
+          TRANSITION_RESPONSE=$(mktemp)
+          TRANSITION_STATUS=$(curl -L -s -o "$TRANSITION_RESPONSE" -w "%{http_code}" -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
-            -d "{\"transition\":{\"id\":\"$REVIEW_ID\"}}"
+            -d "{\"transition\":{\"id\":\"$REVIEW_ID\"}}")
+
+          echo "Transition HTTP status: $TRANSITION_STATUS"
+          echo "Transition response body:"
+          cat "$TRANSITION_RESPONSE"
+
+          if [ "$TRANSITION_STATUS" -lt 200 ] || [ "$TRANSITION_STATUS" -ge 300 ]; then
+            echo "Transition request failed"
+            exit 1
+          fi
 
           echo "=== Transition success ==="
 
           echo "=== Comment start ==="
 
-          curl --fail -L -s -X POST \
+          COMMENT_RESPONSE=$(mktemp)
+          COMMENT_STATUS=$(curl -L -s -o "$COMMENT_RESPONSE" -w "%{http_code}" -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/comment" \
-            -d "{\"body\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"PR 링크: $PR_URL\"}]}]}}"
+            -d "{\"body\":{\"type\":\"doc\",\"version\":1,\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"PR 링크: $PR_URL\"}]}]}}")
+
+          echo "Comment HTTP status: $COMMENT_STATUS"
+          echo "Comment response body:"
+          cat "$COMMENT_RESPONSE"
+
+          if [ "$COMMENT_STATUS" -lt 200 ] || [ "$COMMENT_STATUS" -ge 300 ]; then
+            echo "Comment request failed"
+            exit 1
+          fi
 
           echo "=== Comment success ==="
 
@@ -95,11 +115,21 @@ jobs:
 
           echo "=== Done transition start ==="
 
-          curl --fail -L -s -X POST \
+          DONE_RESPONSE=$(mktemp)
+          DONE_STATUS=$(curl -L -s -o "$DONE_RESPONSE" -w "%{http_code}" -X POST \
             -H "Authorization: Basic $AUTH" \
             -H "Accept: application/json" \
             -H "Content-Type: application/json" \
             "$JIRA_BASE_URL/rest/api/3/issue/$ISSUE_KEY/transitions" \
-            -d "{\"transition\":{\"id\":\"$DONE_ID\"}}"
+            -d "{\"transition\":{\"id\":\"$DONE_ID\"}}")
+
+          echo "Done transition HTTP status: $DONE_STATUS"
+          echo "Done transition response body:"
+          cat "$DONE_RESPONSE"
+
+          if [ "$DONE_STATUS" -lt 200 ] || [ "$DONE_STATUS" -ge 300 ]; then
+            echo "Done transition request failed"
+            exit 1
+          fi
 
           echo "=== Done transition success ==="

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -78,6 +78,6 @@ public class OrderController {
 		@AuthenticationPrincipal Long userId,
 		@Valid @RequestBody OrderCreateRequest request
 	) {
-		return ApiResult.ok(orderService.createOrder(userId, request));
+		return ApiResult.created(orderService.createOrder(userId, request));
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -1,0 +1,83 @@
+package com.goormgb.be.ordercore.order.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
+import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
+import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
+import com.goormgb.be.ordercore.order.service.OrderService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Order", description = "주문 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage/orders")
+public class OrderController {
+
+	private final OrderService orderService;
+
+	@Operation(
+		summary = "주문서 조회",
+		description = "선점된 좌석의 경기·좌석 상세 정보와 예상 금액을 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 파라미터 오류 또는 선점 만료", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "선점 소유권 없음", content = @Content),
+		@ApiResponse(responseCode = "404", description = "경기 또는 좌석 선점 없음", content = @Content)
+	})
+	@GetMapping("/sheet")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<OrderSheetGetResponse> getOrderSheet(
+		@AuthenticationPrincipal Long userId,
+		@Parameter(description = "경기 ID", required = true, example = "1")
+		@RequestParam Long matchId,
+		@Parameter(description = "match_seat ID 목록 (콤마 구분)", required = true)
+		@RequestParam List<Long> seatIds
+	) {
+		return ApiResult.ok(orderService.getOrderSheet(userId, matchId, seatIds));
+	}
+
+	@Operation(
+		summary = "주문 생성",
+		description = "예매자 정보 및 좌석·티켓 타입을 입력받아 주문을 생성합니다. 결제는 별도로 진행합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "주문 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "요청 값 오류 또는 좌석 선점 만료", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "선점 소유권 없음", content = @Content),
+		@ApiResponse(responseCode = "404", description = "경기 또는 좌석 선점 없음", content = @Content)
+	})
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResult<OrderCreateResponse> createOrder(
+		@AuthenticationPrincipal Long userId,
+		@Valid @RequestBody OrderCreateRequest request
+	) {
+		return ApiResult.ok(orderService.createOrder(userId, request));
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
@@ -1,6 +1,5 @@
 package com.goormgb.be.ordercore.order.dto.request;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import jakarta.validation.Valid;
@@ -8,6 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record OrderCreateRequest(
@@ -32,7 +32,8 @@ public record OrderCreateRequest(
 	@Size(max = 20)
 	String ordererPhone,
 
-	@NotNull(message = "예매자 생년월일은 필수입니다.")
-	LocalDate ordererBirthDate
+	@NotBlank(message = "예매자 생년월일은 필수입니다.")
+	@Pattern(regexp = "^\\d{6}$", message = "생년월일은 6자리 숫자여야 합니다. (예: 990831)")
+	String ordererBirthDate
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,38 @@
+package com.goormgb.be.ordercore.order.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record OrderCreateRequest(
+
+	@NotNull(message = "matchId는 필수입니다.")
+	Long matchId,
+
+	@NotEmpty(message = "좌석 정보는 최소 1개 이상이어야 합니다.")
+	@Valid
+	List<SeatOrderItem> seats,
+
+	@NotBlank(message = "예매자 이름은 필수입니다.")
+	@Size(max = 50)
+	String ordererName,
+
+	@NotBlank(message = "예매자 이메일은 필수입니다.")
+	@Email(message = "이메일 형식이 올바르지 않습니다.")
+	@Size(max = 255)
+	String ordererEmail,
+
+	@NotBlank(message = "예매자 휴대폰 번호는 필수입니다.")
+	@Size(max = 20)
+	String ordererPhone,
+
+	@NotNull(message = "예매자 생년월일은 필수입니다.")
+	LocalDate ordererBirthDate
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.ordercore.order.dto.request;
+
+import com.goormgb.be.domain.ticket.enums.TicketType;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeatOrderItem(
+
+	@NotNull(message = "matchSeatId는 필수입니다.")
+	Long matchSeatId,
+
+	@NotNull(message = "ticketType은 필수입니다.")
+	TicketType ticketType
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
@@ -1,0 +1,29 @@
+package com.goormgb.be.ordercore.order.dto.response;
+
+import java.time.Instant;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+
+public record OrderCreateResponse(
+	Long orderId,
+	OrderStatus status,
+	Long matchId,
+	int seatCount,
+	int totalAmount,
+	int bookingFee,
+	Instant createdAt
+) {
+
+	public static OrderCreateResponse of(Order order, int seatCount) {
+		return new OrderCreateResponse(
+			order.getId(),
+			order.getStatus(),
+			order.getMatch().getId(),
+			seatCount,
+			order.getTotalAmount(),
+			order.getBookingFee(),
+			order.getCreatedAt()
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
@@ -1,0 +1,74 @@
+package com.goormgb.be.ordercore.order.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
+
+public record OrderSheetGetResponse(
+	MatchInfo match,
+	List<SeatInfo> seats,
+	Summary summary
+) {
+
+	public record MatchInfo(
+		Long matchId,
+		Instant matchAt,
+		ClubInfo homeClub,
+		ClubInfo awayClub,
+		StadiumInfo stadium
+	) {
+		public static MatchInfo from(Match match) {
+			return new MatchInfo(
+				match.getId(),
+				match.getMatchAt(),
+				new ClubInfo(match.getHomeClub().getId(), match.getHomeClub().getKoName()),
+				new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
+				new StadiumInfo(
+					match.getStadium().getId(),
+					match.getStadium().getKoName(),
+					match.getStadium().getAddress()
+				)
+			);
+		}
+	}
+
+	public record ClubInfo(Long clubId, String koName) {}
+
+	public record StadiumInfo(Long stadiumId, String koName, String address) {}
+
+	public record SeatInfo(
+		Long matchSeatId,
+		Long sectionId,
+		String sectionName,
+		Long blockId,
+		String blockCode,
+		Integer rowNo,
+		Integer seatNo,
+		Integer adultPrice
+	) {
+		public static SeatInfo of(SeatHoldInfo holdInfo, Integer adultPrice) {
+			return new SeatInfo(
+				holdInfo.matchSeatId(),
+				holdInfo.sectionId(),
+				holdInfo.sectionName(),
+				holdInfo.blockId(),
+				holdInfo.blockCode(),
+				holdInfo.rowNo(),
+				holdInfo.seatNo(),
+				adultPrice
+			);
+		}
+	}
+
+	public record Summary(int seatCount, int bookingFee) {}
+
+	public static OrderSheetGetResponse of(Match match, List<SeatInfo> seats) {
+		return new OrderSheetGetResponse(
+			MatchInfo.from(match),
+			seats,
+			new Summary(seats.size(), 2000)
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
@@ -7,68 +7,73 @@ import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 
 public record OrderSheetGetResponse(
-	MatchInfo match,
-	List<SeatInfo> seats,
-	Summary summary
+		MatchInfo match,
+		List<SeatInfo> seats,
+		Summary summary
 ) {
 
 	public record MatchInfo(
-		Long matchId,
-		Instant matchAt,
-		ClubInfo homeClub,
-		ClubInfo awayClub,
-		StadiumInfo stadium
+			Long matchId,
+			Instant matchAt,
+			ClubInfo homeClub,
+			ClubInfo awayClub,
+			StadiumInfo stadium
 	) {
 		public static MatchInfo from(Match match) {
 			return new MatchInfo(
-				match.getId(),
-				match.getMatchAt(),
-				new ClubInfo(match.getHomeClub().getId(), match.getHomeClub().getKoName()),
-				new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
-				new StadiumInfo(
-					match.getStadium().getId(),
-					match.getStadium().getKoName(),
-					match.getStadium().getAddress()
-				)
+					match.getId(),
+					match.getMatchAt(),
+					new ClubInfo(match.getHomeClub().getId(), match.getHomeClub().getKoName()),
+					new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
+					new StadiumInfo(
+							match.getStadium().getId(),
+							match.getStadium().getKoName(),
+							match.getStadium().getAddress()
+					)
 			);
 		}
 	}
 
-	public record ClubInfo(Long clubId, String koName) {}
+	public record ClubInfo(Long clubId, String koName) {
+	}
 
-	public record StadiumInfo(Long stadiumId, String koName, String address) {}
+	public record StadiumInfo(Long stadiumId, String koName, String address) {
+	}
 
 	public record SeatInfo(
-		Long matchSeatId,
-		Long sectionId,
-		String sectionName,
-		Long blockId,
-		String blockCode,
-		Integer rowNo,
-		Integer seatNo,
-		Integer adultPrice
+			Long matchSeatId,
+			Long sectionId,
+			String sectionName,
+			Long blockId,
+			String blockCode,
+			Integer rowNo,
+			Integer seatNo,
+			Integer adultPrice
 	) {
 		public static SeatInfo of(SeatHoldInfo holdInfo, Integer adultPrice) {
 			return new SeatInfo(
-				holdInfo.matchSeatId(),
-				holdInfo.sectionId(),
-				holdInfo.sectionName(),
-				holdInfo.blockId(),
-				holdInfo.blockCode(),
-				holdInfo.rowNo(),
-				holdInfo.seatNo(),
-				adultPrice
+					holdInfo.matchSeatId(),
+					holdInfo.sectionId(),
+					holdInfo.sectionName(),
+					holdInfo.blockId(),
+					holdInfo.blockCode(),
+					holdInfo.rowNo(),
+					holdInfo.seatNo(),
+					adultPrice
 			);
 		}
 	}
 
-	public record Summary(int seatCount, int bookingFee) {}
+	public record Summary(int seatCount, int bookingFee) {
+	}
+
+	private static final int BOOKING_FEE = 2_000;
 
 	public static OrderSheetGetResponse of(Match match, List<SeatInfo> seats) {
 		return new OrderSheetGetResponse(
-			MatchInfo.from(match),
-			seats,
-			new Summary(seats.size(), 2000)
+				MatchInfo.from(match),
+				seats,
+				new Summary(seats.size(), BOOKING_FEE)
 		);
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -1,7 +1,6 @@
 package com.goormgb.be.ordercore.order.entity;
 
 import java.time.Instant;
-import java.time.LocalDate;
 
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.global.entity.BaseEntity;
@@ -75,8 +74,8 @@ public class Order extends BaseEntity {
 	@Column(name = "orderer_phone", nullable = false, length = 20)
 	private String ordererPhone;
 
-	@Column(name = "orderer_birth_date", nullable = false)
-	private LocalDate ordererBirthDate;
+	@Column(name = "orderer_birth_date", nullable = false, length = 6)
+	private String ordererBirthDate;
 
 	@Builder
 	public Order(
@@ -86,7 +85,7 @@ public class Order extends BaseEntity {
 		String ordererName,
 		String ordererEmail,
 		String ordererPhone,
-		LocalDate ordererBirthDate
+		String ordererBirthDate
 	) {
 		this.user = user;
 		this.match = match;

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatHoldInfo.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatHoldInfo.java
@@ -1,0 +1,20 @@
+package com.goormgb.be.ordercore.order.query;
+
+import java.time.Instant;
+
+public record SeatHoldInfo(
+	Long holdId,
+	Long matchSeatId,
+	Long userId,
+	Instant expiresAt,
+	Long sectionId,
+	String sectionName,
+	Long blockId,
+	String blockCode,
+	Integer rowNo,
+	Integer seatNo
+) {
+	public boolean isExpired(Instant now) {
+		return expiresAt.isBefore(now);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
@@ -1,0 +1,98 @@
+package com.goormgb.be.ordercore.order.query;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeatInfoQueryService {
+
+	private final NamedParameterJdbcTemplate namedJdbc;
+
+	/**
+	 * matchSeatIds에 해당하는 좌석 선점 정보와 좌석 상세 정보를 조회한다.
+	 * user_id 검증과 만료 여부도 함께 수행한다.
+	 */
+	public List<SeatHoldInfo> findSeatHoldInfos(Long userId, List<Long> matchSeatIds) {
+		String sql = """
+				SELECT
+					sh.id        AS hold_id,
+					sh.match_seat_id,
+					sh.user_id,
+					sh.expires_at,
+					ms.section_id, 
+					sec.name     AS section_name,
+					ms.block_id,
+					b.block_code,
+					ms.row_no,
+					ms.seat_no
+				FROM seat_holds sh
+				JOIN match_seats ms  ON sh.match_seat_id = ms.id
+				JOIN blocks b        ON ms.block_id       = b.id
+				JOIN sections sec    ON ms.section_id     = sec.id
+				WHERE sh.match_seat_id IN (:matchSeatIds)
+				  AND sh.user_id = :userId
+				""";
+
+		var params = new MapSqlParameterSource()
+				.addValue("matchSeatIds", matchSeatIds)
+				.addValue("userId", userId);
+
+		return namedJdbc.query(sql, params, (rs, rowNum) -> new SeatHoldInfo(
+				rs.getLong("hold_id"),
+				rs.getLong("match_seat_id"),
+				rs.getLong("user_id"),
+				rs.getObject("expires_at", Timestamp.class).toInstant(),
+				rs.getLong("section_id"),
+				rs.getString("section_name"),
+				rs.getLong("block_id"),
+				rs.getString("block_code"),
+				rs.getInt("row_no"),
+				rs.getInt("seat_no")
+		));
+	}
+
+	/**
+	 * (sectionId, dayType, ticketType) 조합에 해당하는 가격을 조회한다.
+	 */
+	public Integer findPrice(Long sectionId, String dayType, String ticketType) {
+		String sql = """
+				SELECT price
+				FROM price_policies
+				WHERE section_id  = :sectionId
+				  AND day_type    = :dayType
+				  AND ticket_type = :ticketType
+				""";
+
+		var params = Map.of(
+				"sectionId", sectionId,
+				"dayType", dayType,
+				"ticketType", ticketType
+		);
+
+		List<Integer> results = namedJdbc.queryForList(sql, params, Integer.class);
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	/**
+	 * matchSeatId로 이미 주문된 좌석인지 확인한다.
+	 */
+	public boolean isAlreadyOrdered(Long matchSeatId) {
+		String sql = """
+				SELECT COUNT(*)
+				FROM order_seats
+				WHERE match_seat_id = :matchSeatId
+				""";
+
+		var params = Map.of("matchSeatId", matchSeatId);
+		Integer count = namedJdbc.queryForObject(sql, params, Integer.class);
+		return count != null && count > 0;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -1,0 +1,155 @@
+package com.goormgb.be.ordercore.order.service;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
+import com.goormgb.be.ordercore.order.dto.request.SeatOrderItem;
+import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
+import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.entity.OrderSeat;
+import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final int BOOKING_FEE = 2000;
+
+	private final MatchRepository matchRepository;
+	private final UserRepository userRepository;
+	private final OrderRepository orderRepository;
+	private final OrderSeatRepository orderSeatRepository;
+	private final SeatInfoQueryService seatInfoQueryService;
+
+	/**
+	 * 주문서 조회: 좌석 선점 정보와 경기 정보를 조합하여 반환한다.
+	 */
+	@Transactional(readOnly = true)
+	public OrderSheetGetResponse getOrderSheet(Long userId, Long matchId, List<Long> matchSeatIds) {
+		Preconditions.validate(!matchSeatIds.isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
+
+		Match match = matchRepository.findDetailByIdOrThrow(matchId);
+
+		String dayType = determineDayType(match.getMatchAt());
+
+		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, matchSeatIds);
+		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
+
+		Instant now = Instant.now();
+		List<OrderSheetGetResponse.SeatInfo> seatInfos = holdInfos.stream()
+				.map(hold -> {
+					Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
+					Integer adultPrice = seatInfoQueryService.findPrice(hold.sectionId(), dayType, "ADULT");
+					Preconditions.validate(adultPrice != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
+					return OrderSheetGetResponse.SeatInfo.of(hold, adultPrice);
+				})
+				.toList();
+
+		return OrderSheetGetResponse.of(match, seatInfos);
+	}
+
+	/**
+	 * 주문 생성: 좌석 선점 검증 후 Order + OrderSeat 엔티티를 생성한다.
+	 */
+	public OrderCreateResponse createOrder(Long userId, OrderCreateRequest request) {
+		Preconditions.validate(!request.seats().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
+
+		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
+		Match match = matchRepository.findDetailByIdOrThrow(request.matchId());
+
+		List<Long> matchSeatIds = request.seats().stream()
+				.map(SeatOrderItem::matchSeatId)
+				.toList();
+
+		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, matchSeatIds);
+		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
+
+		Instant now = Instant.now();
+		for (SeatHoldInfo hold : holdInfos) {
+			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
+			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
+					ErrorCode.INVALID_ORDER_STATUS);
+		}
+
+		String dayType = determineDayType(match.getMatchAt());
+		Map<Long, SeatOrderItem> seatItemMap = request.seats().stream()
+				.collect(Collectors.toMap(SeatOrderItem::matchSeatId, item -> item));
+
+		// 가격 미리 계산
+		record SeatPriceItem(SeatHoldInfo hold, SeatOrderItem item, int price) {
+		}
+		List<SeatPriceItem> priceItems = new ArrayList<>();
+		int ticketTotal = 0;
+		for (SeatHoldInfo hold : holdInfos) {
+			SeatOrderItem item = seatItemMap.get(hold.matchSeatId());
+			Integer price = seatInfoQueryService.findPrice(hold.sectionId(), dayType, item.ticketType().name());
+			Preconditions.validate(price != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
+			priceItems.add(new SeatPriceItem(hold, item, price));
+			ticketTotal += price;
+		}
+		int totalAmount = ticketTotal + BOOKING_FEE;
+
+		Order order = Order.builder()
+				.user(user)
+				.match(match)
+				.totalAmount(totalAmount)
+				.ordererName(request.ordererName())
+				.ordererEmail(request.ordererEmail())
+				.ordererPhone(request.ordererPhone())
+				.ordererBirthDate(request.ordererBirthDate())
+				.build();
+
+		orderRepository.save(order);
+
+		List<OrderSeat> orderSeats = priceItems.stream()
+				.map(pi -> OrderSeat.builder()
+						.order(order)
+						.matchSeatId(pi.hold().matchSeatId())
+						.blockId(pi.hold().blockId())
+						.sectionId(pi.hold().sectionId())
+						.rowNo(pi.hold().rowNo())
+						.seatNo(pi.hold().seatNo())
+						.price(pi.price())
+						.ticketType(pi.item().ticketType())
+						.build())
+				.toList();
+
+		orderSeatRepository.saveAll(orderSeats);
+
+		log.info("[OrderService] 주문 생성 완료 - orderId={}, userId={}, seatCount={}, totalAmount={}",
+				order.getId(), userId, orderSeats.size(), totalAmount);
+
+		return OrderCreateResponse.of(order, orderSeats.size());
+	}
+
+	private String determineDayType(Instant matchAt) {
+		DayOfWeek dow = matchAt.atZone(KST).getDayOfWeek();
+		return (dow == DayOfWeek.FRIDAY || dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY)
+				? "WEEKEND" : "WEEKDAY";
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderService {
 
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-	private static final int BOOKING_FEE = 2000;
+	private static final int BOOKING_FEE = 2_000;
 
 	private final MatchRepository matchRepository;
 	private final UserRepository userRepository;
@@ -90,22 +90,20 @@ public class OrderService {
 		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
-		for (SeatHoldInfo hold : holdInfos) {
-			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
-			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
-					ErrorCode.INVALID_ORDER_STATUS);
-		}
-
 		String dayType = determineDayType(match.getMatchAt());
 		Map<Long, SeatOrderItem> seatItemMap = request.seats().stream()
 				.collect(Collectors.toMap(SeatOrderItem::matchSeatId, item -> item));
 
-		// 가격 미리 계산
+		// 유효성 검증 + 가격 계산
 		record SeatPriceItem(SeatHoldInfo hold, SeatOrderItem item, int price) {
 		}
 		List<SeatPriceItem> priceItems = new ArrayList<>();
 		int ticketTotal = 0;
 		for (SeatHoldInfo hold : holdInfos) {
+			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
+			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
+					ErrorCode.INVALID_ORDER_STATUS);
+
 			SeatOrderItem item = seatItemMap.get(hold.matchSeatId());
 			Integer price = seatInfoQueryService.findPrice(hold.sectionId(), dayType, item.ticketType().name());
 			Preconditions.validate(price != null, ErrorCode.PRICE_POLICY_NOT_FOUND);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
@@ -1,0 +1,87 @@
+package com.goormgb.be.ordercore.payment.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
+import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
+import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
+import com.goormgb.be.ordercore.payment.dto.response.PaymentProcessResponse;
+import com.goormgb.be.ordercore.payment.service.PaymentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Payment", description = "결제 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage/orders")
+public class PaymentController {
+
+	private final PaymentService paymentService;
+
+	@Operation(
+		summary = "결제 처리",
+		description = """
+			결제 수단을 선택하여 결제를 진행합니다.
+			- VIRTUAL_ACCOUNT: 가상계좌 발급, 입금 대기 상태 유지
+			- TOSS_PAY / KAKAO_PAY: 즉시 결제 완료 처리 (목업)
+			""",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "결제 처리 성공"),
+		@ApiResponse(responseCode = "400", description = "이미 결제 완료 또는 잘못된 요청", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
+		@ApiResponse(responseCode = "404", description = "주문 없음", content = @Content)
+	})
+	@PostMapping("/{orderId}/payment")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<PaymentProcessResponse> processPayment(
+		@AuthenticationPrincipal Long userId,
+		@Parameter(description = "주문 ID", required = true, example = "1")
+		@PathVariable Long orderId,
+		@Valid @RequestBody PaymentProcessRequest request
+	) {
+		return ApiResult.ok(paymentService.processPayment(userId, orderId, request));
+	}
+
+	@Operation(
+		summary = "현금영수증 신청",
+		description = "결제 완료된 주문에 현금영수증을 신청합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "201", description = "현금영수증 신청 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
+		@ApiResponse(responseCode = "404", description = "주문 또는 결제 정보 없음", content = @Content),
+		@ApiResponse(responseCode = "409", description = "현금영수증 이미 신청됨", content = @Content)
+	})
+	@PostMapping("/{orderId}/cash-receipt")
+	@ResponseStatus(HttpStatus.CREATED)
+	public ApiResult<CashReceiptCreateResponse> createCashReceipt(
+		@AuthenticationPrincipal Long userId,
+		@Parameter(description = "주문 ID", required = true, example = "1")
+		@PathVariable Long orderId,
+		@Valid @RequestBody CashReceiptCreateRequest request
+	) {
+		return ApiResult.ok(paymentService.createCashReceipt(userId, orderId, request));
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
@@ -82,6 +82,6 @@ public class PaymentController {
 		@PathVariable Long orderId,
 		@Valid @RequestBody CashReceiptCreateRequest request
 	) {
-		return ApiResult.ok(paymentService.createCashReceipt(userId, orderId, request));
+		return ApiResult.created(paymentService.createCashReceipt(userId, orderId, request));
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/CashReceiptCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/CashReceiptCreateRequest.java
@@ -1,0 +1,18 @@
+package com.goormgb.be.ordercore.payment.dto.request;
+
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CashReceiptCreateRequest(
+
+	@NotNull(message = "현금영수증 용도는 필수입니다.")
+	CashReceiptPurpose purpose,
+
+	@NotBlank(message = "현금영수증 번호는 필수입니다.")
+	@Size(max = 50)
+	String number
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
@@ -1,0 +1,12 @@
+package com.goormgb.be.ordercore.payment.dto.request;
+
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentProcessRequest(
+
+	@NotNull(message = "결제 수단은 필수입니다.")
+	PaymentMethod paymentMethod
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/CashReceiptCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/CashReceiptCreateResponse.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.ordercore.payment.dto.response;
+
+import com.goormgb.be.ordercore.payment.entity.CashReceipt;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+
+public record CashReceiptCreateResponse(
+	Long orderId,
+	CashReceiptPurpose purpose,
+	String number
+) {
+
+	public static CashReceiptCreateResponse of(Long orderId, CashReceipt cashReceipt) {
+		return new CashReceiptCreateResponse(
+			orderId,
+			cashReceipt.getPurpose(),
+			cashReceipt.getNumber()
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
@@ -1,0 +1,46 @@
+package com.goormgb.be.ordercore.payment.dto.response;
+
+import java.time.Instant;
+
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+
+public record PaymentProcessResponse(
+	Long orderId,
+	OrderStatus orderStatus,
+	PaymentMethod paymentMethod,
+	PaymentStatus paymentStatus,
+	Instant paidAt,
+	VirtualAccountInfo virtualAccount
+) {
+
+	public record VirtualAccountInfo(
+		String bank,
+		String accountNumber,
+		String holder,
+		Instant depositDeadline
+	) {}
+
+	public static PaymentProcessResponse of(Payment payment) {
+		VirtualAccountInfo vaInfo = null;
+		if (payment.getVirtualAccountBank() != null) {
+			vaInfo = new VirtualAccountInfo(
+				payment.getVirtualAccountBank(),
+				payment.getVirtualAccountNumber(),
+				payment.getVirtualAccountHolder(),
+				payment.getDepositDeadline()
+			);
+		}
+
+		return new PaymentProcessResponse(
+			payment.getOrder().getId(),
+			payment.getOrder().getStatus(),
+			payment.getPaymentMethod(),
+			payment.getStatus(),
+			payment.getPaidAt(),
+			vaInfo
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -1,0 +1,140 @@
+package com.goormgb.be.ordercore.payment.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
+import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
+import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
+import com.goormgb.be.ordercore.payment.dto.response.PaymentProcessResponse;
+import com.goormgb.be.ordercore.payment.entity.CashReceipt;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.repository.CashReceiptRepository;
+import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentService {
+
+	// 무통장 입금 가상계좌 목업 정보
+	private static final String VIRTUAL_ACCOUNT_BANK = "국민은행";
+	private static final String VIRTUAL_ACCOUNT_HOLDER = "구름GB";
+	private static final int VIRTUAL_ACCOUNT_DEADLINE_DAYS = 3;
+
+	private final OrderRepository orderRepository;
+	private final PaymentRepository paymentRepository;
+	private final CashReceiptRepository cashReceiptRepository;
+
+	/**
+	 * 결제 처리.
+	 * - VIRTUAL_ACCOUNT: 가상계좌 발급(목업), 입금 대기 상태 유지
+	 * - TOSS_PAY / KAKAO_PAY: 외부 PG 연동 없이 즉시 결제 완료 처리(목업)
+	 */
+	public PaymentProcessResponse processPayment(Long userId, Long orderId, PaymentProcessRequest request) {
+		Order order = findOrderAndValidateOwnership(userId, orderId);
+
+		Preconditions.validate(
+			order.getStatus() == OrderStatus.PAYMENT_PENDING,
+			ErrorCode.PAYMENT_ALREADY_COMPLETED
+		);
+
+		Preconditions.validate(
+			!paymentRepository.findByOrderId(orderId).isPresent(),
+			ErrorCode.PAYMENT_ALREADY_COMPLETED
+		);
+
+		Payment payment = buildPayment(order, request.paymentMethod());
+		paymentRepository.save(payment);
+
+		if (request.paymentMethod() != PaymentMethod.VIRTUAL_ACCOUNT) {
+			// 간편결제(토스페이, 카카오페이) 목업 즉시 완료
+			payment.complete();
+			order.updateStatus(OrderStatus.PAID);
+			log.info("[PaymentService] 간편결제 완료(목업) - orderId={}, method={}", orderId, request.paymentMethod());
+		} else {
+			log.info("[PaymentService] 무통장 입금 가상계좌 발급 - orderId={}", orderId);
+		}
+
+		return PaymentProcessResponse.of(payment);
+	}
+
+	/**
+	 * 현금영수증 신청.
+	 * 결제가 완료된 주문에 한해 현금영수증을 신청한다.
+	 */
+	public CashReceiptCreateResponse createCashReceipt(Long userId, Long orderId, CashReceiptCreateRequest request) {
+		Order order = findOrderAndValidateOwnership(userId, orderId);
+
+		Payment payment = paymentRepository.findByOrderId(orderId)
+			.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
+
+		Preconditions.validate(
+			!cashReceiptRepository.findByPaymentId(payment.getId()).isPresent(),
+			ErrorCode.CASH_RECEIPT_ALREADY_EXISTS
+		);
+
+		CashReceipt cashReceipt = CashReceipt.builder()
+			.payment(payment)
+			.purpose(request.purpose())
+			.number(request.number())
+			.build();
+
+		cashReceiptRepository.save(cashReceipt);
+
+		log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.purpose());
+
+		return CashReceiptCreateResponse.of(orderId, cashReceipt);
+	}
+
+	private Order findOrderAndValidateOwnership(Long userId, Long orderId) {
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+		Preconditions.validate(
+			order.getUser().getId().equals(userId),
+			ErrorCode.ORDER_ACCESS_DENIED
+		);
+
+		return order;
+	}
+
+	private Payment buildPayment(Order order, PaymentMethod method) {
+		if (method == PaymentMethod.VIRTUAL_ACCOUNT) {
+			String mockAccountNumber = generateMockAccountNumber(order.getId());
+			Instant depositDeadline = Instant.now().plus(VIRTUAL_ACCOUNT_DEADLINE_DAYS, ChronoUnit.DAYS);
+
+			return Payment.builder()
+				.order(order)
+				.paymentMethod(method)
+				.virtualAccountBank(VIRTUAL_ACCOUNT_BANK)
+				.virtualAccountNumber(mockAccountNumber)
+				.virtualAccountHolder(VIRTUAL_ACCOUNT_HOLDER)
+				.depositDeadline(depositDeadline)
+				.build();
+		}
+
+		return Payment.builder()
+			.order(order)
+			.paymentMethod(method)
+			.build();
+	}
+
+	private String generateMockAccountNumber(Long orderId) {
+		return String.format("047-000-%08d", orderId);
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/onboarding/OnboardingPreferenceFixture.java
@@ -12,12 +12,10 @@ import com.goormgb.be.domain.onboarding.enums.PriceMode;
 import com.goormgb.be.domain.onboarding.enums.SeatHeight;
 import com.goormgb.be.domain.onboarding.enums.SeatPositionPref;
 import com.goormgb.be.domain.onboarding.enums.Section;
-import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.user.entity.User;
 
 public final class OnboardingPreferenceFixture {
 
-	public static final Viewpoint DEFAULT_VIEWPOINT = Viewpoint.CENTER;
 	public static final SeatHeight DEFAULT_SEAT_HEIGHT = SeatHeight.LOW;
 	public static final Section DEFAULT_SECTION = Section.CENTER_SIDE;
 
@@ -27,10 +25,8 @@ public final class OnboardingPreferenceFixture {
 	public static OnboardingPreference createFirst(User user, Club favoriteClub) {
 		return OnboardingPreference.builder()
 			.user(user)
-			.priority(1)
 			.favoriteClub(favoriteClub)
 			.cheerProximityPref(CheerProximityPref.NEAR)
-			.viewpoint(Viewpoint.CENTER)
 			.seatHeight(SeatHeight.LOW)
 			.section(Section.CENTER_SIDE)
 			.seatPositionPref(SeatPositionPref.AISLE)
@@ -46,10 +42,8 @@ public final class OnboardingPreferenceFixture {
 	public static OnboardingPreference createSecond(User user, Club favoriteClub) {
 		return OnboardingPreference.builder()
 			.user(user)
-			.priority(2)
 			.favoriteClub(favoriteClub)
 			.cheerProximityPref(CheerProximityPref.ANY)
-			.viewpoint(Viewpoint.INFIELD_1B)
 			.seatHeight(SeatHeight.MID)
 			.section(Section.MIDDLE)
 			.seatPositionPref(SeatPositionPref.ANY)
@@ -63,10 +57,8 @@ public final class OnboardingPreferenceFixture {
 	public static OnboardingPreference createThird(User user, Club favoriteClub) {
 		return OnboardingPreference.builder()
 			.user(user)
-			.priority(3)
 			.favoriteClub(favoriteClub)
 			.cheerProximityPref(CheerProximityPref.FAR)
-			.viewpoint(Viewpoint.OUTFIELD_L)
 			.seatHeight(SeatHeight.HIGH)
 			.section(Section.CORNER)
 			.seatPositionPref(SeatPositionPref.MIDDLE)

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/order/OrderFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/order/OrderFixture.java
@@ -1,0 +1,227 @@
+package com.goormgb.be.ordercore.fixture.order;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.stadium.entity.Stadium;
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
+import com.goormgb.be.ordercore.order.dto.request.SeatOrderItem;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.entity.OrderSeat;
+import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
+import com.goormgb.be.user.entity.User;
+
+public final class OrderFixture {
+
+	private OrderFixture() {
+	}
+
+	public static User createUser() {
+		User user = User.builder()
+			.email("test@test.com")
+			.nickname("테스터")
+			.profileImageUrl(null)
+			.build();
+		ReflectionTestUtils.setField(user, "id", 1L);
+		return user;
+	}
+
+	public static User createUserWithId(Long id) {
+		User user = User.builder()
+			.email("user" + id + "@test.com")
+			.nickname("테스터" + id)
+			.profileImageUrl(null)
+			.build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	public static Stadium createStadium() {
+		Stadium stadium = Stadium.builder()
+			.region("서울")
+			.koName("잠실야구장")
+			.enName("Jamsil Baseball Stadium")
+			.address("서울특별시 송파구 올림픽로 19-2")
+			.build();
+		ReflectionTestUtils.setField(stadium, "id", 1L);
+		return stadium;
+	}
+
+	public static Club createHomeClub(Stadium stadium) {
+		Club club = Club.builder()
+			.koName("LG 트윈스")
+			.enName("LG Twins")
+			.logoImg(null)
+			.clubColor("#C60C30")
+			.stadium(stadium)
+			.homepageRedirectUrl(null)
+			.build();
+		ReflectionTestUtils.setField(club, "id", 1L);
+		return club;
+	}
+
+	public static Club createAwayClub(Stadium stadium) {
+		Club club = Club.builder()
+			.koName("두산 베어스")
+			.enName("Doosan Bears")
+			.logoImg(null)
+			.clubColor("#131230")
+			.stadium(stadium)
+			.homepageRedirectUrl(null)
+			.build();
+		ReflectionTestUtils.setField(club, "id", 2L);
+		return club;
+	}
+
+	/** 평일 경기: 2026-03-11(수) 18:30 KST = 09:30 UTC */
+	public static Match createWeekdayMatch() {
+		Stadium stadium = createStadium();
+		Instant matchAt = Instant.parse("2026-03-11T09:30:00Z");
+		Match match = Match.builder()
+			.matchAt(matchAt)
+			.homeClub(createHomeClub(stadium))
+			.awayClub(createAwayClub(stadium))
+			.stadium(stadium)
+			.saleStatus(SaleStatus.ON_SALE)
+			.build();
+		ReflectionTestUtils.setField(match, "id", 1L);
+		return match;
+	}
+
+	/** 주말 경기: 2026-03-14(토) 14:00 KST = 05:00 UTC */
+	public static Match createWeekendMatch() {
+		Stadium stadium = createStadium();
+		Instant matchAt = Instant.parse("2026-03-14T05:00:00Z");
+		Match match = Match.builder()
+			.matchAt(matchAt)
+			.homeClub(createHomeClub(stadium))
+			.awayClub(createAwayClub(stadium))
+			.stadium(stadium)
+			.saleStatus(SaleStatus.ON_SALE)
+			.build();
+		ReflectionTestUtils.setField(match, "id", 2L);
+		return match;
+	}
+
+	public static Order createOrder(User user, Match match) {
+		Order order = Order.builder()
+			.user(user)
+			.match(match)
+			.totalAmount(24000)
+			.ordererName("홍길동")
+			.ordererEmail("hong@test.com")
+			.ordererPhone("010-1234-5678")
+			.ordererBirthDate("990831")
+			.build();
+		ReflectionTestUtils.setField(order, "id", 1L);
+		ReflectionTestUtils.setField(order, "createdAt", Instant.now());
+		return order;
+	}
+
+	public static Order createOrderWithId(Long id, User user, Match match, int totalAmount) {
+		Order order = Order.builder()
+			.user(user)
+			.match(match)
+			.totalAmount(totalAmount)
+			.ordererName("홍길동")
+			.ordererEmail("hong@test.com")
+			.ordererPhone("010-1234-5678")
+			.ordererBirthDate("990831")
+			.build();
+		ReflectionTestUtils.setField(order, "id", id);
+		ReflectionTestUtils.setField(order, "createdAt", Instant.now());
+		return order;
+	}
+
+	public static OrderSeat createOrderSeat(Order order) {
+		OrderSeat seat = OrderSeat.builder()
+			.order(order)
+			.matchSeatId(101L)
+			.blockId(10L)
+			.sectionId(1L)
+			.rowNo(5)
+			.seatNo(12)
+			.price(22000)
+			.ticketType(TicketType.ADULT)
+			.build();
+		ReflectionTestUtils.setField(seat, "id", 1L);
+		return seat;
+	}
+
+	/** 유효한 선점 (만료 10분 후) */
+	public static SeatHoldInfo createSeatHoldInfo(Long matchSeatId, Long userId) {
+		return new SeatHoldInfo(
+			1L,
+			matchSeatId,
+			userId,
+			Instant.now().plus(10, ChronoUnit.MINUTES),
+			1L,
+			"블루석",
+			10L,
+			"BLUE_01",
+			5,
+			12
+		);
+	}
+
+	/** 만료된 선점 (1분 전 만료) */
+	public static SeatHoldInfo createExpiredSeatHoldInfo(Long matchSeatId, Long userId) {
+		return new SeatHoldInfo(
+			2L,
+			matchSeatId,
+			userId,
+			Instant.now().minus(1, ChronoUnit.MINUTES),
+			1L,
+			"블루석",
+			10L,
+			"BLUE_01",
+			5,
+			12
+		);
+	}
+
+	public static SeatHoldInfo createSeatHoldInfoWithSection(Long holdId, Long matchSeatId, Long userId,
+		Long sectionId, String sectionName) {
+		return new SeatHoldInfo(
+			holdId,
+			matchSeatId,
+			userId,
+			Instant.now().plus(10, ChronoUnit.MINUTES),
+			sectionId,
+			sectionName,
+			10L,
+			"BLUE_0" + holdId,
+			5,
+			(int)(holdId * 10)
+		);
+	}
+
+	public static OrderCreateRequest createOrderCreateRequest() {
+		return new OrderCreateRequest(
+			1L,
+			List.of(new SeatOrderItem(101L, TicketType.ADULT)),
+			"홍길동",
+			"hong@test.com",
+			"010-1234-5678",
+			"990831"
+		);
+	}
+
+	public static OrderCreateRequest createOrderCreateRequestWithSeats(Long matchId, List<SeatOrderItem> seats) {
+		return new OrderCreateRequest(
+			matchId,
+			seats,
+			"홍길동",
+			"hong@test.com",
+			"010-1234-5678",
+			"990831"
+		);
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/payment/PaymentFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/payment/PaymentFixture.java
@@ -1,0 +1,93 @@
+package com.goormgb.be.ordercore.fixture.payment;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
+import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
+import com.goormgb.be.ordercore.payment.entity.CashReceipt;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+
+public final class PaymentFixture {
+
+	private PaymentFixture() {
+	}
+
+	public static Payment createVirtualAccountPayment(Order order) {
+		Payment payment = Payment.builder()
+			.order(order)
+			.paymentMethod(PaymentMethod.VIRTUAL_ACCOUNT)
+			.virtualAccountBank("국민은행")
+			.virtualAccountNumber("047-000-00000001")
+			.virtualAccountHolder("구름GB")
+			.depositDeadline(Instant.now().plus(3, ChronoUnit.DAYS))
+			.build();
+		ReflectionTestUtils.setField(payment, "id", 1L);
+		return payment;
+	}
+
+	public static Payment createCompletedTossPayPayment(Order order) {
+		Payment payment = Payment.builder()
+			.order(order)
+			.paymentMethod(PaymentMethod.TOSS_PAY)
+			.build();
+		ReflectionTestUtils.setField(payment, "id", 2L);
+		payment.complete();
+		return payment;
+	}
+
+	public static Payment createCompletedKakaoPayPayment(Order order) {
+		Payment payment = Payment.builder()
+			.order(order)
+			.paymentMethod(PaymentMethod.KAKAO_PAY)
+			.build();
+		ReflectionTestUtils.setField(payment, "id", 3L);
+		payment.complete();
+		return payment;
+	}
+
+	public static CashReceipt createPersonalDeductionReceipt(Payment payment) {
+		CashReceipt cashReceipt = CashReceipt.builder()
+			.payment(payment)
+			.purpose(CashReceiptPurpose.PERSONAL_DEDUCTION)
+			.number("010-1234-5678")
+			.build();
+		ReflectionTestUtils.setField(cashReceipt, "id", 1L);
+		return cashReceipt;
+	}
+
+	public static CashReceipt createBusinessExpenseReceipt(Payment payment) {
+		CashReceipt cashReceipt = CashReceipt.builder()
+			.payment(payment)
+			.purpose(CashReceiptPurpose.BUSINESS_EXPENSE)
+			.number("123-45-67890")
+			.build();
+		ReflectionTestUtils.setField(cashReceipt, "id", 2L);
+		return cashReceipt;
+	}
+
+	public static PaymentProcessRequest createVirtualAccountRequest() {
+		return new PaymentProcessRequest(PaymentMethod.VIRTUAL_ACCOUNT);
+	}
+
+	public static PaymentProcessRequest createTossPayRequest() {
+		return new PaymentProcessRequest(PaymentMethod.TOSS_PAY);
+	}
+
+	public static PaymentProcessRequest createKakaoPayRequest() {
+		return new PaymentProcessRequest(PaymentMethod.KAKAO_PAY);
+	}
+
+	public static CashReceiptCreateRequest createPersonalDeductionRequest() {
+		return new CashReceiptCreateRequest(CashReceiptPurpose.PERSONAL_DEDUCTION, "010-1234-5678");
+	}
+
+	public static CashReceiptCreateRequest createBusinessExpenseRequest() {
+		return new CashReceiptCreateRequest(CashReceiptPurpose.BUSINESS_EXPENSE, "123-45-67890");
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
@@ -1,0 +1,327 @@
+package com.goormgb.be.ordercore.order.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
+import com.goormgb.be.ordercore.order.dto.request.SeatOrderItem;
+import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
+import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.service.OrderService;
+import com.goormgb.be.ordercore.support.WebMvcTestSupport;
+
+@WebMvcTest(controllers = OrderController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("OrderController 슬라이스 테스트")
+class OrderControllerTest extends WebMvcTestSupport {
+
+	@MockitoBean
+	private OrderService orderService;
+
+	private void setAuthentication(Long userId) {
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userId, null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER")))
+		);
+	}
+
+	private OrderSheetGetResponse createMockOrderSheetResponse() {
+		OrderSheetGetResponse.ClubInfo homeClub = new OrderSheetGetResponse.ClubInfo(1L, "LG 트윈스");
+		OrderSheetGetResponse.ClubInfo awayClub = new OrderSheetGetResponse.ClubInfo(2L, "두산 베어스");
+		OrderSheetGetResponse.StadiumInfo stadium = new OrderSheetGetResponse.StadiumInfo(
+			1L, "잠실야구장", "서울특별시 송파구 올림픽로 19-2"
+		);
+		OrderSheetGetResponse.MatchInfo matchInfo = new OrderSheetGetResponse.MatchInfo(
+			1L, Instant.parse("2026-03-11T09:30:00Z"), homeClub, awayClub, stadium
+		);
+		OrderSheetGetResponse.SeatInfo seatInfo = new OrderSheetGetResponse.SeatInfo(
+			101L, 1L, "블루석", 10L, "BLUE_01", 5, 12, 22000
+		);
+		return new OrderSheetGetResponse(
+			matchInfo,
+			List.of(seatInfo),
+			new OrderSheetGetResponse.Summary(1, 2000)
+		);
+	}
+
+	private OrderCreateResponse createMockOrderCreateResponse() {
+		return new OrderCreateResponse(1L, OrderStatus.PAYMENT_PENDING, 1L, 1, 24000, 2000, Instant.now());
+	}
+
+	@Nested
+	@DisplayName("GET /mypage/orders/sheet — 주문서 조회")
+	class GetOrderSheet {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 주문서 정보를 반환한다")
+		void getOrderSheet_성공() throws Exception {
+			given(orderService.getOrderSheet(eq(1L), eq(1L), eq(List.of(101L))))
+				.willReturn(createMockOrderSheetResponse());
+
+			mockMvc.perform(get("/mypage/orders/sheet")
+					.param("matchId", "1")
+					.param("seatIds", "101"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.data.match.matchId").value(1))
+				.andExpect(jsonPath("$.data.match.homeClub.koName").value("LG 트윈스"))
+				.andExpect(jsonPath("$.data.match.awayClub.koName").value("두산 베어스"))
+				.andExpect(jsonPath("$.data.match.stadium.koName").value("잠실야구장"))
+				.andExpect(jsonPath("$.data.seats").isArray())
+				.andExpect(jsonPath("$.data.seats.length()").value(1))
+				.andExpect(jsonPath("$.data.seats[0].matchSeatId").value(101))
+				.andExpect(jsonPath("$.data.seats[0].adultPrice").value(22000))
+				.andExpect(jsonPath("$.data.summary.seatCount").value(1))
+				.andExpect(jsonPath("$.data.summary.bookingFee").value(2000));
+		}
+
+		@Test
+		@DisplayName("복수 좌석 ID로 주문서를 조회할 수 있다")
+		void getOrderSheet_복수좌석_성공() throws Exception {
+			OrderSheetGetResponse.ClubInfo homeClub = new OrderSheetGetResponse.ClubInfo(1L, "LG 트윈스");
+			OrderSheetGetResponse.ClubInfo awayClub = new OrderSheetGetResponse.ClubInfo(2L, "두산 베어스");
+			OrderSheetGetResponse.StadiumInfo stadium = new OrderSheetGetResponse.StadiumInfo(1L, "잠실야구장", "주소");
+			OrderSheetGetResponse.MatchInfo matchInfo = new OrderSheetGetResponse.MatchInfo(
+				1L, Instant.now(), homeClub, awayClub, stadium
+			);
+			List<OrderSheetGetResponse.SeatInfo> seats = List.of(
+				new OrderSheetGetResponse.SeatInfo(101L, 1L, "블루석", 10L, "BLUE_01", 5, 12, 22000),
+				new OrderSheetGetResponse.SeatInfo(102L, 1L, "블루석", 10L, "BLUE_02", 5, 13, 22000)
+			);
+			OrderSheetGetResponse response = new OrderSheetGetResponse(
+				matchInfo, seats, new OrderSheetGetResponse.Summary(2, 2000)
+			);
+
+			given(orderService.getOrderSheet(eq(1L), eq(1L), eq(List.of(101L, 102L))))
+				.willReturn(response);
+
+			mockMvc.perform(get("/mypage/orders/sheet")
+					.param("matchId", "1")
+					.param("seatIds", "101", "102"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.seats.length()").value(2))
+				.andExpect(jsonPath("$.data.summary.seatCount").value(2));
+		}
+
+		@Test
+		@DisplayName("선점 만료 시 400을 반환한다")
+		void getOrderSheet_선점_만료_400() throws Exception {
+			given(orderService.getOrderSheet(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.SEAT_HOLD_EXPIRED));
+
+			mockMvc.perform(get("/mypage/orders/sheet")
+					.param("matchId", "1")
+					.param("seatIds", "101"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("좌석 선점이 만료되었습니다."));
+		}
+
+		@Test
+		@DisplayName("선점 정보가 없으면 404를 반환한다")
+		void getOrderSheet_선점_미발견_404() throws Exception {
+			given(orderService.getOrderSheet(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+
+			mockMvc.perform(get("/mypage/orders/sheet")
+					.param("matchId", "1")
+					.param("seatIds", "101"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("좌석 선점 정보를 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("가격 정책이 없으면 404를 반환한다")
+		void getOrderSheet_가격정책_미발견_404() throws Exception {
+			given(orderService.getOrderSheet(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.PRICE_POLICY_NOT_FOUND));
+
+			mockMvc.perform(get("/mypage/orders/sheet")
+					.param("matchId", "1")
+					.param("seatIds", "101"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("해당 좌석의 가격 정책을 찾을 수 없습니다."));
+		}
+	}
+
+	@Nested
+	@DisplayName("POST /mypage/orders — 주문 생성")
+	class CreateOrder {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 201과 생성된 주문 정보를 반환한다")
+		void createOrder_성공() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(eq(1L), any(OrderCreateRequest.class)))
+				.willReturn(createMockOrderCreateResponse());
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.data.orderId").value(1))
+				.andExpect(jsonPath("$.data.status").value("PAYMENT_PENDING"))
+				.andExpect(jsonPath("$.data.matchId").value(1))
+				.andExpect(jsonPath("$.data.seatCount").value(1))
+				.andExpect(jsonPath("$.data.totalAmount").value(24000))
+				.andExpect(jsonPath("$.data.bookingFee").value(2000));
+		}
+
+		@Test
+		@DisplayName("생년월일이 6자리가 아니면 400을 반환한다")
+		void createOrder_생년월일_형식오류_400() throws Exception {
+			OrderCreateRequest invalidRequest = new OrderCreateRequest(
+				1L,
+				List.of(new SeatOrderItem(101L, TicketType.ADULT)),
+				"홍길동", "hong@test.com", "010-1234-5678",
+				"19990831" // 8자리 — 유효하지 않음
+			);
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidRequest)))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("이메일 형식이 잘못되면 400을 반환한다")
+		void createOrder_이메일_형식오류_400() throws Exception {
+			OrderCreateRequest invalidRequest = new OrderCreateRequest(
+				1L,
+				List.of(new SeatOrderItem(101L, TicketType.ADULT)),
+				"홍길동", "not-an-email", "010-1234-5678", "990831"
+			);
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidRequest)))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("seats가 비어있으면 400을 반환한다")
+		void createOrder_빈좌석_400() throws Exception {
+			OrderCreateRequest invalidRequest = new OrderCreateRequest(
+				1L, List.of(),
+				"홍길동", "hong@test.com", "010-1234-5678", "990831"
+			);
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidRequest)))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 404를 반환한다")
+		void createOrder_사용자_미발견_404() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(any(), any()))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("선점이 만료된 경우 400을 반환한다")
+		void createOrder_선점_만료_400() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(any(), any()))
+				.willThrow(new CustomException(ErrorCode.SEAT_HOLD_EXPIRED));
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("좌석 선점이 만료되었습니다."));
+		}
+
+		@Test
+		@DisplayName("이미 주문된 좌석이면 400을 반환한다")
+		void createOrder_이미_주문된_좌석_400() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(any(), any()))
+				.willThrow(new CustomException(ErrorCode.INVALID_ORDER_STATUS));
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("주문 상태가 올바르지 않습니다."));
+		}
+
+		@Test
+		@DisplayName("선점 정보가 없으면 404를 반환한다")
+		void createOrder_선점_미발견_404() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(any(), any()))
+				.willThrow(new CustomException(ErrorCode.SEAT_HOLD_NOT_FOUND));
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("좌석 선점 정보를 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("matchId가 없으면 400을 반환한다")
+		void createOrder_matchId_누락_400() throws Exception {
+			String invalidJson = """
+				{
+				  "seats": [{"matchSeatId": 101, "ticketType": "ADULT"}],
+				  "ordererName": "홍길동",
+				  "ordererEmail": "hong@test.com",
+				  "ordererPhone": "010-1234-5678",
+				  "ordererBirthDate": "990831"
+				}
+				""";
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(invalidJson))
+				.andExpect(status().isBadRequest());
+		}
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
@@ -191,7 +191,7 @@ class OrderControllerTest extends WebMvcTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.code").value("CREATED"))
 				.andExpect(jsonPath("$.data.orderId").value(1))
 				.andExpect(jsonPath("$.data.status").value("PAYMENT_PENDING"))
 				.andExpect(jsonPath("$.data.matchId").value(1))

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/entity/OrderEntityTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/entity/OrderEntityTest.java
@@ -1,0 +1,175 @@
+package com.goormgb.be.ordercore.order.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.user.entity.User;
+
+@DisplayName("Order 엔티티 단위 테스트")
+class OrderEntityTest {
+
+	private Order createTestOrder() {
+		User user = OrderFixture.createUser();
+		return Order.builder()
+			.user(user)
+			.match(OrderFixture.createWeekdayMatch())
+			.totalAmount(24000)
+			.ordererName("홍길동")
+			.ordererEmail("hong@test.com")
+			.ordererPhone("010-1234-5678")
+			.ordererBirthDate("990831")
+			.build();
+	}
+
+	@Nested
+	@DisplayName("생성 시 초기 상태 검증")
+	class Creation {
+
+		@Test
+		@DisplayName("주문 생성 시 상태는 PAYMENT_PENDING이다")
+		void 생성시_상태는_PAYMENT_PENDING() {
+			Order order = createTestOrder();
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 예약 수수료는 2000원이다")
+		void 생성시_예약수수료는_2000() {
+			Order order = createTestOrder();
+			assertThat(order.getBookingFee()).isEqualTo(2000);
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 취소 수수료는 0원이다")
+		void 생성시_취소수수료는_0() {
+			Order order = createTestOrder();
+			assertThat(order.getCancellationFee()).isEqualTo(0);
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 환불 금액은 null이다")
+		void 생성시_환불금액은_null() {
+			Order order = createTestOrder();
+			assertThat(order.getRefundedAmount()).isNull();
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 취소 시각은 null이다")
+		void 생성시_취소시각은_null() {
+			Order order = createTestOrder();
+			assertThat(order.getCancelledAt()).isNull();
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 예매자 정보가 올바르게 저장된다")
+		void 생성시_예매자정보_저장() {
+			Order order = createTestOrder();
+			assertThat(order.getOrdererName()).isEqualTo("홍길동");
+			assertThat(order.getOrdererEmail()).isEqualTo("hong@test.com");
+			assertThat(order.getOrdererPhone()).isEqualTo("010-1234-5678");
+			assertThat(order.getOrdererBirthDate()).isEqualTo("990831");
+		}
+
+		@Test
+		@DisplayName("주문 생성 시 총 금액이 올바르게 저장된다")
+		void 생성시_총금액_저장() {
+			Order order = createTestOrder();
+			assertThat(order.getTotalAmount()).isEqualTo(24000);
+		}
+	}
+
+	@Nested
+	@DisplayName("updateStatus() 상태 변경")
+	class UpdateStatus {
+
+		@Test
+		@DisplayName("PAYMENT_PENDING → PAID로 상태를 변경할 수 있다")
+		void updateStatus_PAID로_변경() {
+			Order order = createTestOrder();
+			order.updateStatus(OrderStatus.PAID);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PENDING → CANCEL_REQUESTED로 상태를 변경할 수 있다")
+		void updateStatus_CANCEL_REQUESTED로_변경() {
+			Order order = createTestOrder();
+			order.updateStatus(OrderStatus.CANCEL_REQUESTED);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+		}
+
+		@Test
+		@DisplayName("PAID → REFUND_PROCESSING으로 상태를 변경할 수 있다")
+		void updateStatus_REFUND_PROCESSING으로_변경() {
+			Order order = createTestOrder();
+			order.updateStatus(OrderStatus.PAID);
+			order.updateStatus(OrderStatus.REFUND_PROCESSING);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_PROCESSING);
+		}
+
+		@Test
+		@DisplayName("REFUND_PROCESSING → REFUND_COMPLETED로 상태를 변경할 수 있다")
+		void updateStatus_REFUND_COMPLETED로_변경() {
+			Order order = createTestOrder();
+			order.updateStatus(OrderStatus.REFUND_PROCESSING);
+			order.updateStatus(OrderStatus.REFUND_COMPLETED);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_COMPLETED);
+		}
+	}
+
+	@Nested
+	@DisplayName("cancel() 취소 처리")
+	class Cancel {
+
+		@Test
+		@DisplayName("cancel() 호출 시 상태가 CANCEL_REQUESTED로 변경된다")
+		void cancel_상태가_CANCEL_REQUESTED() {
+			Order order = createTestOrder();
+			order.cancel(1000, 23000);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+		}
+
+		@Test
+		@DisplayName("cancel() 호출 시 취소 수수료가 저장된다")
+		void cancel_취소수수료_저장() {
+			Order order = createTestOrder();
+			order.cancel(1000, 23000);
+			assertThat(order.getCancellationFee()).isEqualTo(1000);
+		}
+
+		@Test
+		@DisplayName("cancel() 호출 시 환불 금액이 저장된다")
+		void cancel_환불금액_저장() {
+			Order order = createTestOrder();
+			order.cancel(1000, 23000);
+			assertThat(order.getRefundedAmount()).isEqualTo(23000);
+		}
+
+		@Test
+		@DisplayName("cancel() 호출 시 취소 시각이 설정된다")
+		void cancel_취소시각_설정() {
+			Order order = createTestOrder();
+			Instant before = Instant.now();
+			order.cancel(0, 24000);
+			assertThat(order.getCancelledAt()).isNotNull();
+			assertThat(order.getCancelledAt()).isAfterOrEqualTo(before);
+		}
+
+		@Test
+		@DisplayName("취소 수수료 0원, 전액 환불 시에도 정상 처리된다")
+		void cancel_전액환불_정상처리() {
+			Order order = createTestOrder();
+			order.cancel(0, 24000);
+			assertThat(order.getCancellationFee()).isEqualTo(0);
+			assertThat(order.getRefundedAmount()).isEqualTo(24000);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+		}
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/query/SeatHoldInfoTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/query/SeatHoldInfoTest.java
@@ -1,0 +1,52 @@
+package com.goormgb.be.ordercore.order.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SeatHoldInfo 도메인 단위 테스트")
+class SeatHoldInfoTest {
+
+	private SeatHoldInfo createHoldInfo(Instant expiresAt) {
+		return new SeatHoldInfo(1L, 101L, 1L, expiresAt, 1L, "블루석", 10L, "BLUE_01", 5, 12);
+	}
+
+	@Test
+	@DisplayName("만료 시각이 현재보다 이전이면 isExpired()가 true를 반환한다")
+	void isExpired_만료된_선점은_true() {
+		SeatHoldInfo expired = createHoldInfo(Instant.now().minus(1, ChronoUnit.SECONDS));
+		assertThat(expired.isExpired(Instant.now())).isTrue();
+	}
+
+	@Test
+	@DisplayName("만료 시각이 현재보다 이후이면 isExpired()가 false를 반환한다")
+	void isExpired_유효한_선점은_false() {
+		SeatHoldInfo active = createHoldInfo(Instant.now().plus(10, ChronoUnit.MINUTES));
+		assertThat(active.isExpired(Instant.now())).isFalse();
+	}
+
+	@Test
+	@DisplayName("만료 시각이 훨씬 먼 미래이면 isExpired()가 false를 반환한다")
+	void isExpired_먼_미래는_false() {
+		SeatHoldInfo farFuture = createHoldInfo(Instant.now().plus(30, ChronoUnit.DAYS));
+		assertThat(farFuture.isExpired(Instant.now())).isFalse();
+	}
+
+	@Test
+	@DisplayName("1초 뒤에 만료되는 선점은 isExpired()가 false를 반환한다")
+	void isExpired_1초_후_만료는_false() {
+		SeatHoldInfo almostExpired = createHoldInfo(Instant.now().plus(1, ChronoUnit.SECONDS));
+		assertThat(almostExpired.isExpired(Instant.now())).isFalse();
+	}
+
+	@Test
+	@DisplayName("1초 전에 만료된 선점은 isExpired()가 true를 반환한다")
+	void isExpired_1초_전_만료는_true() {
+		SeatHoldInfo justExpired = createHoldInfo(Instant.now().minus(1, ChronoUnit.SECONDS));
+		assertThat(justExpired.isExpired(Instant.now())).isTrue();
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
@@ -1,0 +1,418 @@
+package com.goormgb.be.ordercore.order.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
+import com.goormgb.be.ordercore.order.dto.request.SeatOrderItem;
+import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
+import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderService 서비스 단위 테스트")
+class OrderServiceTest {
+
+	@Mock
+	private MatchRepository matchRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private OrderSeatRepository orderSeatRepository;
+	@Mock
+	private SeatInfoQueryService seatInfoQueryService;
+
+	private OrderService orderService;
+
+	@BeforeEach
+	void setUp() {
+		orderService = new OrderService(
+			matchRepository, userRepository, orderRepository, orderSeatRepository, seatInfoQueryService
+		);
+	}
+
+	@Nested
+	@DisplayName("getOrderSheet — 주문서 조회")
+	class GetOrderSheet {
+
+		@Test
+		@DisplayName("유효한 요청이면 주문서를 반환한다")
+		void getOrderSheet_성공() {
+			Long userId = 1L;
+			Long matchId = 1L;
+			List<Long> seatIds = List.of(101L);
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+
+			OrderSheetGetResponse response = orderService.getOrderSheet(userId, matchId, seatIds);
+
+			assertThat(response).isNotNull();
+			assertThat(response.seats()).hasSize(1);
+			assertThat(response.seats().get(0).matchSeatId()).isEqualTo(101L);
+			assertThat(response.seats().get(0).adultPrice()).isEqualTo(22000);
+			assertThat(response.summary().seatCount()).isEqualTo(1);
+			assertThat(response.summary().bookingFee()).isEqualTo(2000);
+		}
+
+		@Test
+		@DisplayName("주말 경기이면 WEEKEND dayType으로 가격을 조회한다")
+		void getOrderSheet_주말경기_WEEKEND_dayType() {
+			Long userId = 1L;
+			Long matchId = 2L;
+			List<Long> seatIds = List.of(101L);
+			Match weekendMatch = OrderFixture.createWeekendMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(weekendMatch);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
+
+			OrderSheetGetResponse response = orderService.getOrderSheet(userId, matchId, seatIds);
+
+			assertThat(response.seats().get(0).adultPrice()).isEqualTo(24000);
+			then(seatInfoQueryService).should().findPrice(1L, "WEEKEND", "ADULT");
+		}
+
+		@Test
+		@DisplayName("복수 좌석 주문서 조회 시 각 좌석 정보가 모두 포함된다")
+		void getOrderSheet_복수좌석_성공() {
+			Long userId = 1L;
+			Long matchId = 1L;
+			List<Long> seatIds = List.of(101L, 102L);
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo hold1 = OrderFixture.createSeatHoldInfo(101L, userId);
+			SeatHoldInfo hold2 = new SeatHoldInfo(
+				2L, 102L, userId,
+				Instant.now().plus(10, ChronoUnit.MINUTES),
+				1L, "블루석", 10L, "BLUE_02", 6, 1
+			);
+
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(hold1, hold2));
+			given(seatInfoQueryService.findPrice(eq(1L), eq("WEEKDAY"), eq("ADULT"))).willReturn(22000);
+
+			OrderSheetGetResponse response = orderService.getOrderSheet(userId, matchId, seatIds);
+
+			assertThat(response.seats()).hasSize(2);
+			assertThat(response.summary().seatCount()).isEqualTo(2);
+		}
+
+		@Test
+		@DisplayName("seatIds가 비어있으면 ORDER_SEAT_EMPTY 예외가 발생한다")
+		void getOrderSheet_빈seatIds_예외() {
+			assertThatThrownBy(
+				() -> orderService.getOrderSheet(1L, 1L, Collections.emptyList())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_SEAT_EMPTY.getMessage());
+		}
+
+		@Test
+		@DisplayName("선점 정보가 누락된 경우 SEAT_HOLD_NOT_FOUND 예외가 발생한다")
+		void getOrderSheet_선점_미발견_예외() {
+			Long userId = 1L;
+			Match match = OrderFixture.createWeekdayMatch();
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L, 102L)))
+				.willReturn(List.of(OrderFixture.createSeatHoldInfo(101L, userId))); // 1개만 반환
+
+			assertThatThrownBy(
+				() -> orderService.getOrderSheet(userId, 1L, List.of(101L, 102L))
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.SEAT_HOLD_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("선점이 만료된 경우 SEAT_HOLD_EXPIRED 예외가 발생한다")
+		void getOrderSheet_선점_만료_예외() {
+			Long userId = 1L;
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo expiredHold = OrderFixture.createExpiredSeatHoldInfo(101L, userId);
+
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(expiredHold));
+
+			assertThatThrownBy(
+				() -> orderService.getOrderSheet(userId, 1L, List.of(101L))
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.SEAT_HOLD_EXPIRED.getMessage());
+		}
+
+		@Test
+		@DisplayName("가격 정책이 없는 경우 PRICE_POLICY_NOT_FOUND 예외가 발생한다")
+		void getOrderSheet_가격정책_미발견_예외() {
+			Long userId = 1L;
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
+
+			assertThatThrownBy(
+				() -> orderService.getOrderSheet(userId, 1L, List.of(101L))
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PRICE_POLICY_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("createOrder — 주문 생성")
+	class CreateOrder {
+
+		private void stubSaveOrder(Long orderId) {
+			given(orderRepository.save(any(Order.class))).willAnswer(inv -> {
+				Order o = inv.getArgument(0);
+				ReflectionTestUtils.setField(o, "id", orderId);
+				ReflectionTestUtils.setField(o, "createdAt", Instant.now());
+				return o;
+			});
+		}
+
+		@Test
+		@DisplayName("유효한 단일 좌석 주문 시 totalAmount = 티켓가격 + 2000이다")
+		void createOrder_단일좌석_totalAmount_계산() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			stubSaveOrder(1L);
+
+			OrderCreateResponse response = orderService.createOrder(userId, request);
+
+			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+			assertThat(response.totalAmount()).isEqualTo(22000 + 2000);
+			assertThat(response.bookingFee()).isEqualTo(2000);
+			assertThat(response.seatCount()).isEqualTo(1);
+			assertThat(response.matchId()).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("복수 좌석 주문 시 totalAmount = 모든 티켓 합산 + 2000이다")
+		void createOrder_복수좌석_totalAmount_계산() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo hold1 = OrderFixture.createSeatHoldInfo(101L, userId);
+			SeatHoldInfo hold2 = new SeatHoldInfo(
+				2L, 102L, userId,
+				Instant.now().plus(10, ChronoUnit.MINUTES),
+				1L, "블루석", 10L, "BLUE_02", 6, 1
+			);
+			OrderCreateRequest request = new OrderCreateRequest(
+				1L,
+				List.of(
+					new SeatOrderItem(101L, TicketType.ADULT),
+					new SeatOrderItem(102L, TicketType.YOUTH)
+				),
+				"홍길동", "hong@test.com", "010-1234-5678", "990831"
+			);
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L, 102L)))
+				.willReturn(List.of(hold1, hold2));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.isAlreadyOrdered(102L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "YOUTH")).willReturn(7000);
+			stubSaveOrder(1L);
+
+			OrderCreateResponse response = orderService.createOrder(userId, request);
+
+			assertThat(response.seatCount()).isEqualTo(2);
+			assertThat(response.totalAmount()).isEqualTo(22000 + 7000 + 2000);
+		}
+
+		@Test
+		@DisplayName("주말 경기 주문 시 WEEKEND 가격이 적용된다")
+		void createOrder_주말경기_WEEKEND가격_적용() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match weekendMatch = OrderFixture.createWeekendMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = new OrderCreateRequest(
+				2L,
+				List.of(new SeatOrderItem(101L, TicketType.ADULT)),
+				"홍길동", "hong@test.com", "010-1234-5678", "990831"
+			);
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(2L)).willReturn(weekendMatch);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
+			stubSaveOrder(1L);
+
+			orderService.createOrder(userId, request);
+
+			then(seatInfoQueryService).should().findPrice(1L, "WEEKEND", "ADULT");
+		}
+
+		@Test
+		@DisplayName("OrderSeat이 모두 저장된다")
+		void createOrder_OrderSeat_저장() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			stubSaveOrder(1L);
+
+			orderService.createOrder(userId, request);
+
+			then(orderSeatRepository).should().saveAll(any());
+		}
+
+		@Test
+		@DisplayName("seats가 비어있으면 ORDER_SEAT_EMPTY 예외가 발생한다")
+		void createOrder_빈좌석_예외() {
+			OrderCreateRequest request = new OrderCreateRequest(
+				1L, Collections.emptyList(),
+				"홍길동", "hong@test.com", "010-1234-5678", "990831"
+			);
+
+			assertThatThrownBy(() -> orderService.createOrder(1L, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_SEAT_EMPTY.getMessage());
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 USER_NOT_FOUND 예외가 발생한다")
+		void createOrder_사용자_미발견_예외() {
+			Long userId = 999L;
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("선점 정보가 누락된 경우 SEAT_HOLD_NOT_FOUND 예외가 발생한다")
+		void createOrder_선점_미발견_예외() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(Collections.emptyList());
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.SEAT_HOLD_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("선점이 만료된 경우 SEAT_HOLD_EXPIRED 예외가 발생한다")
+		void createOrder_선점_만료_예외() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo expiredHold = OrderFixture.createExpiredSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(expiredHold));
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.SEAT_HOLD_EXPIRED.getMessage());
+		}
+
+		@Test
+		@DisplayName("이미 주문된 좌석이면 INVALID_ORDER_STATUS 예외가 발생한다")
+		void createOrder_이미_주문된_좌석_예외() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(true);
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+		}
+
+		@Test
+		@DisplayName("가격 정책이 없는 경우 PRICE_POLICY_NOT_FOUND 예외가 발생한다")
+		void createOrder_가격정책_미발견_예외() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PRICE_POLICY_NOT_FOUND.getMessage());
+		}
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,305 @@
+package com.goormgb.be.ordercore.payment.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.fixture.payment.PaymentFixture;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
+import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
+import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
+import com.goormgb.be.ordercore.payment.dto.response.PaymentProcessResponse;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+import com.goormgb.be.ordercore.payment.service.PaymentService;
+import com.goormgb.be.ordercore.support.WebMvcTestSupport;
+
+@WebMvcTest(controllers = PaymentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("PaymentController 슬라이스 테스트")
+class PaymentControllerTest extends WebMvcTestSupport {
+
+	@MockitoBean
+	private PaymentService paymentService;
+
+	private void setAuthentication(Long userId) {
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userId, null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER")))
+		);
+	}
+
+	@Nested
+	@DisplayName("POST /mypage/orders/{orderId}/payment — 결제 처리")
+	class ProcessPayment {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("토스페이 결제 성공 시 200과 COMPLETED 상태를 반환한다")
+		void processPayment_TOSS_PAY_성공() throws Exception {
+			PaymentProcessRequest request = PaymentFixture.createTossPayRequest();
+			PaymentProcessResponse response = new PaymentProcessResponse(
+				1L, OrderStatus.PAID,
+				PaymentMethod.TOSS_PAY, PaymentStatus.COMPLETED,
+				Instant.now(), null
+			);
+
+			given(paymentService.processPayment(eq(1L), eq(1L), any(PaymentProcessRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.data.orderId").value(1))
+				.andExpect(jsonPath("$.data.orderStatus").value("PAID"))
+				.andExpect(jsonPath("$.data.paymentMethod").value("TOSS_PAY"))
+				.andExpect(jsonPath("$.data.paymentStatus").value("COMPLETED"))
+				.andExpect(jsonPath("$.data.paidAt").exists());
+		}
+
+		@Test
+		@DisplayName("카카오페이 결제 성공 시 200과 COMPLETED 상태를 반환한다")
+		void processPayment_KAKAO_PAY_성공() throws Exception {
+			PaymentProcessRequest request = PaymentFixture.createKakaoPayRequest();
+			PaymentProcessResponse response = new PaymentProcessResponse(
+				1L, OrderStatus.PAID,
+				PaymentMethod.KAKAO_PAY, PaymentStatus.COMPLETED,
+				Instant.now(), null
+			);
+
+			given(paymentService.processPayment(eq(1L), eq(1L), any(PaymentProcessRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.paymentMethod").value("KAKAO_PAY"))
+				.andExpect(jsonPath("$.data.paymentStatus").value("COMPLETED"));
+		}
+
+		@Test
+		@DisplayName("가상계좌 결제 성공 시 200과 가상계좌 정보를 반환한다")
+		void processPayment_VIRTUAL_ACCOUNT_성공() throws Exception {
+			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
+			Instant deadline = Instant.now().plus(3, ChronoUnit.DAYS);
+			PaymentProcessResponse.VirtualAccountInfo vaInfo = new PaymentProcessResponse.VirtualAccountInfo(
+				"국민은행", "047-000-00000001", "구름GB", deadline
+			);
+			PaymentProcessResponse response = new PaymentProcessResponse(
+				1L, OrderStatus.PAYMENT_PENDING,
+				PaymentMethod.VIRTUAL_ACCOUNT, PaymentStatus.PENDING,
+				null, vaInfo
+			);
+
+			given(paymentService.processPayment(eq(1L), eq(1L), any(PaymentProcessRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.paymentMethod").value("VIRTUAL_ACCOUNT"))
+				.andExpect(jsonPath("$.data.paymentStatus").value("PENDING"))
+				.andExpect(jsonPath("$.data.orderStatus").value("PAYMENT_PENDING"))
+				.andExpect(jsonPath("$.data.virtualAccount.bank").value("국민은행"))
+				.andExpect(jsonPath("$.data.virtualAccount.holder").value("구름GB"))
+				.andExpect(jsonPath("$.data.virtualAccount.accountNumber").value("047-000-00000001"));
+		}
+
+		@Test
+		@DisplayName("paymentMethod가 없으면 400을 반환한다")
+		void processPayment_결제수단_누락_400() throws Exception {
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{}"))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("주문이 없으면 404를 반환한다")
+		void processPayment_주문_미발견_404() throws Exception {
+			given(paymentService.processPayment(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+			mockMvc.perform(post("/mypage/orders/99/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createTossPayRequest())))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("주문 소유권이 없으면 403을 반환한다")
+		void processPayment_소유권_없음_403() throws Exception {
+			given(paymentService.processPayment(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createTossPayRequest())))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+		}
+
+		@Test
+		@DisplayName("이미 결제 완료된 주문이면 400을 반환한다")
+		void processPayment_이미_완료_400() throws Exception {
+			given(paymentService.processPayment(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.PAYMENT_ALREADY_COMPLETED));
+
+			mockMvc.perform(post("/mypage/orders/1/payment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createTossPayRequest())))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("이미 결제가 완료된 주문입니다."));
+		}
+	}
+
+	@Nested
+	@DisplayName("POST /mypage/orders/{orderId}/cash-receipt — 현금영수증 신청")
+	class CreateCashReceipt {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("개인소득공제 현금영수증 신청 성공 시 201을 반환한다")
+		void createCashReceipt_개인소득공제_성공() throws Exception {
+			CashReceiptCreateRequest request = PaymentFixture.createPersonalDeductionRequest();
+			CashReceiptCreateResponse response = new CashReceiptCreateResponse(
+				1L, CashReceiptPurpose.PERSONAL_DEDUCTION, "010-1234-5678"
+			);
+
+			given(paymentService.createCashReceipt(eq(1L), eq(1L), any(CashReceiptCreateRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.data.orderId").value(1))
+				.andExpect(jsonPath("$.data.purpose").value("PERSONAL_DEDUCTION"))
+				.andExpect(jsonPath("$.data.number").value("010-1234-5678"));
+		}
+
+		@Test
+		@DisplayName("사업자지출증빙 현금영수증 신청 성공 시 201을 반환한다")
+		void createCashReceipt_사업자지출증빙_성공() throws Exception {
+			CashReceiptCreateRequest request = PaymentFixture.createBusinessExpenseRequest();
+			CashReceiptCreateResponse response = new CashReceiptCreateResponse(
+				1L, CashReceiptPurpose.BUSINESS_EXPENSE, "123-45-67890"
+			);
+
+			given(paymentService.createCashReceipt(eq(1L), eq(1L), any(CashReceiptCreateRequest.class)))
+				.willReturn(response);
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.purpose").value("BUSINESS_EXPENSE"))
+				.andExpect(jsonPath("$.data.number").value("123-45-67890"));
+		}
+
+		@Test
+		@DisplayName("purpose가 없으면 400을 반환한다")
+		void createCashReceipt_purpose_누락_400() throws Exception {
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"number\": \"010-1234-5678\"}"))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("number가 없으면 400을 반환한다")
+		void createCashReceipt_number_누락_400() throws Exception {
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"purpose\": \"PERSONAL_DEDUCTION\"}"))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("결제 정보가 없으면 404를 반환한다")
+		void createCashReceipt_결제_미발견_404() throws Exception {
+			given(paymentService.createCashReceipt(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createPersonalDeductionRequest())))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("결제 정보를 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("현금영수증이 이미 신청된 경우 409를 반환한다")
+		void createCashReceipt_중복신청_409() throws Exception {
+			given(paymentService.createCashReceipt(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS));
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createPersonalDeductionRequest())))
+				.andExpect(status().isConflict())
+				.andExpect(jsonPath("$.message").value("현금영수증이 이미 신청되었습니다."));
+		}
+
+		@Test
+		@DisplayName("주문 소유권이 없으면 403을 반환한다")
+		void createCashReceipt_소유권_없음_403() throws Exception {
+			given(paymentService.createCashReceipt(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createPersonalDeductionRequest())))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+		}
+
+		@Test
+		@DisplayName("주문이 없으면 404를 반환한다")
+		void createCashReceipt_주문_미발견_404() throws Exception {
+			given(paymentService.createCashReceipt(any(), any(), any()))
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(PaymentFixture.createPersonalDeductionRequest())))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
+		}
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
@@ -207,7 +207,7 @@ class PaymentControllerTest extends WebMvcTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.code").value("CREATED"))
 				.andExpect(jsonPath("$.data.orderId").value(1))
 				.andExpect(jsonPath("$.data.purpose").value("PERSONAL_DEDUCTION"))
 				.andExpect(jsonPath("$.data.number").value("010-1234-5678"));

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/entity/PaymentEntityTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/entity/PaymentEntityTest.java
@@ -1,0 +1,170 @@
+package com.goormgb.be.ordercore.payment.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+
+@DisplayName("Payment 엔티티 단위 테스트")
+class PaymentEntityTest {
+
+	private Order createOrder() {
+		return OrderFixture.createOrder(
+			OrderFixture.createUser(),
+			OrderFixture.createWeekdayMatch()
+		);
+	}
+
+	private Payment createPendingPayment(PaymentMethod method) {
+		return Payment.builder()
+			.order(createOrder())
+			.paymentMethod(method)
+			.build();
+	}
+
+	@Nested
+	@DisplayName("생성 시 초기 상태 검증")
+	class Creation {
+
+		@Test
+		@DisplayName("결제 생성 시 상태는 PENDING이다")
+		void 생성시_상태는_PENDING() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+		}
+
+		@Test
+		@DisplayName("결제 생성 시 paidAt은 null이다")
+		void 생성시_paidAt은_null() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			assertThat(payment.getPaidAt()).isNull();
+		}
+
+		@Test
+		@DisplayName("간편결제 생성 시 가상계좌 정보는 null이다")
+		void 간편결제_생성시_가상계좌_null() {
+			Payment payment = createPendingPayment(PaymentMethod.KAKAO_PAY);
+			assertThat(payment.getVirtualAccountBank()).isNull();
+			assertThat(payment.getVirtualAccountNumber()).isNull();
+			assertThat(payment.getVirtualAccountHolder()).isNull();
+			assertThat(payment.getDepositDeadline()).isNull();
+		}
+
+		@Test
+		@DisplayName("가상계좌 생성 시 계좌 정보가 올바르게 설정된다")
+		void 가상계좌_생성시_계좌정보_설정() {
+			Instant deadline = Instant.now().plus(3, ChronoUnit.DAYS);
+			Payment payment = Payment.builder()
+				.order(createOrder())
+				.paymentMethod(PaymentMethod.VIRTUAL_ACCOUNT)
+				.virtualAccountBank("국민은행")
+				.virtualAccountNumber("047-000-00000001")
+				.virtualAccountHolder("구름GB")
+				.depositDeadline(deadline)
+				.build();
+
+			assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
+			assertThat(payment.getVirtualAccountBank()).isEqualTo("국민은행");
+			assertThat(payment.getVirtualAccountNumber()).isEqualTo("047-000-00000001");
+			assertThat(payment.getVirtualAccountHolder()).isEqualTo("구름GB");
+			assertThat(payment.getDepositDeadline()).isEqualTo(deadline);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+		}
+
+		@Test
+		@DisplayName("결제 수단이 올바르게 저장된다")
+		void 결제수단_저장() {
+			Payment tossPay = createPendingPayment(PaymentMethod.TOSS_PAY);
+			Payment kakaoPay = createPendingPayment(PaymentMethod.KAKAO_PAY);
+			Payment virtualAccount = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+
+			assertThat(tossPay.getPaymentMethod()).isEqualTo(PaymentMethod.TOSS_PAY);
+			assertThat(kakaoPay.getPaymentMethod()).isEqualTo(PaymentMethod.KAKAO_PAY);
+			assertThat(virtualAccount.getPaymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
+		}
+	}
+
+	@Nested
+	@DisplayName("complete() 결제 완료 처리")
+	class Complete {
+
+		@Test
+		@DisplayName("complete() 호출 시 상태가 COMPLETED로 변경된다")
+		void complete_상태가_COMPLETED() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			payment.complete();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+		}
+
+		@Test
+		@DisplayName("complete() 호출 시 paidAt이 설정된다")
+		void complete_paidAt_설정() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			Instant before = Instant.now();
+			payment.complete();
+			assertThat(payment.getPaidAt()).isNotNull();
+			assertThat(payment.getPaidAt()).isAfterOrEqualTo(before);
+		}
+
+		@Test
+		@DisplayName("가상계좌 결제도 complete() 호출 시 COMPLETED 상태가 된다")
+		void 가상계좌_complete() {
+			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			payment.complete();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+		}
+	}
+
+	@Nested
+	@DisplayName("cancel() 결제 취소 처리")
+	class Cancel {
+
+		@Test
+		@DisplayName("cancel() 호출 시 상태가 CANCELLED로 변경된다")
+		void cancel_상태가_CANCELLED() {
+			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			payment.cancel();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("완료된 결제도 cancel() 호출 시 CANCELLED 상태가 된다")
+		void 완료된결제_cancel() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			payment.complete();
+			payment.cancel();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+		}
+	}
+
+	@Nested
+	@DisplayName("refund() 환불 처리")
+	class Refund {
+
+		@Test
+		@DisplayName("refund() 호출 시 상태가 REFUNDED로 변경된다")
+		void refund_상태가_REFUNDED() {
+			Payment payment = createPendingPayment(PaymentMethod.TOSS_PAY);
+			payment.complete();
+			payment.refund();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+		}
+
+		@Test
+		@DisplayName("PENDING 상태에서도 refund() 호출 가능하다")
+		void refund_PENDING_상태에서_호출가능() {
+			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			payment.refund();
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+		}
+	}
+}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -1,0 +1,322 @@
+package com.goormgb.be.ordercore.payment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.fixture.payment.PaymentFixture;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
+import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
+import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
+import com.goormgb.be.ordercore.payment.dto.response.PaymentProcessResponse;
+import com.goormgb.be.ordercore.payment.entity.CashReceipt;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+import com.goormgb.be.ordercore.payment.repository.CashReceiptRepository;
+import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
+import com.goormgb.be.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService 서비스 단위 테스트")
+class PaymentServiceTest {
+
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private PaymentRepository paymentRepository;
+	@Mock
+	private CashReceiptRepository cashReceiptRepository;
+
+	private PaymentService paymentService;
+
+	@BeforeEach
+	void setUp() {
+		paymentService = new PaymentService(orderRepository, paymentRepository, cashReceiptRepository);
+	}
+
+	private Order createOrderWithUser(Long orderId, Long userId) {
+		User user = OrderFixture.createUserWithId(userId);
+		Order order = OrderFixture.createOrder(user, OrderFixture.createWeekdayMatch());
+		ReflectionTestUtils.setField(order, "id", orderId);
+		return order;
+	}
+
+	@Nested
+	@DisplayName("processPayment — 결제 처리")
+	class ProcessPayment {
+
+		@Test
+		@DisplayName("토스페이 결제 시 즉시 COMPLETED 상태가 되고 orderStatus가 PAID가 된다")
+		void processPayment_TOSS_PAY_즉시완료() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			PaymentProcessRequest request = PaymentFixture.createTossPayRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
+
+			assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.TOSS_PAY);
+			assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+			assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAID);
+			assertThat(response.paidAt()).isNotNull();
+			assertThat(response.virtualAccount()).isNull();
+		}
+
+		@Test
+		@DisplayName("카카오페이 결제 시 즉시 COMPLETED 상태가 되고 orderStatus가 PAID가 된다")
+		void processPayment_KAKAO_PAY_즉시완료() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			PaymentProcessRequest request = PaymentFixture.createKakaoPayRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
+
+			assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.KAKAO_PAY);
+			assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+			assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAID);
+		}
+
+		@Test
+		@DisplayName("가상계좌 결제 시 PENDING 상태를 유지하고 가상계좌 정보를 반환한다")
+		void processPayment_VIRTUAL_ACCOUNT_대기상태() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			ReflectionTestUtils.setField(order, "id", orderId);
+			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
+
+			assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
+			assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.PENDING);
+			assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+			assertThat(response.virtualAccount()).isNotNull();
+			assertThat(response.virtualAccount().bank()).isEqualTo("국민은행");
+			assertThat(response.virtualAccount().holder()).isEqualTo("구름GB");
+			assertThat(response.virtualAccount().accountNumber()).startsWith("047-000-");
+			assertThat(response.virtualAccount().depositDeadline()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("가상계좌 번호는 orderId 기반으로 생성된다")
+		void processPayment_가상계좌번호_orderId_기반() {
+			Long userId = 1L;
+			Long orderId = 42L;
+			Order order = createOrderWithUser(orderId, userId);
+			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
+
+			assertThat(response.virtualAccount().accountNumber()).isEqualTo("047-000-00000042");
+		}
+
+		@Test
+		@DisplayName("주문이 없으면 ORDER_NOT_FOUND 예외가 발생한다")
+		void processPayment_주문_미발견_예외() {
+			given(orderRepository.findById(99L)).willReturn(Optional.empty());
+
+			assertThatThrownBy(
+				() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("주문 소유자가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		void processPayment_소유권_없음_예외() {
+			Long actualOwnerId = 1L;
+			Long attackerId = 99L;
+			Order order = createOrderWithUser(1L, actualOwnerId);
+
+			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(
+				() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PENDING이 아닌 주문은 PAYMENT_ALREADY_COMPLETED 예외가 발생한다")
+		void processPayment_이미_결제된_주문_예외() {
+			Long userId = 1L;
+			Order order = createOrderWithUser(1L, userId);
+			order.updateStatus(OrderStatus.PAID); // PAID 상태로 변경
+
+			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(
+				() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+		}
+
+		@Test
+		@DisplayName("이미 결제 정보가 존재하면 PAYMENT_ALREADY_COMPLETED 예외가 발생한다")
+		void processPayment_결제정보_이미_존재_예외() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			Payment existingPayment = PaymentFixture.createVirtualAccountPayment(order);
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(existingPayment));
+
+			assertThatThrownBy(
+				() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("createCashReceipt — 현금영수증 신청")
+	class CreateCashReceipt {
+
+		@Test
+		@DisplayName("개인소득공제 현금영수증을 정상 신청한다")
+		void createCashReceipt_개인소득공제_성공() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
+			CashReceiptCreateRequest request = PaymentFixture.createPersonalDeductionRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.empty());
+			given(cashReceiptRepository.save(any(CashReceipt.class))).willAnswer(inv -> inv.getArgument(0));
+
+			CashReceiptCreateResponse response = paymentService.createCashReceipt(userId, orderId, request);
+
+			assertThat(response.orderId()).isEqualTo(orderId);
+			assertThat(response.purpose()).isEqualTo(CashReceiptPurpose.PERSONAL_DEDUCTION);
+			assertThat(response.number()).isEqualTo("010-1234-5678");
+		}
+
+		@Test
+		@DisplayName("사업자지출증빙 현금영수증을 정상 신청한다")
+		void createCashReceipt_사업자지출증빙_성공() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
+			CashReceiptCreateRequest request = PaymentFixture.createBusinessExpenseRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.empty());
+			given(cashReceiptRepository.save(any(CashReceipt.class))).willAnswer(inv -> inv.getArgument(0));
+
+			CashReceiptCreateResponse response = paymentService.createCashReceipt(userId, orderId, request);
+
+			assertThat(response.purpose()).isEqualTo(CashReceiptPurpose.BUSINESS_EXPENSE);
+			assertThat(response.number()).isEqualTo("123-45-67890");
+		}
+
+		@Test
+		@DisplayName("결제 정보가 없으면 PAYMENT_NOT_FOUND 예외가 발생한다")
+		void createCashReceipt_결제_미발견_예외() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(
+				() -> paymentService.createCashReceipt(userId, orderId, PaymentFixture.createPersonalDeductionRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("현금영수증이 이미 신청된 경우 CASH_RECEIPT_ALREADY_EXISTS 예외가 발생한다")
+		void createCashReceipt_중복신청_예외() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
+			CashReceipt existing = PaymentFixture.createPersonalDeductionReceipt(payment);
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.of(existing));
+
+			assertThatThrownBy(
+				() -> paymentService.createCashReceipt(userId, orderId, PaymentFixture.createPersonalDeductionRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
+		}
+
+		@Test
+		@DisplayName("주문 소유자가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		void createCashReceipt_소유권_없음_예외() {
+			Long actualOwnerId = 1L;
+			Long attackerId = 99L;
+			Order order = createOrderWithUser(1L, actualOwnerId);
+
+			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(
+				() -> paymentService.createCashReceipt(attackerId, 1L, PaymentFixture.createPersonalDeductionRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+		}
+
+		@Test
+		@DisplayName("주문이 없으면 ORDER_NOT_FOUND 예외가 발생한다")
+		void createCashReceipt_주문_미발견_예외() {
+			given(orderRepository.findById(99L)).willReturn(Optional.empty());
+
+			assertThatThrownBy(
+				() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
+			)
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+		}
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/PricePolicyInitializer.java
@@ -41,8 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PricePolicyInitializer implements CommandLineRunner {
 
-	private static final Long JAMSIL_STADIUM_ID = 1L;
-
 	private final SectionRepository sectionRepository;
 	private final PricePolicyRepository pricePolicyRepository;
 
@@ -141,7 +139,6 @@ public class PricePolicyInitializer implements CommandLineRunner {
 
 	private PricePolicy policy(Long sectionId, DayType dayType, TicketType ticketType, int price) {
 		return PricePolicy.builder()
-			.stadiumId(JAMSIL_STADIUM_ID)
 			.sectionId(sectionId)
 			.dayType(dayType)
 			.ticketType(ticketType)

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/entity/PricePolicy.java
@@ -21,8 +21,8 @@ import lombok.NoArgsConstructor;
 	name = "price_policies",
 	uniqueConstraints = {
 		@UniqueConstraint(
-			name = "uk_price_policies_stadium_id_section_id_day_type_ticket_type",
-			columnNames = {"stadium_id", "section_id", "day_type", "ticket_type"}
+			name = "uk_price_policies_section_id_day_type_ticket_type",
+			columnNames = {"section_id", "day_type", "ticket_type"}
 		)
 	},
 	indexes = {
@@ -35,9 +35,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PricePolicy extends BaseEntity {
-
-	@Column(name = "stadium_id", nullable = false)
-	private Long stadiumId;
 
 	@Column(name = "section_id", nullable = false)
 	private Long sectionId;
@@ -55,13 +52,11 @@ public class PricePolicy extends BaseEntity {
 
 	@Builder
 	public PricePolicy(
-		Long stadiumId,
 		Long sectionId,
 		DayType dayType,
 		TicketType ticketType,
 		Integer price
 	) {
-		this.stadiumId = stadiumId;
 		this.sectionId = sectionId;
 		this.dayType = dayType;
 		this.ticketType = ticketType;

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
 	SEAT_HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "좌석 선점이 만료되었습니다."),
 	SEAT_HOLD_OWNERSHIP_DENIED(HttpStatus.FORBIDDEN, "해당 좌석 선점에 접근할 권한이 없습니다."),
 	PRICE_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 좌석의 가격 정책을 찾을 수 없습니다."),
+	SEAT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 세션이 존재하지 않거나 만료되었습니다."),
 
 	// Payment
 	PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -59,6 +59,24 @@ public enum ErrorCode {
 	INVALID_MATCH_MONTH(HttpStatus.BAD_REQUEST, "올바른 경기 월을 입력해주세요."),
 	INVALID_MATCH_YEAR(HttpStatus.BAD_REQUEST, "올바른 경기 년도를 입력해주세요."),
 
+	// Order
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+	ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 주문에 접근할 권한이 없습니다."),
+	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
+	ORDER_SEAT_EMPTY(HttpStatus.BAD_REQUEST, "주문 좌석 정보가 없습니다."),
+
+	// Seat Hold
+	SEAT_HOLD_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 선점 정보를 찾을 수 없습니다."),
+	SEAT_HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "좌석 선점이 만료되었습니다."),
+	SEAT_HOLD_OWNERSHIP_DENIED(HttpStatus.FORBIDDEN, "해당 좌석 선점에 접근할 권한이 없습니다."),
+	PRICE_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 좌석의 가격 정책을 찾을 수 없습니다."),
+
+	// Payment
+	PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+	PAYMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 주문입니다."),
+	CASH_RECEIPT_ALREADY_EXISTS(HttpStatus.CONFLICT, "현금영수증이 이미 신청되었습니다."),
+	INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 수단입니다."),
+
 	;
 
 	private final HttpStatus status;

--- a/common-core/src/main/java/com/goormgb/be/global/response/ApiResult.java
+++ b/common-core/src/main/java/com/goormgb/be/global/response/ApiResult.java
@@ -30,6 +30,14 @@ public class ApiResult<T> {
 		return of("OK", message, data);
 	}
 
+	public static ApiResult<Void> created() {
+		return of("CREATED", "성공", null);
+	}
+
+	public static <T> ApiResult<T> created(T data) {
+		return of("CREATED", "성공", data);
+	}
+
 	private static <T> ApiResult<T> of(String code, String message, T data) {
 		return new ApiResult<>(code, message, data);
 	}


### PR DESCRIPTION
## 🔧 작업 내
- 주문서 조회 / 주문 생성 / 결제 처리 / 현금영수증 신청 API 구현
- Order-Core가 Seat 모듈 엔티티에 의존하지 않도록 NamedParameterJdbcTemplate 기반 네이티브 쿼리 서비스 분리!!

## 🧩 구현 상세
### T1 — 주문서 조회 · 주문 생성
- `SeatInfoQueryService`: seat_holds·match_seats·blocks·sections JOIN 쿼리, 가격 정책 조회, 중복 주문 체크
- `OrderService.getOrderSheet()`: 좌석 선점 검증 + 만료 확인 + 성인 기준 가격 조회
- `OrderService.createOrder()`: 선점 소유권·만료·중복 검증 → KST 기준 WEEKDAY/WEEKEND 판별 → totalAmount = 티켓합산 + 예약수수료(2,000원)

### T2 — 결제 처리 · 현금영수증
- `PaymentService.processPayment()`: 간편결제(토스/카카오) 즉시완료 목업, 가상계좌 발급 목업(예시로.. 국민은행, 3일 입금기한)
- `PaymentService.createCashReceipt()`: 결제 완료 후 개인소득공제·사업자지출증빙 신청, 중복 방지

### 테스트
- 도메인 단위 테스트: `SeatHoldInfoTest`, `OrderEntityTest`, `PaymentEntityTest`
- 서비스 단위 테스트: `OrderServiceTest`(12케이스), `PaymentServiceTest`(12케이스) — Mockito
- 슬라이스 테스트: `OrderControllerTest`, `PaymentControllerTest` — `@WebMvcTest`, Bean Validation 포함

### 주문
<img width="1188" height="621" alt="스크린샷 2026-03-15 오후 3 29 15" src="https://github.com/user-attachments/assets/19ea7b2e-b999-4f5c-899e-92eefe2bc61b" />
<img width="1196" height="508" alt="스크린샷 2026-03-15 오후 3 29 21" src="https://github.com/user-attachments/assets/2af8d4a4-35ac-408a-88ca-28dba0983c8b" />
<img width="1083" height="449" alt="스크린샷 2026-03-15 오후 3 29 44" src="https://github.com/user-attachments/assets/378998d9-befb-4d29-8bf8-05ec90786119" />
<img width="1012" height="544" alt="스크린샷 2026-03-15 오후 3 29 55" src="https://github.com/user-attachments/assets/8bdea28c-5b08-47ce-9692-d501e63c5344" />
<img width="1242" height="447" alt="스크린샷 2026-03-15 오후 3 30 00" src="https://github.com/user-attachments/assets/8b28bc34-363d-4b42-8dd0-a25aa1b1926f" />
<img width="1063" height="586" alt="스크린샷 2026-03-15 오후 3 30 23" src="https://github.com/user-attachments/assets/f894df62-7c65-4941-bfe0-c04b29b5fd0a" />
<img width="1049" height="518" alt="스크린샷 2026-03-15 오후 3 30 29" src="https://github.com/user-attachments/assets/b9f229c4-94a0-4ccf-94c8-deca8c717236" />


### 결제
<img width="1281" height="421" alt="스크린샷 2026-03-15 오후 3 27 34" src="https://github.com/user-attachments/assets/0834c395-a48f-45d0-b4c2-6ceb10785d68" />
<img width="1064" height="547" alt="스크린샷 2026-03-15 오후 3 27 40" src="https://github.com/user-attachments/assets/af8668d0-106a-4164-ba79-ed841c18d3ef" />
<img width="1120" height="515" alt="스크린샷 2026-03-15 오후 3 27 47" src="https://github.com/user-attachments/assets/b1750680-1b5e-42ba-8aba-a0c2ac0b4bde" />
<img width="997" height="472" alt="스크린샷 2026-03-15 오후 3 28 10" src="https://github.com/user-attachments/assets/61c2d1af-3f27-4181-b7e2-72c03b34bd9c" />
<img width="1202" height="529" alt="스크린샷 2026-03-15 오후 3 28 26" src="https://github.com/user-attachments/assets/7b1ddb43-4c26-4620-880d-83e006b467bd" />
<img width="1200" height="578" alt="스크린샷 2026-03-15 오후 3 28 34" src="https://github.com/user-attachments/assets/97a94525-d7b9-44d7-a95c-edcb42f57773" />

### 📌 관련 Jira Issue
- GRGB-243

## ❗ 참고 사항
- 결제 PG 연동은 목업 처리 — 실제 연동 시`PaymentService.processPayment()` 교체 필요

### 작업량이 굉장히 많습니다..!!! 커밋단위로리뷰 봐주세요!
코드 작업량이 정말 많아서 제가 테스트를 도메인 서비스 컨트롤러 빡빡하게 넣어놧습니다!
로컬에서는 빌드와 테스트 전부 통과햇습니다!