### PR TITLE
feat(seat): 블럭 추천 리스트 API 구현 [GRGB-252]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.seat.block.entity.Block;
 
@@ -13,4 +14,7 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 	List<Block> findAllWithSectionAndArea();
 
 	List<Block> findBySectionIdInOrderBySectionIdAscBlockCodeAsc(List<Long> sectionIds);
+
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id IN :blockIds")
+	List<Block> findAllByIdInWithSectionAndArea(@Param("blockIds") List<Long> blockIds);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -23,4 +23,16 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 		@Param("matchId") Long matchId,
 		@Param("saleStatus") MatchSeatSaleStatus saleStatus
 	);
+
+	@Query("""
+		SELECT ms FROM MatchSeat ms
+		WHERE ms.matchId = :matchId
+		  AND ms.blockId = :blockId
+		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.AVAILABLE
+		ORDER BY ms.rowNo ASC, ms.templateColNo ASC
+		""")
+	List<MatchSeat> findAvailableSeatsByMatchIdAndBlockId(
+		@Param("matchId") Long matchId,
+		@Param("blockId") Long blockId
+	);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
 
@@ -38,5 +39,21 @@ public class SeatRecommendationController {
 		// TODO: 큐 진입 토큰 확인
 	) {
 		return ApiResult.ok(seatRecommendationService.getRecommendationSeatEntry(matchId, userId));
+	}
+
+	@Operation(
+		summary = "추천 블럭 리스트 조회",
+		description = "사용자의 선호 블럭 내에서 N연석 가능 개수와 취향 점수를 기반으로 추천 블럭 리스트를 반환합니다.",
+		security = @SecurityRequirement(name = "BearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "추천 블럭 리스트 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "추천 가능한 블럭이 없거나 세션/경기를 찾을 수 없습니다.")
+	})
+	@GetMapping("/blocks")
+	public ApiResult<BlockRecommendationResponse> getRecommendedBlocks(
+		@PathVariable Long matchId,
+		@AuthenticationPrincipal Long userId
+	) {
+		return ApiResult.ok(seatRecommendationService.getRecommendedBlocks(matchId, userId));
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/BlockRecommendation.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/BlockRecommendation.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.seat.recommendation.dto.internal;
+
+import com.goormgb.be.seat.block.entity.Block;
+
+public record BlockRecommendation(
+	Block block,
+	int realConsecutiveCount
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -1,0 +1,48 @@
+package com.goormgb.be.seat.recommendation.dto.response;
+
+import java.util.List;
+
+import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
+
+public record BlockRecommendationResponse(
+	Long matchId,
+	int ticketCount,
+	List<RecommendedBlock> blocks
+) {
+
+	public static BlockRecommendationResponse of(
+		Long matchId,
+		int ticketCount,
+		List<BlockRecommendation> recommendations
+	) {
+		List<RecommendedBlock> blocks = new java.util.ArrayList<>();
+		for (int i = 0; i < recommendations.size(); i++) {
+			blocks.add(RecommendedBlock.from(recommendations.get(i), i + 1));
+		}
+		return new BlockRecommendationResponse(matchId, ticketCount, blocks);
+	}
+
+	public record RecommendedBlock(
+		Long blockId,
+		String blockCode,
+		String sectionName,
+		String areaName,
+		String viewpoint,
+		int realConsecutiveCount,
+		int rank
+	) {
+
+		public static RecommendedBlock from(BlockRecommendation recommendation, int rank) {
+			var block = recommendation.block();
+			return new RecommendedBlock(
+				block.getId(),
+				block.getBlockCode(),
+				block.getSection().getName(),
+				block.getArea().getName(),
+				block.getViewpoint().name(),
+				recommendation.realConsecutiveCount(),
+				rank
+			);
+		}
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/ConsecutiveSeatCounter.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/ConsecutiveSeatCounter.java
@@ -1,0 +1,109 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 블럭 내 "진짜 N연석" 가능 묶음 수를 계산하는 컴포넌트.
+ *
+ * <p>진짜 N연석이란, 같은 열(row) 안에서 template_col_no가 빈칸 없이 연속으로 N개 붙어있는 좌석 묶음을 말한다.</p>
+ *
+ * <h3>계산 방식</h3>
+ * <ol>
+ *   <li>해당 블럭의 AVAILABLE 좌석을 열(row)별로 그룹화한다.</li>
+ *   <li>각 열에서 template_col_no가 연속인 구간(세그먼트)을 추출한다.
+ *       <br>예: [1,2,3,4,5, _, 7,8,9] → 세그먼트 [1~5], [7~9]</li>
+ *   <li>각 세그먼트에서 N개짜리 묶음이 몇 개 나오는지 센다.
+ *       <br>공식: (세그먼트 길이 - N + 1), 음수면 0</li>
+ *   <li>모든 열의 묶음 수를 합산해서 반환한다.</li>
+ * </ol>
+ *
+ * <h3>예시</h3>
+ * <pre>
+ * 14칸 열에서 12석 AVAILABLE, 연속 구간이 [1~8], [10~13]이고, N=5일 때:
+ *   [1~8] → 8-5+1 = 4개
+ *   [10~13] → 4-5+1 = 0개 (4 < 5이므로 불가)
+ *   합계 = 4개
+ * </pre>
+ */
+@Component
+@RequiredArgsConstructor
+public class ConsecutiveSeatCounter {
+
+	private final MatchSeatRepository matchSeatRepository;
+
+	/**
+	 * 특정 경기·블럭에서 진짜 N연석이 가능한 묶음의 총 개수를 반환한다.
+	 *
+	 * @param matchId       경기 ID
+	 * @param blockId       블럭 ID
+	 * @param requiredSeats 필요 연석 수 (N)
+	 * @return 진짜 N연석 가능 묶음 수 (0이면 해당 블럭에서 N연석 불가)
+	 */
+	public int countRealConsecutiveSeats(Long matchId, Long blockId, int requiredSeats) {
+		List<MatchSeat> availableSeats = matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(matchId, blockId);
+
+		if (availableSeats.isEmpty()) {
+			return 0;
+		}
+
+		Map<Integer, List<Integer>> seatsByRow = availableSeats.stream()
+			.collect(Collectors.groupingBy(
+				MatchSeat::getRowNo,
+				Collectors.mapping(MatchSeat::getTemplateColNo, Collectors.toList())
+			));
+
+		int totalCount = 0;
+
+		for (List<Integer> colNos : seatsByRow.values()) {
+			totalCount += countConsecutiveGroupsInRow(colNos, requiredSeats);
+		}
+
+		return totalCount;
+	}
+
+	private int countConsecutiveGroupsInRow(List<Integer> sortedColNos, int requiredSeats) {
+		if (sortedColNos.size() < requiredSeats) {
+			return 0;
+		}
+
+		List<List<Integer>> consecutiveSegments = extractConsecutiveSegments(sortedColNos);
+
+		int count = 0;
+		for (List<Integer> segment : consecutiveSegments) {
+			if (segment.size() >= requiredSeats) {
+				count += (segment.size() - requiredSeats + 1);
+			}
+		}
+
+		return count;
+	}
+
+	private List<List<Integer>> extractConsecutiveSegments(List<Integer> sortedColNos) {
+		List<List<Integer>> segments = new ArrayList<>();
+		List<Integer> current = new ArrayList<>();
+		current.add(sortedColNos.get(0));
+
+		for (int i = 1; i < sortedColNos.size(); i++) {
+			if (sortedColNos.get(i) == sortedColNos.get(i - 1) + 1) {
+				current.add(sortedColNos.get(i));
+			} else {
+				segments.add(current);
+				current = new ArrayList<>();
+				current.add(sortedColNos.get(i));
+			}
+		}
+		segments.add(current);
+
+		return segments;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculator.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculator.java
@@ -1,0 +1,134 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.entity.Block;
+
+/**
+ * 사용자의 온보딩 선호 정보를 기반으로 블럭별 "선호도 점수"를 계산하는 컴포넌트.
+ *
+ * <p>연석 개수 차이가 크지 않을 때(±10 이내) 어떤 블럭을 더 위로 올릴지 결정하는 보조 점수이다.</p>
+ *
+ * <h3>점수 구성 (최대 70점)</h3>
+ * <ul>
+ *   <li><b>뷰포인트 선호</b> — 유저가 온보딩에서 선택한 관람 시야 우선순위
+ *       <br>1순위: 30점, 2순위: 20점, 3순위: 10점</li>
+ *   <li><b>응원 구단 일치</b> — 유저 응원구단이 경기 참가팀이고, 블럭이 해당 팀 area(홈/어웨이)에 속하면 25점</li>
+ *   <li><b>응원석 근접 선호</b> — NEAR이면 응원석 가까운 블럭(cheerRank ≤ 3)에 15점,
+ *       FAR이면 먼 블럭(cheerRank > 3)에 15점, ANY면 0점</li>
+ * </ul>
+ */
+@Component
+public class PreferenceScoreCalculator {
+
+	private static final int VIEWPOINT_1ST_WEIGHT = 30;
+	private static final int VIEWPOINT_2ND_WEIGHT = 20;
+	private static final int VIEWPOINT_3RD_WEIGHT = 10;
+	private static final int CLUB_PREFERENCE_WEIGHT = 25;
+	private static final int CHEER_PROXIMITY_WEIGHT = 15;
+
+	/**
+	 * 블럭 하나에 대한 사용자 선호도 점수를 계산한다.
+	 *
+	 * @param block      점수를 매길 블럭
+	 * @param pref       사용자 온보딩 선호 정보 (응원구단, 응원석 근접 선호)
+	 * @param viewpoints 사용자 뷰포인트 우선순위 목록 (1~3순위)
+	 * @param match      현재 경기 정보 (홈/어웨이 구단 판별용)
+	 * @return 선호도 점수 (0 ~ 70)
+	 */
+	public int calculatePreferenceScore(
+		Block block,
+		OnboardingPreference pref,
+		List<OnboardingViewpointPriority> viewpoints,
+		Match match
+	) {
+		int score = 0;
+
+		score += calculateViewpointScore(block, viewpoints);
+		score += calculateClubPreferenceScore(block, pref, match);
+		score += calculateCheerProximityScore(block, pref, match);
+
+		return score;
+	}
+
+	private int calculateViewpointScore(Block block, List<OnboardingViewpointPriority> viewpoints) {
+		Map<Viewpoint, Integer> viewpointPriorityMap = viewpoints.stream()
+			.collect(Collectors.toMap(
+				OnboardingViewpointPriority::getViewpoint,
+				OnboardingViewpointPriority::getPriority
+			));
+
+		Integer priority = viewpointPriorityMap.get(block.getViewpoint());
+		if (priority == null) {
+			return 0;
+		}
+
+		return switch (priority) {
+			case 1 -> VIEWPOINT_1ST_WEIGHT;
+			case 2 -> VIEWPOINT_2ND_WEIGHT;
+			case 3 -> VIEWPOINT_3RD_WEIGHT;
+			default -> 0;
+		};
+	}
+
+	private int calculateClubPreferenceScore(Block block, OnboardingPreference pref, Match match) {
+		Long favoriteClubId = pref.getFavoriteClub().getId();
+		AreaCode areaCode = block.getArea().getCode();
+
+		if (favoriteClubId.equals(match.getHomeClub().getId()) && areaCode == AreaCode.HOME) {
+			return CLUB_PREFERENCE_WEIGHT;
+		}
+
+		if (favoriteClubId.equals(match.getAwayClub().getId()) && areaCode == AreaCode.AWAY) {
+			return CLUB_PREFERENCE_WEIGHT;
+		}
+
+		return 0;
+	}
+
+	private int calculateCheerProximityScore(Block block, OnboardingPreference pref, Match match) {
+		CheerProximityPref cheerPref = pref.getCheerProximityPref();
+		if (cheerPref == CheerProximityPref.ANY) {
+			return 0;
+		}
+
+		Integer cheerRank = resolveCheerRank(block, pref, match);
+		if (cheerRank == null) {
+			return 0;
+		}
+
+		if (cheerPref == CheerProximityPref.NEAR) {
+			return cheerRank <= 3 ? CHEER_PROXIMITY_WEIGHT : 0;
+		}
+
+		if (cheerPref == CheerProximityPref.FAR) {
+			return cheerRank > 3 ? CHEER_PROXIMITY_WEIGHT : 0;
+		}
+
+		return 0;
+	}
+
+	private Integer resolveCheerRank(Block block, OnboardingPreference pref, Match match) {
+		Long favoriteClubId = pref.getFavoriteClub().getId();
+
+		if (favoriteClubId.equals(match.getHomeClub().getId())) {
+			return block.getHomeCheerRank();
+		}
+
+		if (favoriteClubId.equals(match.getAwayClub().getId())) {
+			return block.getAwayCheerRank();
+		}
+
+		return block.getHomeCheerRank();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -1,10 +1,26 @@
 package com.goormgb.be.seat.recommendation.service;
 
-import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
+import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,13 +28,81 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatRecommendationService {
 
+	private static final int CONSECUTIVE_COUNT_THRESHOLD = 10;
+
 	private final MatchRepository matchRepository;
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	private final BlockRepository blockRepository;
+	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
+	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
+	private final ConsecutiveSeatCounter consecutiveSeatCounter;
+	private final PreferenceScoreCalculator preferenceScoreCalculator;
 
 	public SeatEntryResponse getRecommendationSeatEntry(Long matchId, Long userId) {
 		var match = matchRepository.findDetailByIdOrThrow(matchId);
 		var seatSession = seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 
 		return SeatEntryResponse.of(match, seatSession);
+	}
+
+	@Transactional(readOnly = true)
+	public BlockRecommendationResponse getRecommendedBlocks(Long matchId, Long userId) {
+		SeatSession seatSession = seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+		int ticketCount = seatSession.getTicketCount();
+		List<Long> preferredBlockIds = seatSession.getPreferredBlockIds();
+
+		Match match = matchRepository.findDetailByIdOrThrow(matchId);
+		List<Block> preferredBlocks = blockRepository.findAllByIdInWithSectionAndArea(preferredBlockIds);
+		OnboardingPreference pref = onboardingPreferenceRepository.findByUserIdOrThrow(
+			userId, ErrorCode.PREFERENCE_NOT_FOUND);
+		List<OnboardingViewpointPriority> viewpoints =
+			onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId);
+
+		List<BlockRecommendation> recommendations = buildRecommendations(matchId, ticketCount, preferredBlocks);
+
+		if (recommendations.isEmpty()) {
+			throw new CustomException(ErrorCode.NO_AVAILABLE_BLOCK);
+		}
+
+		sortRecommendations(recommendations, pref, viewpoints, match);
+
+		return BlockRecommendationResponse.of(matchId, ticketCount, recommendations);
+	}
+
+	private List<BlockRecommendation> buildRecommendations(Long matchId, int ticketCount, List<Block> blocks) {
+		List<BlockRecommendation> recommendations = new ArrayList<>();
+
+		for (Block block : blocks) {
+			int count = consecutiveSeatCounter.countRealConsecutiveSeats(matchId, block.getId(), ticketCount);
+			if (count > 0) {
+				recommendations.add(new BlockRecommendation(block, count));
+			}
+		}
+
+		return recommendations;
+	}
+
+	private void sortRecommendations(
+		List<BlockRecommendation> recommendations,
+		OnboardingPreference pref,
+		List<OnboardingViewpointPriority> viewpoints,
+		Match match
+	) {
+		recommendations.sort((b1, b2) -> {
+			int countDiff = b2.realConsecutiveCount() - b1.realConsecutiveCount();
+
+			if (Math.abs(countDiff) > CONSECUTIVE_COUNT_THRESHOLD) {
+				return countDiff;
+			}
+
+			int score1 = preferenceScoreCalculator.calculatePreferenceScore(b1.block(), pref, viewpoints, match);
+			int score2 = preferenceScoreCalculator.calculatePreferenceScore(b2.block(), pref, viewpoints, match);
+
+			if (score1 != score2) {
+				return score2 - score1;
+			}
+
+			return countDiff;
+		});
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationControllerTest.java
@@ -76,7 +76,7 @@ class SeatRecommendationControllerTest {
 			.andExpect(jsonPath("$.data.match.stadium.stadiumId").value(3))
 			.andExpect(jsonPath("$.data.match.stadium.koName").value("잠실 야구장"))
 			.andExpect(jsonPath("$.data.seatSession.recommendationEnabled").value(true))
-			.andExpect(jsonPath("$.data.seatSession.headCount").value(2))
+			.andExpect(jsonPath("$.data.seatSession.ticketCount").value(2))
 			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[0]").value(206))
 			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[1]").value(208))
 			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[2]").value(105));

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/ConsecutiveSeatCounterTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/ConsecutiveSeatCounterTest.java
@@ -1,0 +1,153 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+@ExtendWith(MockitoExtension.class)
+class ConsecutiveSeatCounterTest {
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+
+	@InjectMocks
+	private ConsecutiveSeatCounter consecutiveSeatCounter;
+
+	private MatchSeat createSeat(int rowNo, int templateColNo) {
+		return MatchSeat.builder()
+			.matchId(1L)
+			.seatId((long)(rowNo * 100 + templateColNo))
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(rowNo)
+			.seatNo(templateColNo)
+			.templateColNo(templateColNo)
+			.seatZone(SeatZone.LOW)
+			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+			.build();
+	}
+
+	@Test
+	@DisplayName("14칸 연속 row에서 5연석 가능 개수는 10개이다")
+	void 전체_연속_14칸에서_5연석() {
+		// given
+		List<MatchSeat> seats = new java.util.ArrayList<>();
+		for (int col = 1; col <= 14; col++) {
+			seats.add(createSeat(1, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 5);
+
+		// then
+		assertThat(count).isEqualTo(10); // 14 - 5 + 1 = 10
+	}
+
+	@Test
+	@DisplayName("중간에 빠진 좌석이 있으면 연속 구간별로 계산한다")
+	void 중간_빠진_좌석_연속구간_분리() {
+		// given: [1,2,3,4,5, _, 7,8,9,10,11,12,13,14]
+		List<MatchSeat> seats = new java.util.ArrayList<>();
+		for (int col = 1; col <= 5; col++) {
+			seats.add(createSeat(1, col));
+		}
+		for (int col = 7; col <= 14; col++) {
+			seats.add(createSeat(1, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 5);
+
+		// then
+		// [1~5] → 5-5+1 = 1개
+		// [7~14] → 8-5+1 = 4개
+		// 합계 = 5개
+		assertThat(count).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("여러 row에서 연석 개수를 합산한다")
+	void 여러_row_합산() {
+		// given: row1에 [1~14], row2에 [1~14]
+		List<MatchSeat> seats = new java.util.ArrayList<>();
+		for (int col = 1; col <= 14; col++) {
+			seats.add(createSeat(1, col));
+		}
+		for (int col = 1; col <= 14; col++) {
+			seats.add(createSeat(2, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 5);
+
+		// then
+		assertThat(count).isEqualTo(20); // (14-5+1) * 2 = 20
+	}
+
+	@Test
+	@DisplayName("연석 가능한 좌석이 없으면 0을 반환한다")
+	void 연석_불가_0반환() {
+		// given: [1, 3, 5, 7] — 모두 떨어져 있음
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 1),
+			createSeat(1, 3),
+			createSeat(1, 5),
+			createSeat(1, 7)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 2);
+
+		// then
+		assertThat(count).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("좌석이 비어있으면 0을 반환한다")
+	void 좌석_없음_0반환() {
+		// given
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(List.of());
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 3);
+
+		// then
+		assertThat(count).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("1매 요청 시 AVAILABLE 좌석 수만큼 반환한다")
+	void 단일석_요청() {
+		// given
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 1),
+			createSeat(1, 5),
+			createSeat(2, 3)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		int count = consecutiveSeatCounter.countRealConsecutiveSeats(1L, 1L, 1);
+
+		// then
+		assertThat(count).isEqualTo(3);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculatorTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculatorTest.java
@@ -1,0 +1,204 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.domain.stadium.entity.Stadium;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.user.entity.User;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PreferenceScoreCalculatorTest {
+
+	private final PreferenceScoreCalculator calculator = new PreferenceScoreCalculator();
+
+	private Club createClub(Long id, String name) {
+		Club club = Club.builder()
+			.koName(name)
+			.enName(name)
+			.logoImg("logo.png")
+			.clubColor("#000")
+			.build();
+		ReflectionTestUtils.setField(club, "id", id);
+		return club;
+	}
+
+	private User createUser(Long id) {
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	private Match createMatch(Club home, Club away) {
+		Stadium stadium = Stadium.builder()
+			.region("서울")
+			.koName("잠실")
+			.enName("Jamsil")
+			.address("서울시")
+			.build();
+		return Match.create(Instant.now(), home, away, stadium, SaleStatus.ON_SALE);
+	}
+
+	private Block createBlock(AreaCode areaCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
+		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
+		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
+		return Block.builder()
+			.area(area)
+			.section(section)
+			.blockCode("205")
+			.viewpoint(viewpoint)
+			.homeCheerRank(homeCheerRank)
+			.awayCheerRank(awayCheerRank)
+			.build();
+	}
+
+	private OnboardingPreference createPref(User user, Club favoriteClub, CheerProximityPref cheerPref) {
+		return OnboardingPreference.builder()
+			.user(user)
+			.favoriteClub(favoriteClub)
+			.cheerProximityPref(cheerPref)
+			.build();
+	}
+
+	private OnboardingViewpointPriority createViewpointPriority(User user, Viewpoint viewpoint, int priority) {
+		return OnboardingViewpointPriority.builder()
+			.user(user)
+			.viewpoint(viewpoint)
+			.priority(priority)
+			.build();
+	}
+
+	@Test
+	@DisplayName("뷰포인트 1순위 블럭은 30점을 받는다")
+	void 뷰포인트_1순위_30점() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
+		OnboardingPreference pref = createPref(user, createClub(3L, "삼성 라이온즈"), CheerProximityPref.ANY);
+		List<OnboardingViewpointPriority> viewpoints = List.of(
+			createViewpointPriority(user, Viewpoint.OUTFIELD_C, 1)
+		);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, viewpoints, match);
+
+		// then
+		assertThat(score).isEqualTo(30);
+	}
+
+	@Test
+	@DisplayName("응원구단이 홈팀이고 블럭이 HOME이면 구단 가중치 25점을 받는다")
+	void 응원구단_홈팀_HOME블럭_25점() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
+		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.ANY);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+
+		// then
+		assertThat(score).isEqualTo(25);
+	}
+
+	@Test
+	@DisplayName("NEAR 선호 + 응원석 가까운 블럭(rank<=3)이면 15점을 받는다")
+	void NEAR_응원석_가까운_블럭_15점() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 2, 80);
+		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.NEAR);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+
+		// then
+		// clubPref(25) + cheerProximity(15) = 40
+		assertThat(score).isEqualTo(40);
+	}
+
+	@Test
+	@DisplayName("FAR 선호 + 응원석 먼 블럭(rank>3)이면 15점을 받는다")
+	void FAR_응원석_먼_블럭_15점() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
+		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.FAR);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+
+		// then
+		assertThat(score).isEqualTo(15);
+	}
+
+	@Test
+	@DisplayName("모든 조건이 맞으면 최대 점수를 받는다")
+	void 모든_조건_최대점수() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
+		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.NEAR);
+		List<OnboardingViewpointPriority> viewpoints = List.of(
+			createViewpointPriority(user, Viewpoint.INFIELD_1B, 1)
+		);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, viewpoints, match);
+
+		// then
+		// viewpoint(30) + clubPref(25) + cheerProximity(15) = 70
+		assertThat(score).isEqualTo(70);
+	}
+
+	@Test
+	@DisplayName("비참가 구단 팬은 구단 가중치를 받지 않는다")
+	void 비참가_구단_팬_구단가중치_없음() {
+		// given
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		Club samsungClub = createClub(3L, "삼성 라이온즈");
+		User user = createUser(1L);
+		Match match = createMatch(lgClub, doosanClub);
+		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
+		OnboardingPreference pref = createPref(user, samsungClub, CheerProximityPref.ANY);
+
+		// when
+		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+
+		// then
+		assertThat(score).isEqualTo(0);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -1,0 +1,218 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
+import com.goormgb.be.domain.stadium.entity.Stadium;
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+class SeatRecommendationServiceTest {
+
+	@Mock
+	private MatchRepository matchRepository;
+	@Mock
+	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	@Mock
+	private BlockRepository blockRepository;
+	@Mock
+	private OnboardingPreferenceRepository onboardingPreferenceRepository;
+	@Mock
+	private OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
+	@Mock
+	private ConsecutiveSeatCounter consecutiveSeatCounter;
+	@Mock
+	private PreferenceScoreCalculator preferenceScoreCalculator;
+
+	@InjectMocks
+	private SeatRecommendationService seatRecommendationService;
+
+	private Club createClub(Long id, String name) {
+		Club club = Club.builder()
+			.koName(name).enName(name).logoImg("logo.png").clubColor("#000").build();
+		ReflectionTestUtils.setField(club, "id", id);
+		return club;
+	}
+
+	private User createUser(Long id) {
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	private Block createBlock(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint) {
+		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
+		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
+		Block block = Block.builder()
+			.area(area).section(section).blockCode(blockCode)
+			.viewpoint(viewpoint).homeCheerRank(1).awayCheerRank(81).build();
+		ReflectionTestUtils.setField(block, "id", id);
+		return block;
+	}
+
+	private SeatSession createSeatSession(int ticketCount, List<Long> blockIds) {
+		SeatSession session = new SeatSession();
+		ReflectionTestUtils.setField(session, "userId", 1L);
+		ReflectionTestUtils.setField(session, "matchId", 1L);
+		ReflectionTestUtils.setField(session, "recommendationEnabled", true);
+		ReflectionTestUtils.setField(session, "ticketCount", ticketCount);
+		ReflectionTestUtils.setField(session, "preferredBlockIds", blockIds);
+		return session;
+	}
+
+	private Match createMatch(Club home, Club away) {
+		Stadium stadium = Stadium.builder()
+			.region("서울").koName("잠실").enName("Jamsil").address("서울시").build();
+		return Match.create(Instant.now(), home, away, stadium, SaleStatus.ON_SALE);
+	}
+
+	@Test
+	@DisplayName("추천 블럭 리스트를 연석 개수 기준으로 정렬하여 반환한다")
+	void 추천_블럭_리스트_연석개수_정렬() {
+		// given
+		Long userId = 1L;
+		Long matchId = 1L;
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(userId);
+
+		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block206 = createBlock(206L, "206", AreaCode.HOME, Viewpoint.INFIELD_1B);
+
+		SeatSession session = createSeatSession(5, List.of(205L, 206L));
+		Match match = createMatch(lgClub, doosanClub);
+		OnboardingPreference pref = OnboardingPreference.builder()
+			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.ANY).build();
+
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 206L)))
+			.willReturn(List.of(block205, block206));
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
+		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
+
+		// block206이 연석 더 많음 (차이 > 10)
+		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 5)).willReturn(5);
+		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 206L, 5)).willReturn(20);
+
+		// when
+		BlockRecommendationResponse response = seatRecommendationService.getRecommendedBlocks(matchId, userId);
+
+		// then
+		assertThat(response.blocks()).hasSize(2);
+		assertThat(response.blocks().get(0).blockCode()).isEqualTo("206");
+		assertThat(response.blocks().get(0).rank()).isEqualTo(1);
+		assertThat(response.blocks().get(1).blockCode()).isEqualTo("205");
+		assertThat(response.blocks().get(1).rank()).isEqualTo(2);
+		assertThat(response.ticketCount()).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("연석 개수 차이가 10 이내이면 선호도 점수로 정렬한다")
+	void 연석_비슷하면_취향점수_정렬() {
+		// given
+		Long userId = 1L;
+		Long matchId = 1L;
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(userId);
+
+		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block408 = createBlock(408L, "408", AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C);
+
+		SeatSession session = createSeatSession(3, List.of(205L, 408L));
+		Match match = createMatch(lgClub, doosanClub);
+		OnboardingPreference pref = OnboardingPreference.builder()
+			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.NEAR).build();
+		List<OnboardingViewpointPriority> viewpoints = List.of(
+			OnboardingViewpointPriority.builder().user(user).viewpoint(Viewpoint.INFIELD_1B).priority(1).build()
+		);
+
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 408L)))
+			.willReturn(List.of(block205, block408));
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
+		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(viewpoints);
+
+		// 연석 차이 10 이내
+		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 3)).willReturn(12);
+		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 408L, 3)).willReturn(15);
+
+		// block205의 선호도 점수가 더 높음
+		given(preferenceScoreCalculator.calculatePreferenceScore(eq(block205), any(), any(), any())).willReturn(70);
+		given(preferenceScoreCalculator.calculatePreferenceScore(eq(block408), any(), any(), any())).willReturn(15);
+
+		// when
+		BlockRecommendationResponse response = seatRecommendationService.getRecommendedBlocks(matchId, userId);
+
+		// then
+		assertThat(response.blocks()).hasSize(2);
+		assertThat(response.blocks().get(0).blockCode()).isEqualTo("205"); // 선호도 점수 높음
+		assertThat(response.blocks().get(1).blockCode()).isEqualTo("408");
+	}
+
+	@Test
+	@DisplayName("추천 가능한 블럭이 없으면 예외를 발생시킨다")
+	void 추천_블럭_없음_예외() {
+		// given
+		Long userId = 1L;
+		Long matchId = 1L;
+		Club lgClub = createClub(1L, "LG 트윈스");
+		Club doosanClub = createClub(2L, "두산 베어스");
+		User user = createUser(userId);
+
+		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+
+		SeatSession session = createSeatSession(5, List.of(205L));
+		Match match = createMatch(lgClub, doosanClub);
+		OnboardingPreference pref = OnboardingPreference.builder()
+			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.ANY).build();
+
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L))).willReturn(List.of(block205));
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
+		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
+
+		// 모든 블럭에 연석 없음
+		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 5)).willReturn(0);
+
+		// when & then
+		assertThatThrownBy(() -> seatRecommendationService.getRecommendedBlocks(matchId, userId))
+			.isInstanceOf(CustomException.class)
+			.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode()).isEqualTo(ErrorCode.NO_AVAILABLE_BLOCK));
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
 	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
 	ORDER_SEAT_EMPTY(HttpStatus.BAD_REQUEST, "주문 좌석 정보가 없습니다."),
 
