### PR TITLE
feat(seat-common): 좌석 Hold api 구현 [GRGB-258]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
@@ -3,13 +3,18 @@ package com.goormgb.be.seat.common.controller;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.seat.common.dto.request.SeatHoldCreateRequest;
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
+import com.goormgb.be.seat.common.service.SeatHoldService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatCommonController {
 
 	private final SeatCommonService seatCommonService;
+	private final SeatHoldService seatHoldService;
 
 	@Operation(
 		summary = "좌석 그룹 초기 조회",
@@ -40,6 +46,26 @@ public class SeatCommonController {
 		// TODO: 큐 진입 토큰 확인
 	) {
 		return ApiResult.ok(seatCommonService.getSeatGroupsEntry(matchId, userId));
+	}
+
+	@Operation(
+		summary = "직접 선택 좌석 선점",
+		description = "사용자가 선택한 좌석을 5분간 선점(Hold)합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "좌석 선점 성공"),
+		@ApiResponse(responseCode = "400", description = "좌석 요청 값이 유효하지 않습니다."),
+		@ApiResponse(responseCode = "404", description = "좌석 또는 좌석 세션을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "409", description = "다른 사용자가 이미 좌석을 선점 중입니다.")
+	})
+	@PostMapping("/seat-holds")
+	public ApiResult<SeatHoldCreateResponse> createSeatHolds(
+		@PathVariable Long matchId,
+		@RequestBody SeatHoldCreateRequest request,
+		@AuthenticationPrincipal Long userId
+	) {
+		return ApiResult.ok(seatHoldService.createOrRefreshHold(userId, matchId, request.seatIds()));
 	}
 
 	@Operation(

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/request/SeatHoldCreateRequest.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/request/SeatHoldCreateRequest.java
@@ -1,0 +1,8 @@
+package com.goormgb.be.seat.common.dto.request;
+
+import java.util.List;
+
+public record SeatHoldCreateRequest(
+	List<Long> seatIds
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatHoldCreateResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatHoldCreateResponse.java
@@ -1,0 +1,16 @@
+package com.goormgb.be.seat.common.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SeatHoldCreateResponse(
+	Long matchId,
+	List<Long> seatIds,
+	int seatCount,
+	Instant holdExpiresAt
+) {
+
+	public static SeatHoldCreateResponse of(Long matchId, List<Long> seatIds, Instant holdExpiresAt) {
+		return new SeatHoldCreateResponse(matchId, seatIds, seatIds.size(), holdExpiresAt);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -1,0 +1,145 @@
+package com.goormgb.be.seat.common.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.redisson.api.RLock;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
+import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeatHoldService {
+
+	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+
+	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	private final MatchSeatRepository matchSeatRepository;
+	private final SeatHoldRepository seatHoldRepository;
+	private final SeatHoldLockManager seatHoldLockManager;
+	private final Clock clock;
+
+	@Transactional
+	public SeatHoldCreateResponse createOrRefreshHold(Long userId, Long matchId, List<Long> seatIds) {
+		List<Long> normalizedSeatIds = normalizeSeatIds(seatIds);
+		validateSeatCount(userId, matchId, normalizedSeatIds.size());
+
+		List<RLock> locks = seatHoldLockManager.lockAll(matchId, normalizedSeatIds);
+		try {
+			return createOrRefreshHoldTx(userId, matchId, normalizedSeatIds);
+		} finally {
+			seatHoldLockManager.unlockAll(locks);
+		}
+	}
+
+	private SeatHoldCreateResponse createOrRefreshHoldTx(Long userId, Long matchId, List<Long> seatIds) {
+		Instant now = clock.instant();
+		Instant expiresAt = now.plus(HOLD_TTL);
+
+		List<MatchSeat> requestedSeats = matchSeatRepository.findAllByMatchIdAndSeatIdIn(matchId, seatIds);
+
+		Preconditions.validate(requestedSeats.size() == seatIds.size(), ErrorCode.MATCH_SEAT_NOT_FOUND);
+		Preconditions.validate(
+			requestedSeats.stream().noneMatch(seat -> seat.getSaleStatus() == MatchSeatSaleStatus.SOLD),
+			ErrorCode.SEAT_ALREADY_SOLD
+		);
+
+		List<SeatHold> activeRequestedHolds = seatHoldRepository
+			.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(matchId, seatIds, now);
+
+		boolean hasOtherUserHold = activeRequestedHolds.stream().anyMatch(hold -> !hold.isOwnedBy(userId));
+		Preconditions.validate(!hasOtherUserHold, ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
+
+		List<SeatHold> userActiveHolds = seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(userId, matchId,
+			now);
+		Set<Long> currentHeldSeatIds = userActiveHolds.stream()
+			.map(SeatHold::getSeatId)
+			.collect(java.util.stream.Collectors.toSet());
+		Set<Long> requestedSeatSet = new HashSet<>(seatIds);
+
+		if (currentHeldSeatIds.equals(requestedSeatSet) && !userActiveHolds.isEmpty()) {
+			userActiveHolds.forEach(hold -> hold.extendHold(expiresAt));
+			requestedSeats.forEach(MatchSeat::markBlocked);
+			return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
+		}
+
+		releaseUserActiveHolds(userActiveHolds);
+
+		List<SeatHold> newHolds = requestedSeats.stream()
+			.map(seat -> SeatHold.builder()
+				.matchSeatId(seat.getId())
+				.matchId(matchId)
+				.seatId(seat.getSeatId())
+				.userId(userId)
+				.expiresAt(expiresAt)
+				.build())
+			.toList();
+
+		requestedSeats.forEach(MatchSeat::markBlocked);
+		seatHoldRepository.saveAll(newHolds);
+
+		return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
+	}
+
+	private void releaseUserActiveHolds(List<SeatHold> userActiveHolds) {
+		if (userActiveHolds.isEmpty()) {
+			return;
+		}
+
+		List<Long> matchSeatIds = userActiveHolds.stream().map(SeatHold::getMatchSeatId).toList();
+		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
+		seatsToRelease.forEach(MatchSeat::markAvailable);
+		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
+	}
+
+	private List<Long> normalizeSeatIds(List<Long> seatIds) {
+		Preconditions.validate(
+			seatIds != null && !seatIds.isEmpty(),
+			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+		);
+
+		Preconditions.validate(
+			seatIds.stream().noneMatch(java.util.Objects::isNull),
+			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+		);
+
+		Preconditions.validate(
+			new HashSet<>(seatIds).size() == seatIds.size(),
+			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+		);
+
+		return seatIds.stream()
+			.sorted(Comparator.naturalOrder())
+			.toList();
+	}
+
+	private void validateSeatCount(Long userId, Long matchId, int requestedCount) {
+		SeatSession seatSession =
+			seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+
+		Preconditions.validate(
+			seatSession.getTicketCount() == requestedCount,
+			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+		);
+	}
+}
+

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/lock/SeatHoldLockManager.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/lock/SeatHoldLockManager.java
@@ -1,0 +1,60 @@
+package com.goormgb.be.seat.common.service.lock;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SeatHoldLockManager {
+
+	private static final String KEY_PREFIX = "seat:hold:match:";
+	private static final Duration WAIT_TIME = Duration.ofMillis(100);
+	private static final Duration LEASE_TIME = Duration.ofSeconds(5);
+
+	private final RedissonClient redissonClient;
+
+	public List<RLock> lockAll(Long matchId, List<Long> sortedSeatIds) {
+		List<RLock> acquired = new ArrayList<>();
+
+		try {
+			for (Long seatId : sortedSeatIds) {
+				RLock lock = redissonClient.getLock(buildKey(matchId, seatId));
+				boolean locked = lock.tryLock(WAIT_TIME.toMillis(), LEASE_TIME.toMillis(), TimeUnit.MILLISECONDS);
+				if (!locked) {
+					unlockAll(acquired);
+					throw new CustomException(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
+				}
+				acquired.add(lock);
+			}
+			return acquired;
+		} catch (InterruptedException e) {
+			unlockAll(acquired);
+			Thread.currentThread().interrupt();
+			throw new CustomException(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
+		}
+	}
+
+	public void unlockAll(List<RLock> locks) {
+		for (int i = locks.size() - 1; i >= 0; i--) {
+			RLock lock = locks.get(i);
+			if (lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+
+	private String buildKey(Long matchId, Long seatId) {
+		return KEY_PREFIX + matchId + ":seat:" + seatId;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -46,4 +46,6 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 		@Param("matchId") Long matchId,
 		@Param("sectionId") Long sectionId
 	);
+
+	List<MatchSeat> findAllByMatchIdAndSeatIdIn(Long matchId, List<Long> seatIds);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -20,4 +20,8 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
 		List<Long> matchSeatIds,
 		Instant now
 	);
+
+	List<SeatHold> findAllByUserIdAndMatchIdAndExpiresAtAfter(Long userId, Long matchId, Instant now);
+
+	List<SeatHold> findAllByMatchIdAndSeatIdInAndExpiresAtAfter(Long matchId, List<Long> seatIds, Instant now);
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
@@ -18,8 +18,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
+import com.goormgb.be.seat.common.service.SeatHoldService;
 import com.goormgb.be.seat.support.WebMvcTestSupport;
 
 @WebMvcTest(SeatCommonController.class)
@@ -28,6 +30,9 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 
 	@MockitoBean
 	private SeatCommonService seatCommonService;
+
+	@MockitoBean
+	private SeatHoldService seatHoldService;
 
 	private void setAuthentication(Long userId) {
 		SecurityContextHolder.getContext().setAuthentication(
@@ -89,6 +94,36 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.data.seatGroups[1].sections[0].remainingSeatCount").value(120));
 
 		then(seatCommonService).should().getSeatGroupsEntry(matchId, userId);
+	}
+
+	@Test
+	@DisplayName("POST /matches/{matchId}/seat-holds - 좌석 선점 성공")
+	void 좌석_선점_성공() throws Exception {
+		Long matchId = 10L;
+		Long userId = 7L;
+		setAuthentication(userId);
+
+		SeatHoldCreateResponse response = SeatHoldCreateResponse.of(
+			matchId,
+			List.of(206313L, 206314L),
+			Instant.parse("2026-04-15T10:05:00Z")
+		);
+		given(seatHoldService.createOrRefreshHold(eq(userId), eq(matchId), eq(List.of(206313L, 206314L))))
+			.willReturn(response);
+
+		mockMvc.perform(post("/matches/{matchId}/seat-holds", matchId)
+				.contentType("application/json")
+				.content("""
+					{"seatIds":[206313,206314]}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.data.matchId").value(10))
+			.andExpect(jsonPath("$.data.seatCount").value(2))
+			.andExpect(jsonPath("$.data.seatIds[0]").value(206313))
+			.andExpect(jsonPath("$.data.holdExpiresAt").value("2026-04-15T10:05:00Z"));
+
+		then(seatHoldService).should().createOrRefreshHold(userId, matchId, List.of(206313L, 206314L));
 	}
 
 	@Test

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
@@ -1,0 +1,198 @@
+package com.goormgb.be.seat.common.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
+import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
+import com.goormgb.be.seat.redis.SeatSession;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldServiceTest {
+
+	private static final Long USER_ID = 7L;
+	private static final Long MATCH_ID = 10L;
+	private static final Instant NOW = Instant.parse("2026-04-15T10:00:00Z");
+
+	@Mock
+	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+	@Mock
+	private SeatHoldLockManager seatHoldLockManager;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private SeatHoldService seatHoldService;
+
+	private MatchSeat matchSeat(Long seatId, MatchSeatSaleStatus status) {
+		return MatchSeat.builder()
+			.matchId(MATCH_ID)
+			.seatId(seatId)
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(1)
+			.seatNo(seatId.intValue())
+			.templateColNo(seatId.intValue())
+			.seatZone(SeatZone.LOW)
+			.saleStatus(status)
+			.build();
+	}
+
+	private SeatHold seatHold(Long matchSeatId, Long seatId, Long userId, Instant expiresAt) {
+		return SeatHold.builder()
+			.matchSeatId(matchSeatId)
+			.matchId(MATCH_ID)
+			.seatId(seatId)
+			.userId(userId)
+			.expiresAt(expiresAt)
+			.build();
+	}
+
+	private void setupSession(int ticketCount) {
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
+			.willReturn(new SeatSession(USER_ID, MATCH_ID, true, ticketCount, List.of(1L)));
+	}
+
+	@Test
+	@DisplayName("seatIds가 중복이면 INVALID_SEAT_HOLD_REQUEST 예외가 발생한다")
+	void 중복_좌석_요청_예외() {
+		// when & then
+		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(1L, 1L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_SEAT_HOLD_REQUEST);
+
+		verifyNoInteractions(seatHoldLockManager);
+	}
+
+	@Test
+	@DisplayName("동일 좌석 재요청이면 hold 만료시간을 연장한다")
+	void 동일_좌석_재요청_만료_연장() {
+		// given
+		setupSession(2);
+		given(clock.instant()).willReturn(NOW);
+		RLock lock1 = mock(RLock.class);
+		RLock lock2 = mock(RLock.class);
+		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of(
+				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
+			));
+		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
+			.willReturn(List.of(
+				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
+			));
+
+		// when
+		SeatHoldCreateResponse response = seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID,
+			List.of(206313L, 206314L));
+
+		// then
+		assertThat(response.matchId()).isEqualTo(MATCH_ID);
+		assertThat(response.seatCount()).isEqualTo(2);
+		assertThat(response.holdExpiresAt()).isEqualTo(NOW.plusSeconds(300));
+		verify(seatHoldRepository, never()).saveAll(anyList());
+		verify(seatHoldRepository, never()).deleteAllByMatchSeatIdIn(anyList());
+		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
+	}
+
+	@Test
+	@DisplayName("기존 hold와 다른 좌석 요청이면 기존 hold를 해제하고 신규 hold를 생성한다")
+	void 다른_좌석_요청시_교체_성공() {
+		// given
+		setupSession(2);
+		given(clock.instant()).willReturn(NOW);
+		RLock lock1 = mock(RLock.class);
+		RLock lock2 = mock(RLock.class);
+		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of());
+		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
+			.willReturn(List.of(
+				seatHold(11L, 205000L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(12L, 205001L, USER_ID, NOW.plusSeconds(60))
+			));
+		given(matchSeatRepository.findAllById(List.of(11L, 12L)))
+			.willReturn(List.of(matchSeat(205000L, MatchSeatSaleStatus.BLOCKED),
+				matchSeat(205001L, MatchSeatSaleStatus.BLOCKED)));
+
+		// when
+		SeatHoldCreateResponse response = seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID,
+			List.of(206313L, 206314L));
+
+		// then
+		assertThat(response.seatIds()).containsExactly(206313L, 206314L);
+		verify(seatHoldRepository).deleteAllByMatchSeatIdIn(List.of(11L, 12L));
+		verify(seatHoldRepository).saveAll(anyList());
+		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
+	}
+
+	@Test
+	@DisplayName("타 사용자 활성 hold가 있으면 SEAT_ALREADY_HELD_BY_OTHER 예외가 발생한다")
+	void 타사용자_선점_충돌_예외() {
+		// given
+		setupSession(2);
+		given(clock.instant()).willReturn(NOW);
+		RLock lock1 = mock(RLock.class);
+		RLock lock2 = mock(RLock.class);
+		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of(seatHold(1L, 206313L, 999L, NOW.plusSeconds(60))));
+
+		// when & then
+		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
+
+		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
+		verify(seatHoldRepository, never()).saveAll(anyList());
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -86,6 +86,10 @@ public enum ErrorCode {
 	SEAT_LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "다른 사용자가 좌석을 선택 중입니다. 잠시 후 다시 시도해주세요."),
 
 	// Seat Hold
+	INVALID_SEAT_HOLD_REQUEST(HttpStatus.BAD_REQUEST, "좌석 선점 요청이 올바르지 않습니다."),
+	MATCH_SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경기의 좌석 정보를 찾을 수 없습니다."),
+	SEAT_ALREADY_HELD_BY_OTHER(HttpStatus.CONFLICT, "다른 사용자가 이미 좌석을 선점했습니다."),
+	SEAT_ALREADY_SOLD(HttpStatus.CONFLICT, "이미 판매 완료된 좌석입니다."),
 	SEAT_HOLD_NOT_FOUND(HttpStatus.NOT_FOUND, "좌석 선점 정보를 찾을 수 없습니다."),
 	SEAT_HOLD_EXPIRED(HttpStatus.BAD_REQUEST, "좌석 선점이 만료되었습니다."),
 	SEAT_HOLD_OWNERSHIP_DENIED(HttpStatus.FORBIDDEN, "해당 좌석 선점에 접근할 권한이 없습니다."),


### PR DESCRIPTION
## 🔧 작업 내용

- 일반 좌석 선점 API 구현

## 🧩 구현 상세 (선택)

**일반 좌석 선점 API 구현**
> 일반 좌석 선택 페이지에서 섹션을 선택한 후 블럭 내 좌석을 선택하고 예매하기 버튼 눌렀을 때 좌석 선점하는 API
- 선점 데이터는 `seat_holds` 테이블에 저장, `match_seat_id` 유니크 제약으로 동일 좌석 중복 선점 방지
- 선점 성공 시 해당 좌석의 `match_seat` 상태를 `BLOCKED`로 변경, 기존 선점 해제 시는 `AVAILABLE`로 복구
- Redission 분산락을 좌석 단위로 `seat:hold:match:{matchId}:seat:{seatId}`로 적용
- seatId 순서대로 락을 획득해 데드락 방지, 하나라도 획득 실패 시 전체 요청을 실패 처리

### 📌 관련 Jira Issue

- GRGB-258

## 🧪 테스트 방법(선택)

<img width="1242" height="400" alt="image" src="https://github.com/user-attachments/assets/4f53a009-a5e0-45c5-bb5a-ec5583b1d2f6" />

<img width="1156" height="443" alt="image" src="https://github.com/user-attachments/assets/f65c8d9d-0cde-4cde-9fd3-e3cac4f0a988" />


## ❗ 참고 사항

