### PR TITLE
feat(seat): 섹션 별 블록 내 좌석 현황 조회 API [GRGB-255]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -18,6 +18,8 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 
 	List<Block> findBySectionIdInOrderBySectionIdAscBlockCodeAsc(List<Long> sectionIds);
 
+	List<Block> findBySectionIdOrderByBlockCodeAsc(Long sectionId);
+
 	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id IN :blockIds")
 	List<Block> findAllByIdInWithSectionAndArea(@Param("blockIds") List<Long> blockIds);
 

--- a/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,4 +41,24 @@ public class SeatCommonController {
 	) {
 		return ApiResult.ok(seatCommonService.getSeatGroupsEntry(matchId, userId));
 	}
+
+	@Operation(
+		summary = "섹션 별 블럭 좌석 현황 조회",
+		description = "특정 경기/섹션의 블럭별 좌석 현황을 행 단위로 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "404", description = "경기, 섹션을 찾을 수 없거나 좌석 세션이 존재하지 않거나 만료되었습니다.")
+	})
+	@GetMapping("/sections/{sectionId}/blocks")
+	public ApiResult<SectionBlocksResponse> getSectionBlocks(
+		@PathVariable Long matchId,
+		@PathVariable Long sectionId,
+		@AuthenticationPrincipal Long userId
+		// TODO: 큐 진입 토큰 확인
+	) {
+		return ApiResult.ok(seatCommonService.getSectionBlocks(matchId, sectionId, userId));
+	}
+
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
@@ -1,0 +1,30 @@
+package com.goormgb.be.seat.common.dto.response;
+
+import java.util.List;
+
+public record SectionBlocksResponse(
+	List<BlockInfo> blocks
+) {
+
+	public record BlockInfo(
+		Long blockId,
+		String blockCode,
+		String displayName,
+		List<RowInfo> rows
+	) {
+	}
+
+	public record RowInfo(
+		int rowNo,
+		long remainingSeatCount,
+		List<SeatInfo> seats
+	) {
+	}
+
+	public record SeatInfo(
+		Long seatId,
+		int seatNo,
+		String saleStatus
+	) {
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
@@ -6,12 +6,24 @@ public record SectionBlocksResponse(
 	List<BlockInfo> blocks
 ) {
 
+	public static SectionBlocksResponse of(List<BlockInfo> blocks) {
+		return new SectionBlocksResponse(blocks);
+	}
+
 	public record BlockInfo(
 		Long blockId,
 		String blockCode,
 		String displayName,
 		List<RowInfo> rows
 	) {
+		public static BlockInfo of(Long blockId, String blockCode, List<RowInfo> rows) {
+			return new BlockInfo(
+				blockId,
+				blockCode,
+				blockCode + "블럭",
+				rows
+			);
+		}
 	}
 
 	public record RowInfo(
@@ -19,6 +31,9 @@ public record SectionBlocksResponse(
 		long remainingSeatCount,
 		List<SeatInfo> seats
 	) {
+		public static RowInfo of(int rowNo, long remainingSeatCount, List<SeatInfo> seats) {
+			return new RowInfo(rowNo, remainingSeatCount, seats);
+		}
 	}
 
 	public record SeatInfo(
@@ -26,5 +41,8 @@ public record SectionBlocksResponse(
 		int seatNo,
 		String saleStatus
 	) {
+		public static SeatInfo of(Long seatId, int seatNo, String saleStatus) {
+			return new SeatInfo(seatId, seatNo, saleStatus);
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -114,11 +114,13 @@ public class SeatCommonService {
 				.computeIfAbsent(matchSeat.getRowNo(), RowAccumulator::new);
 
 			String seatSaleStatus = toSeatSaleStatus(matchSeat, activeHeldMatchSeatIds);
-			row.seats().add(SectionBlocksResponse.SeatInfo.of(
-				matchSeat.getSeatId(),
-				matchSeat.getSeatNo(),
-				seatSaleStatus
-			));
+			row.addSeat(
+				SectionBlocksResponse.SeatInfo.of(
+					matchSeat.getSeatId(),
+					matchSeat.getSeatNo(),
+					seatSaleStatus
+				)
+			);
 
 			if (MatchSeatSaleStatus.AVAILABLE.name().equals(seatSaleStatus)) {
 				row.increaseRemainingSeatCount();
@@ -210,6 +212,7 @@ public class SeatCommonService {
 	}
 
 	private static final class RowAccumulator {
+
 		private final int rowNo;
 		private long remainingSeatCount;
 		private final List<SectionBlocksResponse.SeatInfo> seats = new ArrayList<>();
@@ -218,8 +221,8 @@ public class SeatCommonService {
 			this.rowNo = rowNo;
 		}
 
-		private List<SectionBlocksResponse.SeatInfo> seats() {
-			return seats;
+		public void addSeat(SectionBlocksResponse.SeatInfo seat) {
+			this.seats.add(seat);
 		}
 
 		private void increaseRemainingSeatCount() {

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -1,21 +1,28 @@
 package com.goormgb.be.seat.common.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 import com.goormgb.be.seat.section.entity.Section;
 import com.goormgb.be.seat.section.repository.SectionRepository;
 
@@ -30,6 +37,7 @@ public class SeatCommonService {
 	private final SectionRepository sectionRepository;
 	private final BlockRepository blockRepository;
 	private final MatchSeatRepository matchSeatRepository;
+	private final SeatHoldRepository seatHoldRepository;
 
 	@Transactional(readOnly = true)
 	public SeatGroupsEntryResponse getSeatGroupsEntry(Long matchId, Long userId) {
@@ -63,6 +71,63 @@ public class SeatCommonService {
 			.toList();
 
 		return SeatGroupsEntryResponse.of(match, seatSession, seatGroups);
+	}
+
+	@Transactional(readOnly = true)
+	public SectionBlocksResponse getSectionBlocks(Long matchId, Long sectionId, Long userId) {
+		matchRepository.findDetailByIdOrThrow(matchId);
+		seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+		sectionRepository.findByIdOrThrow(sectionId, ErrorCode.SECTION_NOT_FOUND);
+
+		List<Block> blocks = blockRepository.findBySectionIdOrderByBlockCodeAsc(sectionId);
+		List<MatchSeat> matchSeats = matchSeatRepository.findByMatchIdAndSectionIdOrderByBlockIdAscRowNoAscSeatNoAsc(
+			matchId,
+			sectionId
+		);
+
+		Set<Long> sectionMatchSeatIds = matchSeats.stream()
+			.map(MatchSeat::getId)
+			.collect(java.util.stream.Collectors.toSet());
+
+		Set<Long> activeHeldMatchSeatIds = new HashSet<>(
+			seatHoldRepository.findAllByMatchIdAndExpiresAtAfter(matchId, java.time.Instant.now())
+				.stream()
+				.map(SeatHold::getMatchSeatId)
+				.filter(sectionMatchSeatIds::contains)
+				.toList()
+		);
+
+		Map<Long, BlockAccumulator> blockMap = new LinkedHashMap<>();
+		for (Block block : blocks) {
+			blockMap.put(block.getId(), new BlockAccumulator(block.getId(), block.getBlockCode()));
+		}
+
+		for (MatchSeat matchSeat : matchSeats) {
+			BlockAccumulator block = blockMap.get(matchSeat.getBlockId());
+			if (block == null) {
+				continue;
+			}
+			RowAccumulator row = block.rowsByRowNo()
+				.computeIfAbsent(matchSeat.getRowNo(), RowAccumulator::new);
+
+			String seatSaleStatus = toSeatSaleStatus(matchSeat, activeHeldMatchSeatIds);
+			row.seats().add(new SectionBlocksResponse.SeatInfo(
+				matchSeat.getSeatId(),
+				matchSeat.getSeatNo(),
+				seatSaleStatus
+			));
+
+			if (MatchSeatSaleStatus.AVAILABLE.name().equals(seatSaleStatus)) {
+				row.increaseRemainingSeatCount();
+			}
+		}
+
+		List<SectionBlocksResponse.BlockInfo> blockInfos = blockMap.values()
+			.stream()
+			.map(BlockAccumulator::toResponse)
+			.toList();
+
+		return new SectionBlocksResponse(blockInfos);
 	}
 
 	private Map<Long, List<Long>> createBlockIdsBySectionId(List<Long> sectionIds) {
@@ -103,6 +168,14 @@ public class SeatCommonService {
 		};
 	}
 
+	private String toSeatSaleStatus(MatchSeat matchSeat, Set<Long> activeHeldMatchSeatIds) {
+		if (matchSeat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE
+			&& activeHeldMatchSeatIds.contains(matchSeat.getId())) {
+			return "HELD";
+		}
+		return matchSeat.getSaleStatus().name();
+	}
+
 	private record SeatGroupAccumulator(
 		Long areaId,
 		String areaName,
@@ -110,6 +183,51 @@ public class SeatCommonService {
 	) {
 		private SeatGroupAccumulator(Long areaId, String areaName) {
 			this(areaId, areaName, new ArrayList<>());
+		}
+	}
+
+	private record BlockAccumulator(
+		Long blockId,
+		String blockCode,
+		Map<Integer, RowAccumulator> rowsByRowNo
+	) {
+		private BlockAccumulator(Long blockId, String blockCode) {
+			this(blockId, blockCode, new LinkedHashMap<>());
+		}
+
+		private SectionBlocksResponse.BlockInfo toResponse() {
+			return new SectionBlocksResponse.BlockInfo(
+				blockId,
+				blockCode,
+				blockCode + "블럭",
+				rowsByRowNo.values().stream().map(RowAccumulator::toResponse).toList()
+			);
+		}
+	}
+
+	private static final class RowAccumulator {
+		private final int rowNo;
+		private long remainingSeatCount;
+		private final List<SectionBlocksResponse.SeatInfo> seats = new ArrayList<>();
+
+		private RowAccumulator(int rowNo) {
+			this.rowNo = rowNo;
+		}
+
+		private List<SectionBlocksResponse.SeatInfo> seats() {
+			return seats;
+		}
+
+		private void increaseRemainingSeatCount() {
+			this.remainingSeatCount++;
+		}
+
+		private SectionBlocksResponse.RowInfo toResponse() {
+			return new SectionBlocksResponse.RowInfo(
+				rowNo,
+				remainingSeatCount,
+				seats
+			);
 		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -1,11 +1,12 @@
 package com.goormgb.be.seat.common.service;
 
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -89,13 +90,15 @@ public class SeatCommonService {
 			.map(MatchSeat::getId)
 			.collect(java.util.stream.Collectors.toSet());
 
-		Set<Long> activeHeldMatchSeatIds = new HashSet<>(
-			seatHoldRepository.findAllByMatchIdAndExpiresAtAfter(matchId, java.time.Instant.now())
-				.stream()
-				.map(SeatHold::getMatchSeatId)
-				.filter(sectionMatchSeatIds::contains)
-				.toList()
-		);
+		Set<Long> activeHeldMatchSeatIds = seatHoldRepository
+			.findAllByMatchIdAndMatchSeatIdInAndExpiresAtAfter(
+				matchId,
+				new ArrayList<>(sectionMatchSeatIds),
+				Instant.now()
+			)
+			.stream()
+			.map(SeatHold::getMatchSeatId)
+			.collect(Collectors.toSet());
 
 		Map<Long, BlockAccumulator> blockMap = new LinkedHashMap<>();
 		for (Block block : blocks) {

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -111,7 +111,7 @@ public class SeatCommonService {
 				.computeIfAbsent(matchSeat.getRowNo(), RowAccumulator::new);
 
 			String seatSaleStatus = toSeatSaleStatus(matchSeat, activeHeldMatchSeatIds);
-			row.seats().add(new SectionBlocksResponse.SeatInfo(
+			row.seats().add(SectionBlocksResponse.SeatInfo.of(
 				matchSeat.getSeatId(),
 				matchSeat.getSeatNo(),
 				seatSaleStatus
@@ -196,11 +196,12 @@ public class SeatCommonService {
 		}
 
 		private SectionBlocksResponse.BlockInfo toResponse() {
-			return new SectionBlocksResponse.BlockInfo(
+			return SectionBlocksResponse.BlockInfo.of(
 				blockId,
 				blockCode,
-				blockCode + "블럭",
-				rowsByRowNo.values().stream().map(RowAccumulator::toResponse).toList()
+				rowsByRowNo.values().stream()
+					.map(RowAccumulator::toResponse)
+					.toList()
 			);
 		}
 	}
@@ -223,7 +224,7 @@ public class SeatCommonService {
 		}
 
 		private SectionBlocksResponse.RowInfo toResponse() {
-			return new SectionBlocksResponse.RowInfo(
+			return SectionBlocksResponse.RowInfo.of(
 				rowNo,
 				remainingSeatCount,
 				seats

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -35,4 +35,15 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 		@Param("matchId") Long matchId,
 		@Param("blockId") Long blockId
 	);
+
+	@Query("""
+		SELECT ms FROM MatchSeat ms
+		WHERE ms.matchId = :matchId
+		  AND ms.sectionId = :sectionId
+		ORDER BY ms.blockId ASC, ms.rowNo ASC, ms.seatNo ASC
+		""")
+	List<MatchSeat> findByMatchIdAndSectionIdOrderByBlockIdAscRowNoAscSeatNoAsc(
+		@Param("matchId") Long matchId,
+		@Param("sectionId") Long sectionId
+	);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.seat.seatHold.repository;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
 	List<SeatHold> findAllByUserIdAndMatchId(Long userId, Long matchId);
 
 	void deleteAllByMatchSeatIdIn(List<Long> matchSeatIds);
+
+	List<SeatHold> findAllByMatchIdAndExpiresAtAfter(Long matchId, Instant now);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -14,4 +14,10 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
 	void deleteAllByMatchSeatIdIn(List<Long> matchSeatIds);
 
 	List<SeatHold> findAllByMatchIdAndExpiresAtAfter(Long matchId, Instant now);
+
+	List<SeatHold> findAllByMatchIdAndMatchSeatIdInAndExpiresAtAfter(
+		Long matchId,
+		List<Long> matchSeatIds,
+		Instant now
+	);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/section/repository/SectionRepository.java
@@ -5,10 +5,16 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.section.entity.Section;
 import com.goormgb.be.seat.section.enums.SectionCode;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+
+	default Section findByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
 
 	List<Section> findByCode(SectionCode code);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
 import com.goormgb.be.seat.support.WebMvcTestSupport;
 
@@ -88,5 +89,52 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.data.seatGroups[1].sections[0].remainingSeatCount").value(120));
 
 		then(seatCommonService).should().getSeatGroupsEntry(matchId, userId);
+	}
+
+	@Test
+	@DisplayName("GET /matches/{matchId}/sections/{sectionId}/blocks - 섹션 별 블럭 좌석 현황 조회 성공")
+	void 섹션_별_블럭_좌석_현황_조회_성공() throws Exception {
+		// given
+		Long matchId = 10L;
+		Long sectionId = 20L;
+		Long userId = 7L;
+		setAuthentication(userId);
+
+		SectionBlocksResponse response = new SectionBlocksResponse(
+			List.of(
+				new SectionBlocksResponse.BlockInfo(
+					205L,
+					"205",
+					"205블럭",
+					List.of(
+						new SectionBlocksResponse.RowInfo(
+							1,
+							2,
+							List.of(
+								new SectionBlocksResponse.SeatInfo(205001L, 1, "AVAILABLE"),
+								new SectionBlocksResponse.SeatInfo(205002L, 2, "SOLD"),
+								new SectionBlocksResponse.SeatInfo(205003L, 3, "HELD")
+							)
+						)
+					)
+				)
+			)
+		);
+
+		given(seatCommonService.getSectionBlocks(eq(matchId), eq(sectionId), eq(userId))).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/matches/{matchId}/sections/{sectionId}/blocks", matchId, sectionId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("성공"))
+			.andExpect(jsonPath("$.data.blocks.length()").value(1))
+			.andExpect(jsonPath("$.data.blocks[0].blockId").value(205))
+			.andExpect(jsonPath("$.data.blocks[0].displayName").value("205블럭"))
+			.andExpect(jsonPath("$.data.blocks[0].rows[0].rowNo").value(1))
+			.andExpect(jsonPath("$.data.blocks[0].rows[0].remainingSeatCount").value(2))
+			.andExpect(jsonPath("$.data.blocks[0].rows[0].seats[2].saleStatus").value("HELD"));
+
+		then(seatCommonService).should().getSectionBlocks(matchId, sectionId, userId);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
@@ -1,0 +1,152 @@
+package com.goormgb.be.seat.common.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.seat.area.entity.Area;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.seat.section.repository.SectionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatCommonServiceTest {
+
+	@Mock
+	private MatchRepository matchRepository;
+	@Mock
+	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	@Mock
+	private SectionRepository sectionRepository;
+	@Mock
+	private BlockRepository blockRepository;
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+
+	@InjectMocks
+	private SeatCommonService seatCommonService;
+
+	private Section createSection(Long sectionId) {
+		Area area = Area.builder().code(AreaCode.HOME).name("1루 구역").build();
+		ReflectionTestUtils.setField(area, "id", 11L);
+		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
+		ReflectionTestUtils.setField(section, "id", sectionId);
+		return section;
+	}
+
+	private Block createBlock(Long blockId, String blockCode, Section section) {
+		Block block = Block.builder()
+			.area(section.getArea())
+			.section(section)
+			.blockCode(blockCode)
+			.viewpoint(com.goormgb.be.domain.onboarding.enums.Viewpoint.INFIELD_1B)
+			.homeCheerRank(1)
+			.awayCheerRank(1)
+			.build();
+		ReflectionTestUtils.setField(block, "id", blockId);
+		return block;
+	}
+
+	private MatchSeat createMatchSeat(
+		Long id,
+		Long matchId,
+		Long seatId,
+		Long sectionId,
+		Long blockId,
+		int rowNo,
+		int seatNo,
+		MatchSeatSaleStatus saleStatus
+	) {
+		MatchSeat seat = MatchSeat.builder()
+			.matchId(matchId)
+			.seatId(seatId)
+			.areaId(11L)
+			.sectionId(sectionId)
+			.blockId(blockId)
+			.rowNo(rowNo)
+			.seatNo(seatNo)
+			.templateColNo(seatNo)
+			.seatZone(SeatZone.MID)
+			.saleStatus(saleStatus)
+			.build();
+		ReflectionTestUtils.setField(seat, "id", id);
+		return seat;
+	}
+
+	private SeatHold createSeatHold(Long matchSeatId, Long matchId, Instant expiresAt) {
+		return SeatHold.builder()
+			.matchSeatId(matchSeatId)
+			.matchId(matchId)
+			.seatId(999L)
+			.userId(77L)
+			.expiresAt(expiresAt)
+			.build();
+	}
+
+	@Test
+	@DisplayName("섹션 블럭 좌석 현황 조회 시 HELD 좌석을 반영하고 행별 남은 좌석 수를 계산한다")
+	void 섹션_블럭_좌석_현황_HELD_반영_성공() {
+		Long userId = 1L;
+		Long matchId = 10L;
+		Long sectionId = 20L;
+
+		Section section = createSection(sectionId);
+		Block block205 = createBlock(205L, "205", section);
+		Block block206 = createBlock(206L, "206", section);
+
+		MatchSeat s1 = createMatchSeat(1001L, matchId, 205001L, sectionId, 205L, 1, 1, MatchSeatSaleStatus.AVAILABLE);
+		MatchSeat s2 = createMatchSeat(1002L, matchId, 205002L, sectionId, 205L, 1, 2, MatchSeatSaleStatus.SOLD);
+		MatchSeat s3 = createMatchSeat(1003L, matchId, 205003L, sectionId, 205L, 1, 3, MatchSeatSaleStatus.AVAILABLE);
+		MatchSeat s4 = createMatchSeat(1004L, matchId, 206001L, sectionId, 206L, 2, 1, MatchSeatSaleStatus.BLOCKED);
+
+		lenient().when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
+		lenient().when(blockRepository.findBySectionIdOrderByBlockCodeAsc(sectionId))
+			.thenReturn(List.of(block205, block206));
+		lenient().when(
+				matchSeatRepository.findByMatchIdAndSectionIdOrderByBlockIdAscRowNoAscSeatNoAsc(matchId, sectionId))
+			.thenReturn(List.of(s1, s2, s3, s4));
+		lenient().when(seatHoldRepository.findAllByMatchIdAndExpiresAtAfter(eq(matchId), any(Instant.class)))
+			.thenReturn(List.of(
+				createSeatHold(1003L, matchId, Instant.now().plusSeconds(60)),
+				createSeatHold(9999L, matchId, Instant.now().plusSeconds(60))
+			));
+
+		SectionBlocksResponse result = seatCommonService.getSectionBlocks(matchId, sectionId, userId);
+
+		assertThat(result.blocks()).hasSize(2);
+		assertThat(result.blocks().get(0).blockCode()).isEqualTo("205");
+		assertThat(result.blocks().get(0).displayName()).isEqualTo("205블럭");
+		assertThat(result.blocks().get(0).rows()).hasSize(1);
+		assertThat(result.blocks().get(0).rows().get(0).remainingSeatCount()).isEqualTo(1);
+		assertThat(result.blocks().get(0).rows().get(0).seats())
+			.extracting(SectionBlocksResponse.SeatInfo::saleStatus)
+			.containsExactly("AVAILABLE", "SOLD", "HELD");
+		assertThat(result.blocks().get(1).rows()).hasSize(1);
+		assertThat(result.blocks().get(1).rows().get(0).remainingSeatCount()).isZero();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
@@ -130,12 +130,15 @@ class SeatCommonServiceTest {
 		lenient().when(
 				matchSeatRepository.findByMatchIdAndSectionIdOrderByBlockIdAscRowNoAscSeatNoAsc(matchId, sectionId))
 			.thenReturn(List.of(s1, s2, s3, s4));
-		lenient().when(seatHoldRepository.findAllByMatchIdAndExpiresAtAfter(eq(matchId), any(Instant.class)))
-			.thenReturn(List.of(
-				createSeatHold(1003L, matchId, Instant.now().plusSeconds(60)),
-				createSeatHold(9999L, matchId, Instant.now().plusSeconds(60))
-			));
-
+		lenient().when(
+			seatHoldRepository.findAllByMatchIdAndMatchSeatIdInAndExpiresAtAfter(
+				eq(matchId),
+				anyList(),
+				any(Instant.class)
+			)
+		).thenReturn(List.of(
+			createSeatHold(1003L, matchId, Instant.now().plusSeconds(60))
+		));
 		SectionBlocksResponse result = seatCommonService.getSectionBlocks(matchId, sectionId, userId);
 
 		assertThat(result.blocks()).hasSize(2);

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -65,6 +65,9 @@ public enum ErrorCode {
 	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
 	ORDER_SEAT_EMPTY(HttpStatus.BAD_REQUEST, "주문 좌석 정보가 없습니다."),
 
+	// Section
+	SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "섹션을 찾을 수 없습니다."),
+
 	// Block Recommendation
 	NO_AVAILABLE_BLOCK(HttpStatus.NOT_FOUND, "선택하신 선호 블럭 내에서는 현재 해당 연석이 가능한 좌석을 찾지 못했어요."),
 	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "블럭을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔧 작업 내용

- 섹션 별 블럭 내 좌석 현황 조회

## 🧩 구현 상세 (선택)

- 섹션 별 블럭 내 좌석 현황 조회
> 사용자가 section을 선택했을 때 좌석 현황을 조회할 수 있는 API

### 📌 관련 Jira Issue

- GRGB-255

## 🧪 테스트 방법(선택)

<img width="1258" height="386" alt="image" src="https://github.com/user-attachments/assets/56119727-1aff-4974-8b72-7b24495e823f" />

<img width="1198" height="355" alt="image" src="https://github.com/user-attachments/assets/7ca6d95f-ff0b-4b6d-bc0b-4bcfe6cd5b34" />



## ❗ 참고 사항

- 좌석 hold 부분은 내일 레디스 다같이 얘기하면서 하는걸루...