+	// Block Recommendation
+	NO_AVAILABLE_BLOCK(HttpStatus.NOT_FOUND, "선택하신 선호 블럭 내에서는 현재 해당 연석이 가능한 좌석을 찾지 못했어요."),
+	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "블럭을 찾을 수 없습니다."),
+
 	// Seat Hold
 	SEAT_HOLD_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 선점 정보를 찾을 수 없습니다."),
 	SEAT_HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "좌석 선점이 만료되었습니다."),


### PR DESCRIPTION
## 🔧 작업 내용
- 유저의 선호 블럭(1~10개) 내에서 N연석 가능한 조합 수를 계산하고, 다중 조건 정렬을 적용하여 추천 블럭 랭킹 리스트를 반환하는 API 구현

## 🧩 구현 상세
- ConsecutiveSeatCounter: AVAILABLE 좌석을 row별로 그룹화 후 template_col_no 기준 슬라이딩 윈도우로 연속 구간을 추출하고, 각 구간에서 (구간 길이 - N + 1)개의 N연석 묶음 수를 합산
- PreferenceScoreCalculator: 연석 개수 차이가 ±10 이내일 때 블럭 정렬에 사용하는 선호도 점수 계산 (최대 70점)
    - 뷰포인트 선호 (1순위 30 / 2순위 20 / 3순위 10)
    - 응원 구단 일치 (25점)
    - 응원석 근접 선호 NEAR/FAR (15점)
