### PR TITLE
[BE] feat(seat): Redisson 분산 락 인프라 세팅 및 SeatBlockLock 전환 [GRGB-259]

### DIFF
--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     implementation project(':common-core')
     testImplementation(testFixtures(project(':common-core')))
 
+    // Redisson 분산 락
+    implementation 'org.redisson:redisson-spring-boot-starter:3.44.0'
+
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
@@ -1,0 +1,23 @@
+package com.goormgb.be.seat.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Bean
+	public RedissonClient redissonClient(
+		@Value("${spring.data.redis.host}") String host,
+		@Value("${spring.data.redis.port}") int port
+	) {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RedissonConfig {
 
-	@Bean
+	@Bean(destroyMethod = "shutdown")
 	public RedissonClient redissonClient(
 		@Value("${spring.data.redis.host}") String host,
 		@Value("${spring.data.redis.port}") int port

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
@@ -1,36 +1,49 @@
 package com.goormgb.be.seat.recommendation.service;
 
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * Redis SETNX 기반 블럭 단위 분산 락.
+ * Redisson 기반 블럭 단위 분산 락.
  *
  * <p>좌석 배정 시 동일 블럭에 대한 동시 접근을 방지한다.
  * 락 획득에 실패하면 다른 사용자가 해당 블럭에서 좌석을 선택 중임을 의미한다.</p>
+ *
+ * <ul>
+ *   <li>waitTime(3초): 락 획득 대기 시간 — 앞 사용자 처리 완료를 기다림</li>
+ *   <li>leaseTime(5초): 락 임대 시간 — 작업 완료 전 자동 해제 방지</li>
+ *   <li>소유자 검증: 락을 획득한 스레드만 해제 가능</li>
+ * </ul>
  */
 @Component
 @RequiredArgsConstructor
 public class SeatBlockLock {
 
 	private static final String LOCK_KEY_PREFIX = "block_lock:";
-	private static final Duration LOCK_TIMEOUT = Duration.ofSeconds(5);
+	private static final long WAIT_TIME_SECONDS = 3;
+	private static final long LEASE_TIME_SECONDS = 5;
 
-	private final StringRedisTemplate redisTemplate;
+	private final RedissonClient redissonClient;
 
 	public boolean tryLock(Long blockId) {
-		String key = LOCK_KEY_PREFIX + blockId;
-		return Boolean.TRUE.equals(
-			redisTemplate.opsForValue().setIfAbsent(key, "LOCKED", LOCK_TIMEOUT)
-		);
+		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
+		try {
+			return lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
 	}
 
 	public void unlock(Long blockId) {
-		String key = LOCK_KEY_PREFIX + blockId;
-		redisTemplate.delete(key);
+		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
+		if (lock.isHeldByCurrentThread()) {
+			lock.unlock();
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
@@ -7,6 +7,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Redisson 기반 블럭 단위 분산 락.
@@ -16,24 +17,24 @@ import lombok.RequiredArgsConstructor;
  *
  * <ul>
  *   <li>waitTime(3초): 락 획득 대기 시간 — 앞 사용자 처리 완료를 기다림</li>
- *   <li>leaseTime(5초): 락 임대 시간 — 작업 완료 전 자동 해제 방지</li>
+ *   <li>Watchdog: 작업 완료 전까지 락을 자동 연장 (기본 30초, 자동 갱신)</li>
  *   <li>소유자 검증: 락을 획득한 스레드만 해제 가능</li>
  * </ul>
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SeatBlockLock {
 
 	private static final String LOCK_KEY_PREFIX = "block_lock:";
 	private static final long WAIT_TIME_SECONDS = 3;
-	private static final long LEASE_TIME_SECONDS = 5;
 
 	private final RedissonClient redissonClient;
 
 	public boolean tryLock(Long blockId) {
 		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
 		try {
-			return lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+			return lock.tryLock(WAIT_TIME_SECONDS, TimeUnit.SECONDS);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			return false;
@@ -43,7 +44,11 @@ public class SeatBlockLock {
 	public void unlock(Long blockId) {
 		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
 		if (lock.isHeldByCurrentThread()) {
-			lock.unlock();
+			try {
+				lock.unlock();
+			} catch (Exception e) {
+				log.error("Failed to unlock seat block lock for blockId: {}", blockId, e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- RedissonClient 빈 등록 (RedissonConfig, 기존 Redis 프로퍼티 재사용)
- redisson-spring-boot-starter 의존성 추가
- SeatBlockLock을 SETNX 방식에서 Redisson RLock으로 전환
- tryLock(waitTime=3s, leaseTime=5s) + 소유자 검증 unlock 적용

## 🔧 작업 내용
- Seat 모듈에 Redisson 분산 락 인프라를 세팅하여 블럭 추천 락 / 일반 좌석 락 작업의 공통 기반 마련
- 기존 SETNX 기반 SeatBlockLock을 Redisson RLock으로 전환
- RedissonClient 빈을 등록하여 추천 On/OFF 각자 락 구현 시 바로 주입받아 사용 가능하도록 구성

## 🧩 구현 상세
- `RedissonConfig`: 기존 `spring.data.redis.host/port` 프로퍼티를 재사용하여 RedissonClient 빈 등록 (설정 중복 방지)
- `SeatBlockLock`: Redisson RLock 기반으로 전환 — `tryLock(waitTime=3s, leaseTime=5s)` + `isHeldByCurrentThread()` 소유자 검증 unlock
- `build.gradle`: `org.redisson:redisson-spring-boot-starter:3.44.0` 의존성 추가

### 📌 관련 Jira Issue
- GRGB-259

## ❗ 참고 사항
- 이 PR은 Redisson 공통 인프라 세팅만 포함합니다
- 후속 작업:
  - 블럭 추천 분산 락 고도화 (@SeulGi0117 )
  - 일반 좌석 포도알 티켓팅 락 구현 (@ejinn1 )
- 기존 테스트는 SeatBlockLock을 Mock으로 사용하므로 변경 없이 전체 통과 확인 완료