### PR TITLE
feat(seat): 블럭추천 좌석 자동 배정 및 Hold 처리 구현 (service + api) [GRGB-253]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -1,11 +1,14 @@
 package com.goormgb.be.seat.block.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.block.entity.Block;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
@@ -17,4 +20,12 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
 	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id IN :blockIds")
 	List<Block> findAllByIdInWithSectionAndArea(@Param("blockIds") List<Long> blockIds);
+
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id = :blockId")
+	Optional<Block> findByIdWithSectionAndArea(@Param("blockId") Long blockId);
+
+	default Block findByIdWithSectionOrThrow(Long blockId) {
+		return findByIdWithSectionAndArea(blockId)
+			.orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
+	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
@@ -3,12 +3,17 @@ package com.goormgb.be.seat.recommendation.controller;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.seat.recommendation.dto.request.SeatAssignmentRequest;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
+import com.goormgb.be.seat.recommendation.service.SeatAssignmentService;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatRecommendationController {
 
 	private final SeatRecommendationService seatRecommendationService;
+	private final SeatAssignmentService seatAssignmentService;
 
 	@Operation(
 		summary = "추천 좌석 초기 조회",
@@ -55,5 +61,26 @@ public class SeatRecommendationController {
 		@AuthenticationPrincipal Long userId
 	) {
 		return ApiResult.ok(seatRecommendationService.getRecommendedBlocks(matchId, userId));
+	}
+
+	@Operation(
+		summary = "좌석 자동 배정 및 선점",
+		description = "선택한 블럭에서 최적의 연석 좌석을 자동 배정하고 5분간 선점(Hold)합니다.",
+		security = @SecurityRequirement(name = "BearerAuth"))
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "좌석 배정 및 선점 성공"),
+		@ApiResponse(responseCode = "404", description = "연석 가능한 좌석을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "다른 사용자가 좌석을 선택 중입니다.")
+	})
+	@PostMapping("/blocks/{blockId}/assign")
+	public ApiResult<SeatAssignmentResponse> assignSeats(
+		@PathVariable Long matchId,
+		@PathVariable Long blockId,
+		@RequestBody SeatAssignmentRequest request,
+		@AuthenticationPrincipal Long userId
+	) {
+		return ApiResult.ok(
+			seatAssignmentService.assignAndHoldSeats(userId, matchId, blockId, request.nearAdjacentToggle())
+		);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/SeatGroup.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/SeatGroup.java
@@ -1,0 +1,24 @@
+package com.goormgb.be.seat.recommendation.dto.internal;
+
+import java.util.List;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+
+/**
+ * 진짜 연석 후보를 나타내는 내부 DTO.
+ * 같은 열(row)에서 templateColNo가 연속인 좌석 묶음이다.
+ *
+ * @param seats         연속 좌석 리스트 (templateColNo 오름차순)
+ * @param rowNo         열 번호
+ * @param startCol      시작 templateColNo
+ * @param endCol        끝 templateColNo
+ * @param aisleDistance  통로까지의 최소 거리
+ */
+public record SeatGroup(
+	List<MatchSeat> seats,
+	int rowNo,
+	int startCol,
+	int endCol,
+	int aisleDistance
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/SemiGroup.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/SemiGroup.java
@@ -1,0 +1,36 @@
+package com.goormgb.be.seat.recommendation.dto.internal;
+
+import java.util.List;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+
+/**
+ * 준연석 후보를 나타내는 내부 DTO.
+ * 인접한 2개 열에서 수평 겹침이 있는 좌석 묶음이다.
+ *
+ * @param upperSeats      위쪽 열의 좌석 리스트
+ * @param lowerSeats      아래쪽 열의 좌석 리스트
+ * @param upperRowNo      위쪽 열 번호
+ * @param lowerRowNo      아래쪽 열 번호
+ * @param overlapCount    수평 겹침 열 수
+ * @param avgAisleDistance 평균 통로 거리
+ */
+public record SemiGroup(
+	List<MatchSeat> upperSeats,
+	List<MatchSeat> lowerSeats,
+	int upperRowNo,
+	int lowerRowNo,
+	int overlapCount,
+	int avgAisleDistance
+) {
+
+	public List<MatchSeat> allSeats() {
+		List<MatchSeat> all = new java.util.ArrayList<>(upperSeats);
+		all.addAll(lowerSeats);
+		return all;
+	}
+
+	public int rowSum() {
+		return upperRowNo + lowerRowNo;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/request/SeatAssignmentRequest.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/request/SeatAssignmentRequest.java
@@ -1,0 +1,6 @@
+package com.goormgb.be.seat.recommendation.dto.request;
+
+public record SeatAssignmentRequest(
+	boolean nearAdjacentToggle
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatAssignmentResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatAssignmentResponse.java
@@ -1,0 +1,55 @@
+package com.goormgb.be.seat.recommendation.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+
+public record SeatAssignmentResponse(
+	Long matchId,
+	String blockCode,
+	String sectionName,
+	List<AssignedSeat> assignedSeats,
+	Instant holdExpiresAt,
+	boolean semiConsecutive
+) {
+
+	public record AssignedSeat(
+		Long matchSeatId,
+		int rowNo,
+		int seatNo,
+		int templateColNo
+	) {
+
+		public static AssignedSeat from(MatchSeat matchSeat) {
+			return new AssignedSeat(
+				matchSeat.getId(),
+				matchSeat.getRowNo(),
+				matchSeat.getSeatNo(),
+				matchSeat.getTemplateColNo()
+			);
+		}
+	}
+
+	public static SeatAssignmentResponse of(
+		Long matchId,
+		Block block,
+		List<MatchSeat> assignedSeats,
+		Instant holdExpiresAt,
+		boolean semiConsecutive
+	) {
+		List<AssignedSeat> seats = assignedSeats.stream()
+			.map(AssignedSeat::from)
+			.toList();
+
+		return new SeatAssignmentResponse(
+			matchId,
+			block.getBlockCode(),
+			block.getSection().getName(),
+			seats,
+			holdExpiresAt,
+			semiConsecutive
+		);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/AisleDistanceCalculator.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/AisleDistanceCalculator.java
@@ -1,0 +1,57 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.config.RowPattern;
+import com.goormgb.be.seat.config.SeatLayoutPatterns;
+
+/**
+ * 좌석 그룹의 통로 거리를 계산하는 컴포넌트.
+ *
+ * <p>통로 거리란, 좌석 그룹의 양쪽 끝에서 가장 가까운 통로까지의 좌석 수를 말한다.
+ * 값이 작을수록 통로에 가까운 좌석이다.</p>
+ *
+ * <h3>계산 방식</h3>
+ * <ol>
+ *   <li>해당 row의 레이아웃 패턴에서 좌석 시작 위치와 좌석 수를 조회한다.</li>
+ *   <li>좌석 그룹의 왼쪽 끝에서 왼쪽 통로까지의 거리를 계산한다.</li>
+ *   <li>좌석 그룹의 오른쪽 끝에서 오른쪽 통로까지의 거리를 계산한다.</li>
+ *   <li>둘 중 작은 값을 반환한다.</li>
+ * </ol>
+ */
+@Component
+public class AisleDistanceCalculator {
+
+	private static final List<RowPattern> LAYOUT = SeatLayoutPatterns.STANDARD;
+
+	/**
+	 * 좌석 그룹의 통로까지 최소 거리를 계산한다.
+	 *
+	 * @param rowNo          열 번호 (1-based)
+	 * @param groupStartCol  그룹의 시작 templateColNo
+	 * @param groupEndCol    그룹의 끝 templateColNo
+	 * @return 통로까지의 최소 거리 (0 = 통로 바로 옆)
+	 */
+	public int calculateAisleDistance(int rowNo, int groupStartCol, int groupEndCol) {
+		RowPattern pattern = findRowPattern(rowNo);
+
+		int rowStartCol = pattern.startTemplateColNo();
+		int rowEndCol = rowStartCol + pattern.seatCount() - 1;
+
+		int leftDistance = groupStartCol - rowStartCol;
+		int rightDistance = rowEndCol - groupEndCol;
+
+		return Math.min(leftDistance, rightDistance);
+	}
+
+	private RowPattern findRowPattern(int rowNo) {
+		for (RowPattern pattern : LAYOUT) {
+			if (pattern.rowNo() == rowNo) {
+				return pattern;
+			}
+		}
+		throw new IllegalArgumentException("Unknown row number: " + rowNo);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinder.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinder.java
@@ -1,0 +1,104 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 블럭 내에서 최적의 "진짜 연석" 묶음을 탐색하는 컴포넌트.
+ *
+ * <p>진짜 연석이란, 같은 열(row) 안에서 templateColNo가 빈칸 없이
+ * 연속으로 N개 붙어있는 좌석 묶음을 말한다.</p>
+ *
+ * <h3>정렬 우선순위</h3>
+ * <ol>
+ *   <li>앞열 우선 (rowNo ASC)</li>
+ *   <li>통로 가까운 좌석 우선 (aisleDistance ASC)</li>
+ *   <li>왼쪽 우선 (startCol ASC)</li>
+ * </ol>
+ */
+@Component
+@RequiredArgsConstructor
+public class RealConsecutiveFinder {
+
+	private final MatchSeatRepository matchSeatRepository;
+	private final AisleDistanceCalculator aisleDistanceCalculator;
+
+	/**
+	 * 특정 블럭에서 최적의 진짜 N연석 묶음을 찾는다.
+	 *
+	 * @param matchId       경기 ID
+	 * @param blockId       블럭 ID
+	 * @param requiredSeats 필요 좌석 수
+	 * @return 최적의 좌석 그룹 (없으면 Optional.empty())
+	 */
+	public Optional<SeatGroup> findBestRealConsecutive(Long matchId, Long blockId, int requiredSeats) {
+		List<MatchSeat> availableSeats = matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(matchId, blockId);
+
+		if (availableSeats.size() < requiredSeats) {
+			return Optional.empty();
+		}
+
+		Map<Integer, List<MatchSeat>> seatsByRow = availableSeats.stream()
+			.collect(Collectors.groupingBy(MatchSeat::getRowNo));
+
+		return seatsByRow.entrySet().stream()
+			.<SeatGroup>mapMulti((entry, consumer) -> {
+				int rowNo = entry.getKey();
+				List<MatchSeat> rowSeats = entry.getValue();
+
+				if (rowSeats.size() < requiredSeats) {
+					return;
+				}
+
+				for (List<MatchSeat> segment : extractConsecutiveSegments(rowSeats)) {
+					if (segment.size() < requiredSeats) {
+						continue;
+					}
+
+					for (int i = 0; i <= segment.size() - requiredSeats; i++) {
+						List<MatchSeat> group = segment.subList(i, i + requiredSeats);
+						int startCol = group.get(0).getTemplateColNo();
+						int endCol = group.get(group.size() - 1).getTemplateColNo();
+						int aisleDistance = aisleDistanceCalculator.calculateAisleDistance(rowNo, startCol, endCol);
+
+						consumer.accept(new SeatGroup(new ArrayList<>(group), rowNo, startCol, endCol, aisleDistance));
+					}
+				}
+			})
+			.min(Comparator
+				.comparingInt(SeatGroup::rowNo)
+				.thenComparingInt(SeatGroup::aisleDistance)
+				.thenComparingInt(SeatGroup::startCol));
+	}
+
+	private List<List<MatchSeat>> extractConsecutiveSegments(List<MatchSeat> sortedSeats) {
+		List<List<MatchSeat>> segments = new ArrayList<>();
+		List<MatchSeat> current = new ArrayList<>();
+		current.add(sortedSeats.get(0));
+
+		for (int i = 1; i < sortedSeats.size(); i++) {
+			if (sortedSeats.get(i).getTemplateColNo() == sortedSeats.get(i - 1).getTemplateColNo() + 1) {
+				current.add(sortedSeats.get(i));
+			} else {
+				segments.add(current);
+				current = new ArrayList<>();
+				current.add(sortedSeats.get(i));
+			}
+		}
+		segments.add(current);
+
+		return segments;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinder.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinder.java
@@ -34,6 +34,7 @@ public class RealConsecutiveFinder {
 
 	private final MatchSeatRepository matchSeatRepository;
 	private final AisleDistanceCalculator aisleDistanceCalculator;
+	private final SeatSegmentExtractor seatSegmentExtractor;
 
 	/**
 	 * 특정 블럭에서 최적의 진짜 N연석 묶음을 찾는다.
@@ -62,7 +63,7 @@ public class RealConsecutiveFinder {
 					return;
 				}
 
-				for (List<MatchSeat> segment : extractConsecutiveSegments(rowSeats)) {
+				for (List<MatchSeat> segment : seatSegmentExtractor.extractConsecutiveSegments(rowSeats)) {
 					if (segment.size() < requiredSeats) {
 						continue;
 					}
@@ -83,22 +84,4 @@ public class RealConsecutiveFinder {
 				.thenComparingInt(SeatGroup::startCol));
 	}
 
-	private List<List<MatchSeat>> extractConsecutiveSegments(List<MatchSeat> sortedSeats) {
-		List<List<MatchSeat>> segments = new ArrayList<>();
-		List<MatchSeat> current = new ArrayList<>();
-		current.add(sortedSeats.get(0));
-
-		for (int i = 1; i < sortedSeats.size(); i++) {
-			if (sortedSeats.get(i).getTemplateColNo() == sortedSeats.get(i - 1).getTemplateColNo() + 1) {
-				current.add(sortedSeats.get(i));
-			} else {
-				segments.add(current);
-				current = new ArrayList<>();
-				current.add(sortedSeats.get(i));
-			}
-		}
-		segments.add(current);
-
-		return segments;
-	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -1,0 +1,138 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 좌석 자동 배정 및 Hold 처리 서비스.
+ *
+ * <p>Redis 분산 락으로 동시성을 제어하며, 진짜 연석 → 준연석 fallback 순서로 좌석을 탐색한다.</p>
+ *
+ * <h3>처리 흐름</h3>
+ * <ol>
+ *   <li>SeatSession에서 ticketCount 조회</li>
+ *   <li>Redis 분산 락 획득 (block_lock:{blockId})</li>
+ *   <li>진짜 연석 탐색</li>
+ *   <li>(fallback) nearAdjacentToggle이 true이면 준연석 탐색</li>
+ *   <li>좌석 상태를 BLOCKED로 변경</li>
+ *   <li>SeatHold 생성 (5분 TTL)</li>
+ *   <li>락 해제</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+public class SeatAssignmentService {
+
+	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+
+	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	private final BlockRepository blockRepository;
+	private final SeatHoldRepository seatHoldRepository;
+	private final RealConsecutiveFinder realConsecutiveFinder;
+	private final SemiConsecutiveFinder semiConsecutiveFinder;
+	private final SeatBlockLock seatBlockLock;
+	private final Clock clock;
+
+	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockId,
+		boolean nearAdjacentToggle) {
+
+		SeatSession seatSession = seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+		int requiredSeats = seatSession.getTicketCount();
+
+		Block block = blockRepository.findByIdWithSectionOrThrow(blockId);
+
+		if (!seatBlockLock.tryLock(blockId)) {
+			throw new CustomException(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
+		}
+
+		try {
+			return doAssignAndHold(userId, matchId, blockId, block, requiredSeats, nearAdjacentToggle);
+		} finally {
+			seatBlockLock.unlock(blockId);
+		}
+	}
+
+	@Transactional
+	protected SeatAssignmentResponse doAssignAndHold(
+		Long userId, Long matchId, Long blockId, Block block,
+		int requiredSeats, boolean nearAdjacentToggle
+	) {
+		// 기존 Hold 정리 (재요청 시)
+		cleanupExistingHolds(userId, matchId);
+
+		// 1. 진짜 연석 탐색
+		var realResult = realConsecutiveFinder.findBestRealConsecutive(matchId, blockId, requiredSeats);
+
+		if (realResult.isPresent()) {
+			SeatGroup seatGroup = realResult.get();
+			return holdSeats(userId, matchId, block, seatGroup.seats(), false);
+		}
+
+		// 2. 준연석 fallback (toggle이 켜져 있는 경우에만)
+		if (nearAdjacentToggle) {
+			var semiResult = semiConsecutiveFinder.findBestSemiConsecutive(matchId, blockId, requiredSeats);
+
+			if (semiResult.isPresent()) {
+				SemiGroup semiGroup = semiResult.get();
+				return holdSeats(userId, matchId, block, semiGroup.allSeats(), true);
+			}
+		}
+
+		throw new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+
+	private SeatAssignmentResponse holdSeats(
+		Long userId, Long matchId, Block block,
+		List<MatchSeat> seats, boolean semiConsecutive
+	) {
+		Instant expiresAt = clock.instant().plus(HOLD_TTL);
+
+		seats.forEach(MatchSeat::markBlocked);
+
+		List<SeatHold> holds = seats.stream()
+			.map(seat -> SeatHold.builder()
+				.matchSeatId(seat.getId())
+				.matchId(matchId)
+				.seatId(seat.getSeatId())
+				.userId(userId)
+				.expiresAt(expiresAt)
+				.build())
+			.toList();
+
+		seatHoldRepository.saveAll(holds);
+
+		return SeatAssignmentResponse.of(matchId, block, seats, expiresAt, semiConsecutive);
+	}
+
+	private void cleanupExistingHolds(Long userId, Long matchId) {
+		List<SeatHold> existingHolds = seatHoldRepository.findAllByUserIdAndMatchId(userId, matchId);
+
+		if (existingHolds.isEmpty()) {
+			return;
+		}
+
+		seatHoldRepository.deleteAllByMatchSeatIdIn(
+			existingHolds.stream().map(SeatHold::getMatchSeatId).toList()
+		);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -13,6 +13,7 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
 import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
@@ -47,6 +48,7 @@ public class SeatAssignmentService {
 
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	private final BlockRepository blockRepository;
+	private final MatchSeatRepository matchSeatRepository;
 	private final SeatHoldRepository seatHoldRepository;
 	private final RealConsecutiveFinder realConsecutiveFinder;
 	private final SemiConsecutiveFinder semiConsecutiveFinder;
@@ -131,8 +133,11 @@ public class SeatAssignmentService {
 			return;
 		}
 
-		seatHoldRepository.deleteAllByMatchSeatIdIn(
-			existingHolds.stream().map(SeatHold::getMatchSeatId).toList()
-		);
+		List<Long> matchSeatIds = existingHolds.stream().map(SeatHold::getMatchSeatId).toList();
+
+		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
+		seatsToRelease.forEach(MatchSeat::markAvailable);
+
+		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
@@ -1,0 +1,36 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis SETNX 기반 블럭 단위 분산 락.
+ *
+ * <p>좌석 배정 시 동일 블럭에 대한 동시 접근을 방지한다.
+ * 락 획득에 실패하면 다른 사용자가 해당 블럭에서 좌석을 선택 중임을 의미한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class SeatBlockLock {
+
+	private static final String LOCK_KEY_PREFIX = "block_lock:";
+	private static final Duration LOCK_TIMEOUT = Duration.ofSeconds(5);
+
+	private final StringRedisTemplate redisTemplate;
+
+	public boolean tryLock(Long blockId) {
+		String key = LOCK_KEY_PREFIX + blockId;
+		return Boolean.TRUE.equals(
+			redisTemplate.opsForValue().setIfAbsent(key, "LOCKED", LOCK_TIMEOUT)
+		);
+	}
+
+	public void unlock(Long blockId) {
+		String key = LOCK_KEY_PREFIX + blockId;
+		redisTemplate.delete(key);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatSegmentExtractor.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatSegmentExtractor.java
@@ -1,0 +1,36 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+
+/**
+ * templateColNo 기준 연속 좌석 구간을 추출하는 공통 컴포넌트.
+ *
+ * <p>RealConsecutiveFinder, SemiConsecutiveFinder에서 공통으로 사용한다.</p>
+ */
+@Component
+public class SeatSegmentExtractor {
+
+	public List<List<MatchSeat>> extractConsecutiveSegments(List<MatchSeat> sortedSeats) {
+		List<List<MatchSeat>> segments = new ArrayList<>();
+		List<MatchSeat> current = new ArrayList<>();
+		current.add(sortedSeats.get(0));
+
+		for (int i = 1; i < sortedSeats.size(); i++) {
+			if (sortedSeats.get(i).getTemplateColNo() == sortedSeats.get(i - 1).getTemplateColNo() + 1) {
+				current.add(sortedSeats.get(i));
+			} else {
+				segments.add(current);
+				current = new ArrayList<>();
+				current.add(sortedSeats.get(i));
+			}
+		}
+		segments.add(current);
+
+		return segments;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinder.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinder.java
@@ -1,0 +1,155 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 블럭 내에서 최적의 "준연석" 묶음을 탐색하는 컴포넌트.
+ *
+ * <p>준연석이란, 인접한 2개 열(row)에 걸쳐 좌석을 배치하되
+ * 수평 겹침(overlap)이 존재하는 좌석 묶음을 말한다.</p>
+ *
+ * <h3>정렬 우선순위</h3>
+ * <ol>
+ *   <li>앞열 합 우선 (rowSum ASC)</li>
+ *   <li>겹침 많음 우선 (overlapCount DESC)</li>
+ *   <li>평균 통로 거리 가까움 우선 (avgAisleDistance ASC)</li>
+ * </ol>
+ */
+@Component
+@RequiredArgsConstructor
+public class SemiConsecutiveFinder {
+
+	private final MatchSeatRepository matchSeatRepository;
+	private final AisleDistanceCalculator aisleDistanceCalculator;
+
+	/**
+	 * 특정 블럭에서 최적의 준연석 묶음을 찾는다.
+	 *
+	 * @param matchId       경기 ID
+	 * @param blockId       블럭 ID
+	 * @param requiredSeats 필요 좌석 수
+	 * @return 최적의 준연석 그룹 (없으면 Optional.empty())
+	 */
+	public Optional<SemiGroup> findBestSemiConsecutive(Long matchId, Long blockId, int requiredSeats) {
+		List<MatchSeat> availableSeats = matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(matchId, blockId);
+
+		if (availableSeats.size() < requiredSeats) {
+			return Optional.empty();
+		}
+
+		Map<Integer, List<MatchSeat>> seatsByRow = availableSeats.stream()
+			.collect(Collectors.groupingBy(
+				MatchSeat::getRowNo,
+				TreeMap::new,
+				Collectors.toList()
+			));
+
+		List<Integer> sortedRows = new ArrayList<>(seatsByRow.keySet());
+
+		return IntStream.range(0, sortedRows.size() - 1)
+			.boxed()
+			.<SemiGroup>mapMulti((i, consumer) -> {
+				int upperRow = sortedRows.get(i);
+				int lowerRow = sortedRows.get(i + 1);
+
+				if (lowerRow - upperRow != 1) {
+					return;
+				}
+
+				var upperSegments = extractConsecutiveSegments(seatsByRow.get(upperRow));
+				var lowerSegments = extractConsecutiveSegments(seatsByRow.get(lowerRow));
+
+				for (var upperSeg : upperSegments) {
+					for (var lowerSeg : lowerSegments) {
+						emitCandidates(consumer, upperSeg, lowerSeg, upperRow, lowerRow, requiredSeats);
+					}
+				}
+			})
+			.min(Comparator
+				.comparingInt(SemiGroup::rowSum)
+				.thenComparing(Comparator.comparingInt(SemiGroup::overlapCount).reversed())
+				.thenComparingInt(SemiGroup::avgAisleDistance));
+	}
+
+	private void emitCandidates(
+		Consumer<SemiGroup> consumer,
+		List<MatchSeat> upperSeg,
+		List<MatchSeat> lowerSeg,
+		int upperRow,
+		int lowerRow,
+		int requiredSeats
+	) {
+		for (int upperCount = 1; upperCount < requiredSeats; upperCount++) {
+			int lowerCount = requiredSeats - upperCount;
+
+			if (upperCount > upperSeg.size() || lowerCount > lowerSeg.size()) {
+				continue;
+			}
+
+			for (int ui = 0; ui <= upperSeg.size() - upperCount; ui++) {
+				List<MatchSeat> upperGroup = upperSeg.subList(ui, ui + upperCount);
+				int upperStart = upperGroup.get(0).getTemplateColNo();
+				int upperEnd = upperGroup.get(upperGroup.size() - 1).getTemplateColNo();
+
+				for (int li = 0; li <= lowerSeg.size() - lowerCount; li++) {
+					List<MatchSeat> lowerGroup = lowerSeg.subList(li, li + lowerCount);
+					int lowerStart = lowerGroup.get(0).getTemplateColNo();
+					int lowerEnd = lowerGroup.get(lowerGroup.size() - 1).getTemplateColNo();
+
+					int overlap = Math.min(upperEnd, lowerEnd) - Math.max(upperStart, lowerStart) + 1;
+
+					if (overlap <= 0) {
+						continue;
+					}
+
+					int upperAisle = aisleDistanceCalculator.calculateAisleDistance(upperRow, upperStart, upperEnd);
+					int lowerAisle = aisleDistanceCalculator.calculateAisleDistance(lowerRow, lowerStart, lowerEnd);
+
+					consumer.accept(new SemiGroup(
+						new ArrayList<>(upperGroup),
+						new ArrayList<>(lowerGroup),
+						upperRow,
+						lowerRow,
+						overlap,
+						(upperAisle + lowerAisle) / 2
+					));
+				}
+			}
+		}
+	}
+
+	private List<List<MatchSeat>> extractConsecutiveSegments(List<MatchSeat> sortedSeats) {
+		List<List<MatchSeat>> segments = new ArrayList<>();
+		List<MatchSeat> current = new ArrayList<>();
+		current.add(sortedSeats.get(0));
+
+		for (int i = 1; i < sortedSeats.size(); i++) {
+			if (sortedSeats.get(i).getTemplateColNo() == sortedSeats.get(i - 1).getTemplateColNo() + 1) {
+				current.add(sortedSeats.get(i));
+			} else {
+				segments.add(current);
+				current = new ArrayList<>();
+				current.add(sortedSeats.get(i));
+			}
+		}
+		segments.add(current);
+
+		return segments;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinder.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinder.java
@@ -37,6 +37,7 @@ public class SemiConsecutiveFinder {
 
 	private final MatchSeatRepository matchSeatRepository;
 	private final AisleDistanceCalculator aisleDistanceCalculator;
+	private final SeatSegmentExtractor seatSegmentExtractor;
 
 	/**
 	 * 특정 블럭에서 최적의 준연석 묶음을 찾는다.
@@ -72,8 +73,8 @@ public class SemiConsecutiveFinder {
 					return;
 				}
 
-				var upperSegments = extractConsecutiveSegments(seatsByRow.get(upperRow));
-				var lowerSegments = extractConsecutiveSegments(seatsByRow.get(lowerRow));
+				var upperSegments = seatSegmentExtractor.extractConsecutiveSegments(seatsByRow.get(upperRow));
+				var lowerSegments = seatSegmentExtractor.extractConsecutiveSegments(seatsByRow.get(lowerRow));
 
 				for (var upperSeg : upperSegments) {
 					for (var lowerSeg : lowerSegments) {
@@ -134,22 +135,4 @@ public class SemiConsecutiveFinder {
 		}
 	}
 
-	private List<List<MatchSeat>> extractConsecutiveSegments(List<MatchSeat> sortedSeats) {
-		List<List<MatchSeat>> segments = new ArrayList<>();
-		List<MatchSeat> current = new ArrayList<>();
-		current.add(sortedSeats.get(0));
-
-		for (int i = 1; i < sortedSeats.size(); i++) {
-			if (sortedSeats.get(i).getTemplateColNo() == sortedSeats.get(i - 1).getTemplateColNo() + 1) {
-				current.add(sortedSeats.get(i));
-			} else {
-				segments.add(current);
-				current = new ArrayList<>();
-				current.add(sortedSeats.get(i));
-			}
-		}
-		segments.add(current);
-
-		return segments;
-	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -1,8 +1,14 @@
 package com.goormgb.be.seat.seatHold.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goormgb.be.seat.seatHold.entity.SeatHold;
 
 public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
+
+	List<SeatHold> findAllByUserIdAndMatchId(Long userId, Long matchId);
+
+	void deleteAllByMatchSeatIdIn(List<Long> matchSeatIds);
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/config/SeatDataInitializerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/config/SeatDataInitializerTest.java
@@ -20,6 +20,7 @@ import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.area.repository.AreaRepository;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.seat.repository.SeatRepository;
 import com.goormgb.be.seat.section.entity.Section;
 import com.goormgb.be.seat.section.enums.SectionCode;
 import com.goormgb.be.seat.section.repository.SectionRepository;
@@ -35,6 +36,9 @@ class SeatDataInitializerTest {
 
 	@Mock
 	private BlockRepository blockRepository;
+
+	@Mock
+	private SeatRepository seatRepository;
 
 	@InjectMocks
 	private SeatDataInitializer seatDataInitializer;

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
@@ -13,19 +13,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.recommendation.service.SeatAssignmentService;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
 
 @WebMvcTest(SeatRecommendationController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class SeatRecommendationControllerTest {
+class SeatAssignmentControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -43,46 +44,44 @@ class SeatRecommendationControllerTest {
 	}
 
 	@Test
-	@DisplayName("추천 좌석 초기 조회에 성공한다")
-	void 추천_좌석_초기_조회_성공() throws Exception {
+	@DisplayName("좌석 배정 및 선점 요청에 성공한다")
+	void 좌석_배정_성공() throws Exception {
 		// given
-		Long matchId = 10L;
+		Long matchId = 1L;
+		Long blockId = 10L;
 		Long userId = 1L;
 		setAuthentication(userId);
 
-		SeatEntryResponse response = new SeatEntryResponse(
-			new SeatEntryResponse.MatchInfo(
-				10L,
-				new SeatEntryResponse.ClubInfo(1L, "LG 트윈스", "lg-twins.png"),
-				new SeatEntryResponse.ClubInfo(3L, "두산 베어스", "doosan-bears.png"),
-				Instant.parse("2026-04-15T18:30:00Z"),
-				new SeatEntryResponse.StadiumInfo(3L, "잠실 야구장")
+		Instant expiresAt = Instant.parse("2026-04-15T10:05:00Z");
+		SeatAssignmentResponse response = new SeatAssignmentResponse(
+			matchId,
+			"CP",
+			"테라존(중앙 프리미엄석)",
+			List.of(
+				new SeatAssignmentResponse.AssignedSeat(101L, 1, 1, 1),
+				new SeatAssignmentResponse.AssignedSeat(102L, 1, 2, 2),
+				new SeatAssignmentResponse.AssignedSeat(103L, 1, 3, 3)
 			),
-			new SeatEntryResponse.SeatSessionInfo(
-				true,
-				2,
-				List.of(206L, 208L, 105L)
-			)
+			expiresAt,
+			false
 		);
 
-		given(seatRecommendationService.getRecommendationSeatEntry(eq(matchId), eq(userId)))
+		given(seatAssignmentService.assignAndHoldSeats(eq(userId), eq(matchId), eq(blockId), eq(false)))
 			.willReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/matches/{matchId}/recommendations/seat-entry", matchId))
+		mockMvc.perform(post("/matches/{matchId}/recommendations/blocks/{blockId}/assign", matchId, blockId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"nearAdjacentToggle\": false}"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
-			.andExpect(jsonPath("$.data.match.matchId").value(10))
-			.andExpect(jsonPath("$.data.match.homeClub.clubId").value(1))
-			.andExpect(jsonPath("$.data.match.homeClub.koName").value("LG 트윈스"))
-			.andExpect(jsonPath("$.data.match.awayClub.clubId").value(3))
-			.andExpect(jsonPath("$.data.match.awayClub.koName").value("두산 베어스"))
-			.andExpect(jsonPath("$.data.match.stadium.stadiumId").value(3))
-			.andExpect(jsonPath("$.data.match.stadium.koName").value("잠실 야구장"))
-			.andExpect(jsonPath("$.data.seatSession.recommendationEnabled").value(true))
-			.andExpect(jsonPath("$.data.seatSession.ticketCount").value(2))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[0]").value(206))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[1]").value(208))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[2]").value(105));
+			.andExpect(jsonPath("$.data.matchId").value(1))
+			.andExpect(jsonPath("$.data.blockCode").value("CP"))
+			.andExpect(jsonPath("$.data.sectionName").value("테라존(중앙 프리미엄석)"))
+			.andExpect(jsonPath("$.data.assignedSeats").isArray())
+			.andExpect(jsonPath("$.data.assignedSeats.length()").value(3))
+			.andExpect(jsonPath("$.data.assignedSeats[0].rowNo").value(1))
+			.andExpect(jsonPath("$.data.assignedSeats[0].seatNo").value(1))
+			.andExpect(jsonPath("$.data.semiConsecutive").value(false));
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/AisleDistanceCalculatorTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/AisleDistanceCalculatorTest.java
@@ -1,0 +1,65 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AisleDistanceCalculatorTest {
+
+	private final AisleDistanceCalculator calculator = new AisleDistanceCalculator();
+
+	@Test
+	@DisplayName("14칸 row에서 왼쪽 끝 좌석은 통로 거리가 0이다")
+	void 왼쪽_끝_통로거리_0() {
+		// row 1: 14칸, startCol=1
+		// 좌석 그룹: [1, 2] → leftDist=0, rightDist=12
+		int distance = calculator.calculateAisleDistance(1, 1, 2);
+		assertThat(distance).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("14칸 row에서 오른쪽 끝 좌석은 통로 거리가 0이다")
+	void 오른쪽_끝_통로거리_0() {
+		// row 1: 14칸, startCol=1, endCol=14
+		// 좌석 그룹: [13, 14] → leftDist=12, rightDist=0
+		int distance = calculator.calculateAisleDistance(1, 13, 14);
+		assertThat(distance).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("14칸 row에서 중앙 좌석은 통로 거리가 5이다")
+	void 중앙_통로거리() {
+		// row 1: 14칸, startCol=1
+		// 좌석 그룹: [6, 7, 8, 9] → leftDist=5, rightDist=5
+		int distance = calculator.calculateAisleDistance(1, 6, 9);
+		assertThat(distance).isEqualTo(5);
+	}
+
+	@Test
+	@DisplayName("7칸 row(4~7행)에서 왼쪽 끝 좌석은 통로 거리가 0이다")
+	void 짧은_row_왼쪽_끝() {
+		// row 4: 7칸, startCol=5
+		// 좌석 그룹: [5, 6] → leftDist=0, rightDist=5
+		int distance = calculator.calculateAisleDistance(4, 5, 6);
+		assertThat(distance).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("7칸 row(4~7행)에서 오른쪽 끝 좌석은 통로 거리가 0이다")
+	void 짧은_row_오른쪽_끝() {
+		// row 5: 7칸, startCol=5, endCol=11
+		// 좌석 그룹: [10, 11] → leftDist=5, rightDist=0
+		int distance = calculator.calculateAisleDistance(5, 10, 11);
+		assertThat(distance).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("단일 좌석의 통로 거리를 정확히 계산한다")
+	void 단일_좌석_통로거리() {
+		// row 8: 14칸, startCol=1
+		// 좌석 [3] → leftDist=2, rightDist=11
+		int distance = calculator.calculateAisleDistance(8, 3, 3);
+		assertThat(distance).isEqualTo(2);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinderTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinderTest.java
@@ -30,6 +30,9 @@ class RealConsecutiveFinderTest {
 	@Spy
 	private AisleDistanceCalculator aisleDistanceCalculator = new AisleDistanceCalculator();
 
+	@Spy
+	private SeatSegmentExtractor seatSegmentExtractor = new SeatSegmentExtractor();
+
 	@InjectMocks
 	private RealConsecutiveFinder realConsecutiveFinder;
 

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinderTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/RealConsecutiveFinderTest.java
@@ -1,0 +1,158 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+@ExtendWith(MockitoExtension.class)
+class RealConsecutiveFinderTest {
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+
+	@Spy
+	private AisleDistanceCalculator aisleDistanceCalculator = new AisleDistanceCalculator();
+
+	@InjectMocks
+	private RealConsecutiveFinder realConsecutiveFinder;
+
+	private MatchSeat createSeat(int rowNo, int templateColNo) {
+		return MatchSeat.builder()
+			.matchId(1L)
+			.seatId((long)(rowNo * 100 + templateColNo))
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(rowNo)
+			.seatNo(templateColNo)
+			.templateColNo(templateColNo)
+			.seatZone(SeatZone.LOW)
+			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+			.build();
+	}
+
+	@Test
+	@DisplayName("앞열 좌석이 우선 선택된다")
+	void 앞열_우선_선택() {
+		// given: row1과 row2 모두 연석 가능
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 14; col++) {
+			seats.add(createSeat(1, col));
+			seats.add(createSeat(2, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().rowNo()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("같은 열에서 통로에 가까운 좌석이 우선 선택된다")
+	void 통로_가까운_좌석_우선() {
+		// given: row1에 모든 좌석 AVAILABLE
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 14; col++) {
+			seats.add(createSeat(1, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3);
+
+		// then: 왼쪽 통로에 가까운 [1,2,3]이 선택됨
+		assertThat(result).isPresent();
+		assertThat(result.get().startCol()).isEqualTo(1);
+		assertThat(result.get().aisleDistance()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("연석 불가능하면 빈 결과를 반환한다")
+	void 연석_불가_빈_결과() {
+		// given: 모든 좌석이 떨어져 있음
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 1),
+			createSeat(1, 3),
+			createSeat(1, 5)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 2);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("좌석이 비어있으면 빈 결과를 반환한다")
+	void 좌석_없음_빈_결과() {
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(List.of());
+
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("중간에 빠진 좌석이 있으면 연속 구간 내에서 탐색한다")
+	void 중간_빠진_좌석_연속구간() {
+		// given: [1,2,3, _, 5,6,7,8,9]
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 3; col++) {
+			seats.add(createSeat(1, col));
+		}
+		for (int col = 5; col <= 9; col++) {
+			seats.add(createSeat(1, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when: 4연석 요청
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 4);
+
+		// then: [5,6,7,8] 선택 (3칸 구간은 4연석 불가)
+		assertThat(result).isPresent();
+		assertThat(result.get().startCol()).isEqualTo(5);
+		assertThat(result.get().seats()).hasSize(4);
+	}
+
+	@Test
+	@DisplayName("정확히 필요한 수만큼 연속 좌석이 있으면 해당 묶음을 반환한다")
+	void 정확히_필요한_수_연석() {
+		// given: [5,6,7]
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 5),
+			createSeat(1, 6),
+			createSeat(1, 7)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SeatGroup> result = realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().startCol()).isEqualTo(5);
+		assertThat(result.get().endCol()).isEqualTo(7);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -1,0 +1,172 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatAssignmentServiceTest {
+
+	@Mock
+	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	@Mock
+	private BlockRepository blockRepository;
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+	@Mock
+	private RealConsecutiveFinder realConsecutiveFinder;
+	@Mock
+	private SemiConsecutiveFinder semiConsecutiveFinder;
+	@Mock
+	private SeatBlockLock seatBlockLock;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private SeatAssignmentService seatAssignmentService;
+
+	private static final Instant FIXED_NOW = Instant.parse("2026-04-15T10:00:00Z");
+
+	private MatchSeat createSeat(int rowNo, int colNo) {
+		return MatchSeat.builder()
+			.matchId(1L)
+			.seatId((long)(rowNo * 100 + colNo))
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(rowNo)
+			.seatNo(colNo)
+			.templateColNo(colNo)
+			.seatZone(SeatZone.LOW)
+			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+			.build();
+	}
+
+	private void setupCommon() {
+		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
+
+		Block block = BlockFixture.cpBlock();
+		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(block);
+		given(seatBlockLock.tryLock(1L)).willReturn(true);
+		given(seatHoldRepository.findAllByUserIdAndMatchId(1L, 1L)).willReturn(List.of());
+	}
+
+	private void setupClockForHold() {
+		given(clock.instant()).willReturn(FIXED_NOW);
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 있으면 해당 좌석을 배정한다")
+	void 진짜_연석_배정_성공() {
+		// given
+		setupCommon();
+		setupClockForHold();
+		List<MatchSeat> seats = List.of(createSeat(1, 1), createSeat(1, 2), createSeat(1, 3));
+		SeatGroup seatGroup = new SeatGroup(seats, 1, 1, 3, 0);
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.of(seatGroup));
+
+		// when
+		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(3);
+		assertThat(response.semiConsecutive()).isFalse();
+		assertThat(response.holdExpiresAt()).isAfter(FIXED_NOW);
+		verify(seatHoldRepository).saveAll(anyList());
+		verify(seatBlockLock).unlock(1L);
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 없고 toggle ON이면 준연석으로 fallback한다")
+	void 준연석_fallback_성공() {
+		// given
+		setupCommon();
+		setupClockForHold();
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		List<MatchSeat> upperSeats = List.of(createSeat(1, 1), createSeat(1, 2));
+		List<MatchSeat> lowerSeats = List.of(createSeat(2, 1));
+		SemiGroup semiGroup = new SemiGroup(upperSeats, lowerSeats, 1, 2, 1, 0);
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.of(semiGroup));
+
+		// when
+		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, true);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(3);
+		assertThat(response.semiConsecutive()).isTrue();
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 없고 toggle OFF이면 예외가 발생한다")
+	void toggle_OFF_연석없음_예외() {
+		// given
+		setupCommon();
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+		verify(seatBlockLock).unlock(1L);
+	}
+
+	@Test
+	@DisplayName("락 획득 실패 시 예외가 발생한다")
+	void 락_획득_실패_예외() {
+		// given
+		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
+		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
+		given(seatBlockLock.tryLock(1L)).willReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
+	}
+
+	@Test
+	@DisplayName("진짜 연석도 준연석도 없으면 예외가 발생한다")
+	void 연석_준연석_모두_없음_예외() {
+		// given
+		setupCommon();
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, true))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -22,6 +22,7 @@ import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.fixture.BlockFixture;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
 import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
@@ -37,6 +38,8 @@ class SeatAssignmentServiceTest {
 	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	@Mock
 	private BlockRepository blockRepository;
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
 	@Mock
 	private SeatHoldRepository seatHoldRepository;
 	@Mock

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinderTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinderTest.java
@@ -30,6 +30,9 @@ class SemiConsecutiveFinderTest {
 	@Spy
 	private AisleDistanceCalculator aisleDistanceCalculator = new AisleDistanceCalculator();
 
+	@Spy
+	private SeatSegmentExtractor seatSegmentExtractor = new SeatSegmentExtractor();
+
 	@InjectMocks
 	private SemiConsecutiveFinder semiConsecutiveFinder;
 

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinderTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SemiConsecutiveFinderTest.java
@@ -1,0 +1,169 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+
+@ExtendWith(MockitoExtension.class)
+class SemiConsecutiveFinderTest {
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+
+	@Spy
+	private AisleDistanceCalculator aisleDistanceCalculator = new AisleDistanceCalculator();
+
+	@InjectMocks
+	private SemiConsecutiveFinder semiConsecutiveFinder;
+
+	private MatchSeat createSeat(int rowNo, int templateColNo) {
+		return MatchSeat.builder()
+			.matchId(1L)
+			.seatId((long)(rowNo * 100 + templateColNo))
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(rowNo)
+			.seatNo(templateColNo)
+			.templateColNo(templateColNo)
+			.seatZone(SeatZone.LOW)
+			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+			.build();
+	}
+
+	@Test
+	@DisplayName("인접 2개 열에서 수평 겹침이 있는 준연석을 찾는다")
+	void 준연석_정상_탐색() {
+		// given: row1에 [1,2,3], row2에 [2,3,4]
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 3; col++) {
+			seats.add(createSeat(1, col));
+		}
+		for (int col = 2; col <= 4; col++) {
+			seats.add(createSeat(2, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when: 4석 요청
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		// then
+		assertThat(result).isPresent();
+		SemiGroup group = result.get();
+		assertThat(group.upperRowNo()).isEqualTo(1);
+		assertThat(group.lowerRowNo()).isEqualTo(2);
+		int totalSeats = group.upperSeats().size() + group.lowerSeats().size();
+		assertThat(totalSeats).isEqualTo(4);
+		assertThat(group.overlapCount()).isGreaterThan(0);
+	}
+
+	@Test
+	@DisplayName("수평 겹침이 없는 조합은 제외된다")
+	void 겹침없는_조합_제외() {
+		// given: row1에 [1,2], row2에 [10,11]
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 1),
+			createSeat(1, 2),
+			createSeat(2, 10),
+			createSeat(2, 11)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when: 4석 요청
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("비인접 열은 준연석 후보에서 제외된다")
+	void 비인접_열_제외() {
+		// given: row1에 [1,2,3], row3에 [1,2,3] (row2 없음)
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 3; col++) {
+			seats.add(createSeat(1, col));
+		}
+		for (int col = 1; col <= 3; col++) {
+			seats.add(createSeat(3, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("좌석이 부족하면 빈 결과를 반환한다")
+	void 좌석_부족_빈_결과() {
+		List<MatchSeat> seats = List.of(
+			createSeat(1, 1),
+			createSeat(2, 1)
+		);
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("앞열 합이 작은 준연석이 우선 선택된다")
+	void 앞열_합_우선() {
+		// given: row1+row2, row8+row9 모두 가능
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 5; col++) {
+			seats.add(createSeat(1, col));
+			seats.add(createSeat(2, col));
+			seats.add(createSeat(8, col));
+			seats.add(createSeat(9, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		// then: row1+row2 (합=3) 우선
+		assertThat(result).isPresent();
+		assertThat(result.get().rowSum()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("겹침이 많은 준연석이 우선 선택된다")
+	void 겹침_많은_우선() {
+		// given: row1에 [1,2,3,4,5], row2에 [1,2,3,4,5]
+		List<MatchSeat> seats = new ArrayList<>();
+		for (int col = 1; col <= 5; col++) {
+			seats.add(createSeat(1, col));
+			seats.add(createSeat(2, col));
+		}
+		given(matchSeatRepository.findAvailableSeatsByMatchIdAndBlockId(1L, 1L)).willReturn(seats);
+
+		// when: 4석 요청
+		Optional<SemiGroup> result = semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 4);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get().overlapCount()).isGreaterThanOrEqualTo(1);
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -69,6 +69,10 @@ public enum ErrorCode {
 	NO_AVAILABLE_BLOCK(HttpStatus.NOT_FOUND, "선택하신 선호 블럭 내에서는 현재 해당 연석이 가능한 좌석을 찾지 못했어요."),
 	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "블럭을 찾을 수 없습니다."),
 
+	// Seat Assignment
+	NO_CONSECUTIVE_SEAT_AVAILABLE(HttpStatus.NOT_FOUND, "해당 블럭에서 연석 가능한 좌석을 찾을 수 없습니다."),
+	SEAT_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "다른 사용자가 좌석을 선택 중입니다. 잠시 후 다시 시도해주세요."),
+
 	// Seat Hold
 	SEAT_HOLD_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 선점 정보를 찾을 수 없습니다."),
 	SEAT_HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "좌석 선점이 만료되었습니다."),


### PR DESCRIPTION
## 🔧 작업 내용
- 추천 블럭 선택 후 최적 연석 좌석을 자동 배정하고 5분간 선점(Hold)하는 기능 구현
- 진짜 연석 → 준연석(Semi-Consecutive) fallback 전략으로 좌석 탐색
- Redis SETNX 기반 블럭 단위 분산 락으로 동시성 제어

## 🧩 구현 상세
### 핵심 알고리즘
- **AisleDistanceCalculator**: 좌석 그룹의 통로까지 최소 거리 계산 (row 레이아웃 패턴 기반)
- **RealConsecutiveFinder**: 같은 열 내 templateColNo 연속 N석 탐색, `mapMulti` + `.min()`으로 최적 후보 선택
  - 정렬: 앞열 → 통로 가까움 → 왼쪽 우선
- **SemiConsecutiveFinder**: 인접 2개 열에서 수평 겹침(overlap > 0)이 있는 좌석 묶음 탐색
  - 정렬: 앞열 합 → 겹침 많음 → 평균 통로 거리 가까움
- **SeatBlockLock**: Redis SETNX 기반 블럭 단위 분산 락 (5초 TTL)

### 분산 락 (`SeatBlockLock`)
- Redis `SET key value NX EX 5` 기반 블럭 단위 락
- 같은 블럭 동시 요청 시 1명만 통과, 다른 블럭은 병렬 처리
- 트랜잭션 밖에서 lock/unlock, `finally` 블럭에서 반드시 해제

### Hold 처리
- 배정된 좌석 상태를 `AVAILABLE → BLOCKED`로 변경
- `SeatHold` 엔티티 생성 (5분 TTL)
- 재요청 시 기존 Hold 정리 후 새로 배정

### 배정 흐름 (SeatAssignmentService)
  1. SeatSession에서 ticketCount 조회
  2. Redis 분산 락 획득 (`block_lock:{blockId}`)
  3. 기존 Hold 정리 (재요청 대응)
  4. 진짜 연석 탐색 → 성공 시 배정
  5. (nearAdjacentToggle ON) 준연석 fallback → 성공 시 배정
  6. MatchSeat `BLOCKED` 처리 + SeatHold 생성 (5분 TTL)
  7. 락 해제

### API
- `POST /matches/{matchId}/recommendations/blocks/{blockId}/assign`
- Request: `{ "nearAdjacentToggle": boolean }`
- Response: 배정된 좌석 정보 + holdExpiresAt + semiConsecutive 여부

### 기타
- `ErrorCode`에 `NO_CONSECUTIVE_SEAT_AVAILABLE`, `SEAT_LOCK_ACQUISITION_FAILED` 추가
- `BlockRepository`에 `findByIdWithSectionOrThrow` 추가
- `SeatHoldRepository`에 `findAllByUserIdAndMatchId`, `deleteAllByMatchSeatIdIn` 추가
- `SeatDataInitializerTest`에 누락된 `SeatRepository` Mock 추가 (기존 NPE 버그 수정)

### 📌 관련 Jira Issue
- GRGB-253

## 🧪 테스트 방법
### 유닛테스트 22개 통과
- **AisleDistanceCalculatorTest**: 14칸/7칸 row별 통로 거리 계산 검증 (6 cases)
<img width="955" height="502" alt="스크린샷 2026-03-15 오후 11 26 28" src="https://github.com/user-attachments/assets/b9fac36b-6474-46c7-ac5a-ae19b5ec91d7" />

- **RealConsecutiveFinderTest**: 앞열 우선, 통로 가까움 우선, 연석 불가 등 (5 cases)
<img width="1023" height="491" alt="스크린샷 2026-03-15 오후 11 27 20" src="https://github.com/user-attachments/assets/bd2d9381-3ece-458f-af52-52c07b9e7406" />

- **SemiConsecutiveFinderTest**: 수평 겹침 필터, 비인접 열 제외, 앞열 합 우선 등 (6 cases)
<img width="922" height="497" alt="스크린샷 2026-03-15 오후 11 27 55" src="https://github.com/user-attachments/assets/857df1ce-6c4c-4cca-be52-a1bac934cde1" />

- **SeatAssignmentServiceTest**: 진짜 연석 배정, 준연석 fallback, toggle OFF 예외, 락 실패 등 (5 cases)
<img width="1051" height="504" alt="스크린샷 2026-03-15 오후 11 28 17" src="https://github.com/user-attachments/assets/b70e9c03-9e17-4a8a-9160-1d4b8bdb906b" />

- **SeatAssignmentControllerTest**: API 정상 응답 검증 (1 case)
<img width="778" height="356" alt="스크린샷 2026-03-15 오후 11 28 55" src="https://github.com/user-attachments/assets/705516e7-91fa-4ea7-9dc9-9ec4adc77a21" />


## ❗ 참고 사항
- 이 PR은 **추천 좌석 플로우 전용** Hold 기능이며, 일반 좌석(유저 직접 선택) Hold는 별도 구현 필요

- 현재 분산 락은 Redis SETNX 기반으로 구현되어 있으며, **다음 PR에서 Redisson 기반으로 전환 예정**
  - 대규모 트래픽 티켓팅 서비스 특성상 좌석이 ms 단위로 Hold/해제되므로, 락 소유자 검증 · Watch Dog(자동 TTL 갱신) · 재시도 대기가 필수
- `SeatBlockLock`을 별도 컴포넌트로 분리해두었기 때문에 해당 클래스만 교체하면 전환 완료