- **다중 조건 정렬:** 연석 개수 차이 >10이면 개수 우선, ≤10이면 선호도 점수 우선, 동점 시 연석 개수 fallback

###  📌 관련 Jira Issue
- GRGB-252

##  🧪 테스트 방법
- ConsecutiveSeatCounterTest: 전체 row 연속, 갭 존재, 멀티 row, 빈 좌석, 단일 좌석 등 6개 케이스
<img width="998" height="501" alt="스크린샷 2026-03-15 오후 8 49 03" src="https://github.com/user-attachments/assets/1226fecc-1e42-444e-85c7-62f9e03ec434" />

- PreferenceScoreCalculatorTest: 뷰포인트 1순위, 구단 일치, NEAR/FAR 응원석 근접, 최대 점수, 비참가 구단 등 6개 케이스
<img width="1146" height="504" alt="스크린샷 2026-03-15 오후 8 50 46" src="https://github.com/user-attachments/assets/7f6a334a-6df0-4c0d-87ac-f04579046dfa" />

- SeatRecommendationServiceTest: 연석 개수 기준 정렬, 선호도 점수 기준 정렬, 추천 블럭 없음 예외 등 3개 케이스
<img width="1039" height="410" alt="스크린샷 2026-03-15 오후 8 51 35" src="https://github.com/user-attachments/assets/8ac25f46-84d2-44a4-93ee-70962f9d8acd" />

- Endpoint: GET /matches/{matchId}/recommendations/blocks
<img width="872" height="382" alt="스크린샷 2026-03-15 오후 8 52 47" src="https://github.com/user-attachments/assets/11f0dd46-252d-4527-afbd-79f89ac33643" />

##  ❗ 참고 사항
좌석 배정 및 Hold 부분 다음 PR 로 이어서 제가 작업할 예정입니다!! @ejinn1 작업하시는데 참고 부탁드립니다