### PR TITLE
refactor(seat): 좌석 선점 트랜잭션-락 경계 불일치 해결 및 안정성 개선 [GRGB-263]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -17,6 +17,22 @@ import com.goormgb.be.seat.redis.SeatSession;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 직접 선택 좌석 선점(Hold) 서비스.
+ *
+ * <p>유저가 좌석맵에서 직접 클릭한 좌석들을 선점한다.
+ * 입력 검증과 Redisson 분산 락 관리를 담당하며,
+ * 실제 트랜잭션 처리는 {@link SeatHoldTransactionalService}에 위임하여
+ * 트랜잭션 커밋이 락 해제보다 먼저 완료되도록 보장한다.</p>
+ *
+ * <h3>처리 흐름</h3>
+ * <ol>
+ *   <li>seatIds 정규화 및 검증 (중복, null, 티켓 수 일치)</li>
+ *   <li>좌석 단위 Redisson 분산 락 획득 (정렬 순서로 데드락 방지)</li>
+ *   <li>트랜잭션 서비스에서 Hold 생성/갱신 + 커밋</li>
+ *   <li>락 해제</li>
+ * </ol>
+ */
 @Service
 @RequiredArgsConstructor
 public class SeatHoldService {

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -1,28 +1,19 @@
 package com.goormgb.be.seat.common.service;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
 
 import org.redisson.api.RLock;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
-import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
-import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
-import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
-import com.goormgb.be.seat.seatHold.entity.SeatHold;
-import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,85 +21,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatHoldService {
 
-	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
-
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
-	private final MatchSeatRepository matchSeatRepository;
-	private final SeatHoldRepository seatHoldRepository;
 	private final SeatHoldLockManager seatHoldLockManager;
-	private final Clock clock;
+	private final SeatHoldTransactionalService seatHoldTransactionalService;
 
-	@Transactional
 	public SeatHoldCreateResponse createOrRefreshHold(Long userId, Long matchId, List<Long> seatIds) {
 		List<Long> normalizedSeatIds = normalizeSeatIds(seatIds);
 		validateSeatCount(userId, matchId, normalizedSeatIds.size());
 
 		List<RLock> locks = seatHoldLockManager.lockAll(matchId, normalizedSeatIds);
 		try {
-			return createOrRefreshHoldTx(userId, matchId, normalizedSeatIds);
+			return seatHoldTransactionalService.createOrRefreshHold(userId, matchId, normalizedSeatIds);
 		} finally {
 			seatHoldLockManager.unlockAll(locks);
 		}
-	}
-
-	private SeatHoldCreateResponse createOrRefreshHoldTx(Long userId, Long matchId, List<Long> seatIds) {
-		Instant now = clock.instant();
-		Instant expiresAt = now.plus(HOLD_TTL);
-
-		List<MatchSeat> requestedSeats = matchSeatRepository.findAllByMatchIdAndSeatIdIn(matchId, seatIds);
-
-		Preconditions.validate(requestedSeats.size() == seatIds.size(), ErrorCode.MATCH_SEAT_NOT_FOUND);
-		Preconditions.validate(
-			requestedSeats.stream().noneMatch(seat -> seat.getSaleStatus() == MatchSeatSaleStatus.SOLD),
-			ErrorCode.SEAT_ALREADY_SOLD
-		);
-
-		List<SeatHold> activeRequestedHolds = seatHoldRepository
-			.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(matchId, seatIds, now);
-
-		boolean hasOtherUserHold = activeRequestedHolds.stream().anyMatch(hold -> !hold.isOwnedBy(userId));
-		Preconditions.validate(!hasOtherUserHold, ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
-
-		List<SeatHold> userActiveHolds = seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(userId, matchId,
-			now);
-		Set<Long> currentHeldSeatIds = userActiveHolds.stream()
-			.map(SeatHold::getSeatId)
-			.collect(java.util.stream.Collectors.toSet());
-		Set<Long> requestedSeatSet = new HashSet<>(seatIds);
-
-		if (currentHeldSeatIds.equals(requestedSeatSet) && !userActiveHolds.isEmpty()) {
-			userActiveHolds.forEach(hold -> hold.extendHold(expiresAt));
-			requestedSeats.forEach(MatchSeat::markBlocked);
-			return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
-		}
-
-		releaseUserActiveHolds(userActiveHolds);
-
-		List<SeatHold> newHolds = requestedSeats.stream()
-			.map(seat -> SeatHold.builder()
-				.matchSeatId(seat.getId())
-				.matchId(matchId)
-				.seatId(seat.getSeatId())
-				.userId(userId)
-				.expiresAt(expiresAt)
-				.build())
-			.toList();
-
-		requestedSeats.forEach(MatchSeat::markBlocked);
-		seatHoldRepository.saveAll(newHolds);
-
-		return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
-	}
-
-	private void releaseUserActiveHolds(List<SeatHold> userActiveHolds) {
-		if (userActiveHolds.isEmpty()) {
-			return;
-		}
-
-		List<Long> matchSeatIds = userActiveHolds.stream().map(SeatHold::getMatchSeatId).toList();
-		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
-		seatsToRelease.forEach(MatchSeat::markAvailable);
-		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
 	}
 
 	private List<Long> normalizeSeatIds(List<Long> seatIds) {
@@ -118,7 +44,7 @@ public class SeatHoldService {
 		);
 
 		Preconditions.validate(
-			seatIds.stream().noneMatch(java.util.Objects::isNull),
+			seatIds.stream().noneMatch(Objects::isNull),
 			ErrorCode.INVALID_SEAT_HOLD_REQUEST
 		);
 
@@ -142,4 +68,3 @@ public class SeatHoldService {
 		);
 	}
 }
-

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
@@ -1,0 +1,96 @@
+package com.goormgb.be.seat.common.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeatHoldTransactionalService {
+
+	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+
+	private final MatchSeatRepository matchSeatRepository;
+	private final SeatHoldRepository seatHoldRepository;
+	private final Clock clock;
+
+	@Transactional
+	public SeatHoldCreateResponse createOrRefreshHold(Long userId, Long matchId, List<Long> seatIds) {
+		Instant now = clock.instant();
+		Instant expiresAt = now.plus(HOLD_TTL);
+
+		List<MatchSeat> requestedSeats = matchSeatRepository.findAllByMatchIdAndSeatIdIn(matchId, seatIds);
+
+		Preconditions.validate(requestedSeats.size() == seatIds.size(), ErrorCode.MATCH_SEAT_NOT_FOUND);
+		Preconditions.validate(
+			requestedSeats.stream().noneMatch(seat -> seat.getSaleStatus() == MatchSeatSaleStatus.SOLD),
+			ErrorCode.SEAT_ALREADY_SOLD
+		);
+
+		List<SeatHold> activeRequestedHolds = seatHoldRepository
+			.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(matchId, seatIds, now);
+
+		boolean hasOtherUserHold = activeRequestedHolds.stream().anyMatch(hold -> !hold.isOwnedBy(userId));
+		Preconditions.validate(!hasOtherUserHold, ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
+
+		List<SeatHold> userActiveHolds = seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(userId, matchId,
+			now);
+		Set<Long> currentHeldSeatIds = userActiveHolds.stream()
+			.map(SeatHold::getSeatId)
+			.collect(Collectors.toSet());
+		Set<Long> requestedSeatSet = new HashSet<>(seatIds);
+
+		if (currentHeldSeatIds.equals(requestedSeatSet) && !userActiveHolds.isEmpty()) {
+			userActiveHolds.forEach(hold -> hold.extendHold(expiresAt));
+			requestedSeats.forEach(MatchSeat::markBlocked);
+			return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
+		}
+
+		releaseUserActiveHolds(userActiveHolds);
+
+		List<SeatHold> newHolds = requestedSeats.stream()
+			.map(seat -> SeatHold.builder()
+				.matchSeatId(seat.getId())
+				.matchId(matchId)
+				.seatId(seat.getSeatId())
+				.userId(userId)
+				.expiresAt(expiresAt)
+				.build())
+			.toList();
+
+		requestedSeats.forEach(MatchSeat::markBlocked);
+		seatHoldRepository.saveAll(newHolds);
+
+		return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
+	}
+
+	private void releaseUserActiveHolds(List<SeatHold> userActiveHolds) {
+		if (userActiveHolds.isEmpty()) {
+			return;
+		}
+
+		List<Long> matchSeatIds = userActiveHolds.stream().map(SeatHold::getMatchSeatId).toList();
+		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
+		seatsToRelease.forEach(MatchSeat::markAvailable);
+		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
+		seatHoldRepository.flush();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
@@ -22,6 +22,20 @@ import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 직접 선택 좌석 선점의 트랜잭션 전담 서비스.
+ *
+ * <p>{@link SeatHoldService}에서 분산 락을 획득한 뒤 호출되며,
+ * 별도 빈으로 분리하여 {@code @Transactional} AOP 프록시가 정상 동작하고
+ * 트랜잭션 커밋이 락 해제보다 먼저 완료되도록 보장한다.</p>
+ *
+ * <h3>Hold 생성/갱신 로직</h3>
+ * <ul>
+ *   <li>동일 좌석 재요청: 기존 Hold의 만료 시간만 연장 (5분 TTL 갱신)</li>
+ *   <li>다른 좌석 요청: 기존 Hold 해제 → 신규 Hold 생성</li>
+ *   <li>타 사용자 Hold 충돌: 예외 발생</li>
+ * </ul>
+ */
 @Service
 @RequiredArgsConstructor
 public class SeatHoldTransactionalService {
@@ -32,6 +46,17 @@ public class SeatHoldTransactionalService {
 	private final SeatHoldRepository seatHoldRepository;
 	private final Clock clock;
 
+	/**
+	 * 좌석 Hold를 생성하거나 기존 Hold를 갱신한다.
+	 *
+	 * <p>이 메서드는 반드시 분산 락이 획득된 상태에서 호출되어야 한다.</p>
+	 *
+	 * @param userId  사용자 ID
+	 * @param matchId 경기 ID
+	 * @param seatIds 정규화된 좌석 ID 목록 (정렬, 중복 제거 완료)
+	 * @return Hold 생성 결과 (좌석 목록, 만료 시각)
+	 * @throws CustomException 좌석 미존재, 판매 완료, 타 사용자 선점 시
+	 */
 	@Transactional
 	public SeatHoldCreateResponse createOrRefreshHold(Long userId, Long matchId, List<Long> seatIds) {
 		Instant now = clock.instant();
@@ -82,6 +107,13 @@ public class SeatHoldTransactionalService {
 		return SeatHoldCreateResponse.of(matchId, seatIds, expiresAt);
 	}
 
+	/**
+	 * 사용자의 활성 Hold를 해제한다.
+	 *
+	 * <p>좌석 상태를 AVAILABLE로 복원하고 Hold 레코드를 삭제한다.
+	 * delete 후 flush()를 호출하여 JPA flush 순서(INSERT → DELETE)로 인한
+	 * unique constraint violation을 방지한다.</p>
+	 */
 	private void releaseUserActiveHolds(List<SeatHold> userActiveHolds) {
 		if (userActiveHolds.isEmpty()) {
 			return;

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/lock/SeatHoldLockManager.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/lock/SeatHoldLockManager.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatHoldLockManager {
 
 	private static final String KEY_PREFIX = "seat:hold:match:";
-	private static final Duration WAIT_TIME = Duration.ofMillis(100);
+	private static final Duration WAIT_TIME = Duration.ofMillis(500);
 	private static final Duration LEASE_TIME = Duration.ofSeconds(5);
 
 	private final RedissonClient redissonClient;

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -1,26 +1,14 @@
 package com.goormgb.be.seat.recommendation.service;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
-
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
-import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
-import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
-import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
-import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
-import com.goormgb.be.seat.seatHold.entity.SeatHold;
-import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,27 +21,18 @@ import lombok.RequiredArgsConstructor;
  * <ol>
  *   <li>SeatSession에서 ticketCount 조회</li>
  *   <li>Redis 분산 락 획득 (block_lock:{blockId})</li>
- *   <li>진짜 연석 탐색</li>
- *   <li>(fallback) nearAdjacentToggle이 true이면 준연석 탐색</li>
- *   <li>좌석 상태를 BLOCKED로 변경</li>
- *   <li>SeatHold 생성 (5분 TTL)</li>
- *   <li>락 해제</li>
+ *   <li>트랜잭션 내에서 좌석 배정 + Hold 생성</li>
+ *   <li>트랜잭션 커밋 후 락 해제</li>
  * </ol>
  */
 @Service
 @RequiredArgsConstructor
 public class SeatAssignmentService {
 
-	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
-
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	private final BlockRepository blockRepository;
-	private final MatchSeatRepository matchSeatRepository;
-	private final SeatHoldRepository seatHoldRepository;
-	private final RealConsecutiveFinder realConsecutiveFinder;
-	private final SemiConsecutiveFinder semiConsecutiveFinder;
 	private final SeatBlockLock seatBlockLock;
-	private final Clock clock;
+	private final SeatAssignmentTransactionalService seatAssignmentTransactionalService;
 
 	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockId,
 		boolean nearAdjacentToggle) {
@@ -68,76 +47,10 @@ public class SeatAssignmentService {
 		}
 
 		try {
-			return doAssignAndHold(userId, matchId, blockId, block, requiredSeats, nearAdjacentToggle);
+			return seatAssignmentTransactionalService.assignAndHold(
+				userId, matchId, blockId, block, requiredSeats, nearAdjacentToggle);
 		} finally {
 			seatBlockLock.unlock(blockId);
 		}
-	}
-
-	@Transactional
-	protected SeatAssignmentResponse doAssignAndHold(
-		Long userId, Long matchId, Long blockId, Block block,
-		int requiredSeats, boolean nearAdjacentToggle
-	) {
-		// 기존 Hold 정리 (재요청 시)
-		cleanupExistingHolds(userId, matchId);
-
-		// 1. 진짜 연석 탐색
-		var realResult = realConsecutiveFinder.findBestRealConsecutive(matchId, blockId, requiredSeats);
-
-		if (realResult.isPresent()) {
-			SeatGroup seatGroup = realResult.get();
-			return holdSeats(userId, matchId, block, seatGroup.seats(), false);
-		}
-
-		// 2. 준연석 fallback (toggle이 켜져 있는 경우에만)
-		if (nearAdjacentToggle) {
-			var semiResult = semiConsecutiveFinder.findBestSemiConsecutive(matchId, blockId, requiredSeats);
-
-			if (semiResult.isPresent()) {
-				SemiGroup semiGroup = semiResult.get();
-				return holdSeats(userId, matchId, block, semiGroup.allSeats(), true);
-			}
-		}
-
-		throw new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
-	}
-
-	private SeatAssignmentResponse holdSeats(
-		Long userId, Long matchId, Block block,
-		List<MatchSeat> seats, boolean semiConsecutive
-	) {
-		Instant expiresAt = clock.instant().plus(HOLD_TTL);
-
-		seats.forEach(MatchSeat::markBlocked);
-
-		List<SeatHold> holds = seats.stream()
-			.map(seat -> SeatHold.builder()
-				.matchSeatId(seat.getId())
-				.matchId(matchId)
-				.seatId(seat.getSeatId())
-				.userId(userId)
-				.expiresAt(expiresAt)
-				.build())
-			.toList();
-
-		seatHoldRepository.saveAll(holds);
-
-		return SeatAssignmentResponse.of(matchId, block, seats, expiresAt, semiConsecutive);
-	}
-
-	private void cleanupExistingHolds(Long userId, Long matchId) {
-		List<SeatHold> existingHolds = seatHoldRepository.findAllByUserIdAndMatchId(userId, matchId);
-
-		if (existingHolds.isEmpty()) {
-			return;
-		}
-
-		List<Long> matchSeatIds = existingHolds.stream().map(SeatHold::getMatchSeatId).toList();
-
-		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
-		seatsToRelease.forEach(MatchSeat::markAvailable);
-
-		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
@@ -1,0 +1,141 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 좌석 자동 배정의 트랜잭션 전담 서비스.
+ *
+ * <p>{@link SeatAssignmentService}에서 분산 락을 획득한 뒤 호출되며,
+ * 별도 빈으로 분리하여 {@code @Transactional} AOP 프록시가 정상 동작하고
+ * 트랜잭션 커밋이 락 해제보다 먼저 완료되도록 보장한다.</p>
+ *
+ * <h3>처리 흐름</h3>
+ * <ol>
+ *   <li>기존 Hold 정리 (재요청 시)</li>
+ *   <li>진짜 연석 탐색 ({@link RealConsecutiveFinder})</li>
+ *   <li>(fallback) nearAdjacentToggle이 true이면 준연석 탐색 ({@link SemiConsecutiveFinder})</li>
+ *   <li>좌석 상태를 BLOCKED로 변경</li>
+ *   <li>SeatHold 생성 (5분 TTL)</li>
+ * </ol>
+ */
+@Service
+@RequiredArgsConstructor
+public class SeatAssignmentTransactionalService {
+
+	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+
+	private final MatchSeatRepository matchSeatRepository;
+	private final SeatHoldRepository seatHoldRepository;
+	private final RealConsecutiveFinder realConsecutiveFinder;
+	private final SemiConsecutiveFinder semiConsecutiveFinder;
+	private final Clock clock;
+
+	/**
+	 * 블럭 내 최적 연석을 탐색하여 좌석을 배정하고 Hold를 생성한다.
+	 *
+	 * <p>진짜 연석을 우선 탐색하고, 없으면 준연석으로 fallback한다.
+	 * 이 메서드는 반드시 분산 락이 획득된 상태에서 호출되어야 한다.</p>
+	 *
+	 * @param userId              사용자 ID
+	 * @param matchId             경기 ID
+	 * @param blockId             블럭 ID
+	 * @param block               블럭 엔티티 (섹션 정보 포함)
+	 * @param requiredSeats       필요 좌석 수
+	 * @param nearAdjacentToggle  준연석 허용 여부
+	 * @return 배정된 좌석 정보 및 Hold 만료 시각
+	 * @throws CustomException 연석/준연석 모두 없을 경우 {@code NO_CONSECUTIVE_SEAT_AVAILABLE}
+	 */
+	@Transactional
+	public SeatAssignmentResponse assignAndHold(
+		Long userId, Long matchId, Long blockId, Block block,
+		int requiredSeats, boolean nearAdjacentToggle
+	) {
+		cleanupExistingHolds(userId, matchId);
+
+		var realResult = realConsecutiveFinder.findBestRealConsecutive(matchId, blockId, requiredSeats);
+
+		if (realResult.isPresent()) {
+			SeatGroup seatGroup = realResult.get();
+			return holdSeats(userId, matchId, block, seatGroup.seats(), false);
+		}
+
+		if (nearAdjacentToggle) {
+			var semiResult = semiConsecutiveFinder.findBestSemiConsecutive(matchId, blockId, requiredSeats);
+
+			if (semiResult.isPresent()) {
+				SemiGroup semiGroup = semiResult.get();
+				return holdSeats(userId, matchId, block, semiGroup.allSeats(), true);
+			}
+		}
+
+		throw new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+
+	/**
+	 * 탐색된 좌석들의 상태를 BLOCKED로 변경하고 SeatHold 레코드를 생성한다.
+	 */
+	private SeatAssignmentResponse holdSeats(
+		Long userId, Long matchId, Block block,
+		List<MatchSeat> seats, boolean semiConsecutive
+	) {
+		Instant expiresAt = clock.instant().plus(HOLD_TTL);
+
+		seats.forEach(MatchSeat::markBlocked);
+
+		List<SeatHold> holds = seats.stream()
+			.map(seat -> SeatHold.builder()
+				.matchSeatId(seat.getId())
+				.matchId(matchId)
+				.seatId(seat.getSeatId())
+				.userId(userId)
+				.expiresAt(expiresAt)
+				.build())
+			.toList();
+
+		seatHoldRepository.saveAll(holds);
+
+		return SeatAssignmentResponse.of(matchId, block, seats, expiresAt, semiConsecutive);
+	}
+
+	/**
+	 * 사용자의 기존 Hold를 정리한다.
+	 *
+	 * <p>재요청 시 이전 Hold의 좌석을 AVAILABLE로 복원하고 Hold 레코드를 삭제한다.
+	 * delete 후 flush()를 호출하여 JPA flush 순서(INSERT → DELETE)로 인한
+	 * unique constraint violation을 방지한다.</p>
+	 */
+	private void cleanupExistingHolds(Long userId, Long matchId) {
+		List<SeatHold> existingHolds = seatHoldRepository.findAllByUserIdAndMatchId(userId, matchId);
+
+		if (existingHolds.isEmpty()) {
+			return;
+		}
+
+		List<Long> matchSeatIds = existingHolds.stream().map(SeatHold::getMatchSeatId).toList();
+
+		List<MatchSeat> seatsToRelease = matchSeatRepository.findAllById(matchSeatIds);
+		seatsToRelease.forEach(MatchSeat::markAvailable);
+
+		seatHoldRepository.deleteAllByMatchSeatIdIn(matchSeatIds);
+		seatHoldRepository.flush();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -20,60 +19,24 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
-import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
-import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
-import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
-import com.goormgb.be.seat.seat.enums.SeatZone;
-import com.goormgb.be.seat.seatHold.entity.SeatHold;
-import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldServiceTest {
 
 	private static final Long USER_ID = 7L;
 	private static final Long MATCH_ID = 10L;
-	private static final Instant NOW = Instant.parse("2026-04-15T10:00:00Z");
 
 	@Mock
 	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	@Mock
-	private MatchSeatRepository matchSeatRepository;
-	@Mock
-	private SeatHoldRepository seatHoldRepository;
-	@Mock
 	private SeatHoldLockManager seatHoldLockManager;
 	@Mock
-	private Clock clock;
+	private SeatHoldTransactionalService seatHoldTransactionalService;
 
 	@InjectMocks
 	private SeatHoldService seatHoldService;
-
-	private MatchSeat matchSeat(Long seatId, MatchSeatSaleStatus status) {
-		return MatchSeat.builder()
-			.matchId(MATCH_ID)
-			.seatId(seatId)
-			.areaId(1L)
-			.sectionId(1L)
-			.blockId(1L)
-			.rowNo(1)
-			.seatNo(seatId.intValue())
-			.templateColNo(seatId.intValue())
-			.seatZone(SeatZone.LOW)
-			.saleStatus(status)
-			.build();
-	}
-
-	private SeatHold seatHold(Long matchSeatId, Long seatId, Long userId, Instant expiresAt) {
-		return SeatHold.builder()
-			.matchSeatId(matchSeatId)
-			.matchId(MATCH_ID)
-			.seatId(seatId)
-			.userId(userId)
-			.expiresAt(expiresAt)
-			.build();
-	}
 
 	private void setupSession(int ticketCount) {
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
@@ -93,30 +56,45 @@ class SeatHoldServiceTest {
 	}
 
 	@Test
-	@DisplayName("동일 좌석 재요청이면 hold 만료시간을 연장한다")
-	void 동일_좌석_재요청_만료_연장() {
+	@DisplayName("seatIds가 null이면 INVALID_SEAT_HOLD_REQUEST 예외가 발생한다")
+	void null_좌석_요청_예외() {
+		// when & then
+		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, null))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_SEAT_HOLD_REQUEST);
+
+		verifyNoInteractions(seatHoldLockManager);
+	}
+
+	@Test
+	@DisplayName("티켓 수와 좌석 수가 다르면 INVALID_SEAT_HOLD_REQUEST 예외가 발생한다")
+	void 티켓수_불일치_예외() {
+		// given
+		setupSession(3);
+
+		// when & then
+		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(1L, 2L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.INVALID_SEAT_HOLD_REQUEST);
+
+		verifyNoInteractions(seatHoldLockManager);
+	}
+
+	@Test
+	@DisplayName("정상 요청 시 락 획득 후 트랜잭션 서비스를 호출하고 락을 해제한다")
+	void 정상_요청_락_트랜잭션_순서() {
 		// given
 		setupSession(2);
-		given(clock.instant()).willReturn(NOW);
 		RLock lock1 = mock(RLock.class);
 		RLock lock2 = mock(RLock.class);
 		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
 
-		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
-			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
-				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
-		given(
-			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
-				any()))
-			.willReturn(List.of(
-				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
-				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
-			));
-		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
-			.willReturn(List.of(
-				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
-				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
-			));
+		SeatHoldCreateResponse expectedResponse = SeatHoldCreateResponse.of(
+			MATCH_ID, List.of(206313L, 206314L), Instant.parse("2026-04-15T10:05:00Z"));
+		given(seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(expectedResponse);
 
 		// when
 		SeatHoldCreateResponse response = seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID,
@@ -125,66 +103,22 @@ class SeatHoldServiceTest {
 		// then
 		assertThat(response.matchId()).isEqualTo(MATCH_ID);
 		assertThat(response.seatCount()).isEqualTo(2);
-		assertThat(response.holdExpiresAt()).isEqualTo(NOW.plusSeconds(300));
-		verify(seatHoldRepository, never()).saveAll(anyList());
-		verify(seatHoldRepository, never()).deleteAllByMatchSeatIdIn(anyList());
-		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
+
+		then(seatHoldTransactionalService).should().createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L));
+		then(seatHoldLockManager).should().unlockAll(List.of(lock1, lock2));
 	}
 
 	@Test
-	@DisplayName("기존 hold와 다른 좌석 요청이면 기존 hold를 해제하고 신규 hold를 생성한다")
-	void 다른_좌석_요청시_교체_성공() {
+	@DisplayName("트랜잭션 서비스에서 예외 발생 시에도 락이 해제된다")
+	void 트랜잭션_예외시_락_해제() {
 		// given
 		setupSession(2);
-		given(clock.instant()).willReturn(NOW);
 		RLock lock1 = mock(RLock.class);
 		RLock lock2 = mock(RLock.class);
 		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
 
-		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
-			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
-				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
-		given(
-			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
-				any()))
-			.willReturn(List.of());
-		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
-			.willReturn(List.of(
-				seatHold(11L, 205000L, USER_ID, NOW.plusSeconds(60)),
-				seatHold(12L, 205001L, USER_ID, NOW.plusSeconds(60))
-			));
-		given(matchSeatRepository.findAllById(List.of(11L, 12L)))
-			.willReturn(List.of(matchSeat(205000L, MatchSeatSaleStatus.BLOCKED),
-				matchSeat(205001L, MatchSeatSaleStatus.BLOCKED)));
-
-		// when
-		SeatHoldCreateResponse response = seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID,
-			List.of(206313L, 206314L));
-
-		// then
-		assertThat(response.seatIds()).containsExactly(206313L, 206314L);
-		verify(seatHoldRepository).deleteAllByMatchSeatIdIn(List.of(11L, 12L));
-		verify(seatHoldRepository).saveAll(anyList());
-		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
-	}
-
-	@Test
-	@DisplayName("타 사용자 활성 hold가 있으면 SEAT_ALREADY_HELD_BY_OTHER 예외가 발생한다")
-	void 타사용자_선점_충돌_예외() {
-		// given
-		setupSession(2);
-		given(clock.instant()).willReturn(NOW);
-		RLock lock1 = mock(RLock.class);
-		RLock lock2 = mock(RLock.class);
-		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
-
-		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
-			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
-				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
-		given(
-			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
-				any()))
-			.willReturn(List.of(seatHold(1L, 206313L, 999L, NOW.plusSeconds(60))));
+		given(seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.willThrow(new CustomException(ErrorCode.SEAT_ALREADY_HELD_BY_OTHER));
 
 		// when & then
 		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
@@ -192,7 +126,6 @@ class SeatHoldServiceTest {
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
 
-		verify(seatHoldLockManager).unlockAll(List.of(lock1, lock2));
-		verify(seatHoldRepository, never()).saveAll(anyList());
+		then(seatHoldLockManager).should().unlockAll(List.of(lock1, lock2));
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
@@ -1,0 +1,195 @@
+package com.goormgb.be.seat.common.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldTransactionalServiceTest {
+
+	private static final Long USER_ID = 7L;
+	private static final Long MATCH_ID = 10L;
+	private static final Instant NOW = Instant.parse("2026-04-15T10:00:00Z");
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private SeatHoldTransactionalService seatHoldTransactionalService;
+
+	private MatchSeat matchSeat(Long seatId, MatchSeatSaleStatus status) {
+		return MatchSeat.builder()
+			.matchId(MATCH_ID)
+			.seatId(seatId)
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(1)
+			.seatNo(seatId.intValue())
+			.templateColNo(seatId.intValue())
+			.seatZone(SeatZone.LOW)
+			.saleStatus(status)
+			.build();
+	}
+
+	private SeatHold seatHold(Long matchSeatId, Long seatId, Long userId, Instant expiresAt) {
+		return SeatHold.builder()
+			.matchSeatId(matchSeatId)
+			.matchId(MATCH_ID)
+			.seatId(seatId)
+			.userId(userId)
+			.expiresAt(expiresAt)
+			.build();
+	}
+
+	@Test
+	@DisplayName("동일 좌석 재요청이면 hold 만료시간을 연장한다")
+	void 동일_좌석_재요청_만료_연장() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of(
+				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
+			));
+		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
+			.willReturn(List.of(
+				seatHold(1L, 206313L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(2L, 206314L, USER_ID, NOW.plusSeconds(60))
+			));
+
+		// when
+		SeatHoldCreateResponse response = seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID,
+			List.of(206313L, 206314L));
+
+		// then
+		assertThat(response.matchId()).isEqualTo(MATCH_ID);
+		assertThat(response.seatCount()).isEqualTo(2);
+		assertThat(response.holdExpiresAt()).isEqualTo(NOW.plusSeconds(300));
+		verify(seatHoldRepository, never()).saveAll(anyList());
+		verify(seatHoldRepository, never()).deleteAllByMatchSeatIdIn(anyList());
+	}
+
+	@Test
+	@DisplayName("기존 hold와 다른 좌석 요청이면 기존 hold를 해제하고 신규 hold를 생성한다")
+	void 다른_좌석_요청시_교체_성공() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of());
+		given(seatHoldRepository.findAllByUserIdAndMatchIdAndExpiresAtAfter(eq(USER_ID), eq(MATCH_ID), any()))
+			.willReturn(List.of(
+				seatHold(11L, 205000L, USER_ID, NOW.plusSeconds(60)),
+				seatHold(12L, 205001L, USER_ID, NOW.plusSeconds(60))
+			));
+		given(matchSeatRepository.findAllById(List.of(11L, 12L)))
+			.willReturn(List.of(matchSeat(205000L, MatchSeatSaleStatus.BLOCKED),
+				matchSeat(205001L, MatchSeatSaleStatus.BLOCKED)));
+
+		// when
+		SeatHoldCreateResponse response = seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID,
+			List.of(206313L, 206314L));
+
+		// then
+		assertThat(response.seatIds()).containsExactly(206313L, 206314L);
+		verify(seatHoldRepository).deleteAllByMatchSeatIdIn(List.of(11L, 12L));
+		verify(seatHoldRepository).flush();
+		verify(seatHoldRepository).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("타 사용자 활성 hold가 있으면 SEAT_ALREADY_HELD_BY_OTHER 예외가 발생한다")
+	void 타사용자_선점_충돌_예외() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+		given(
+			seatHoldRepository.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(eq(MATCH_ID), eq(List.of(206313L, 206314L)),
+				any()))
+			.willReturn(List.of(seatHold(1L, 206313L, 999L, NOW.plusSeconds(60))));
+
+		// when & then
+		assertThatThrownBy(
+			() -> seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SEAT_ALREADY_HELD_BY_OTHER);
+
+		verify(seatHoldRepository, never()).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("이미 판매된 좌석이 포함되면 SEAT_ALREADY_SOLD 예외가 발생한다")
+	void 판매완료_좌석_예외() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.SOLD),
+				matchSeat(206314L, MatchSeatSaleStatus.AVAILABLE)));
+
+		// when & then
+		assertThatThrownBy(
+			() -> seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.SEAT_ALREADY_SOLD);
+	}
+
+	@Test
+	@DisplayName("요청한 좌석이 DB에 없으면 MATCH_SEAT_NOT_FOUND 예외가 발생한다")
+	void 좌석_미존재_예외() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		given(matchSeatRepository.findAllByMatchIdAndSeatIdIn(MATCH_ID, List.of(206313L, 206314L)))
+			.willReturn(List.of(matchSeat(206313L, MatchSeatSaleStatus.AVAILABLE)));
+
+		// when & then
+		assertThatThrownBy(
+			() -> seatHoldTransactionalService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(206313L, 206314L)))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.MATCH_SEAT_NOT_FOUND);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -3,10 +3,8 @@ package com.goormgb.be.seat.recommendation.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,16 +18,9 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.fixture.BlockFixture;
-import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
-import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
-import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
-import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
-import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
-import com.goormgb.be.seat.seat.enums.SeatZone;
-import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SeatAssignmentServiceTest {
@@ -39,107 +30,38 @@ class SeatAssignmentServiceTest {
 	@Mock
 	private BlockRepository blockRepository;
 	@Mock
-	private MatchSeatRepository matchSeatRepository;
-	@Mock
-	private SeatHoldRepository seatHoldRepository;
-	@Mock
-	private RealConsecutiveFinder realConsecutiveFinder;
-	@Mock
-	private SemiConsecutiveFinder semiConsecutiveFinder;
-	@Mock
 	private SeatBlockLock seatBlockLock;
 	@Mock
-	private Clock clock;
+	private SeatAssignmentTransactionalService seatAssignmentTransactionalService;
 
 	@InjectMocks
 	private SeatAssignmentService seatAssignmentService;
 
-	private static final Instant FIXED_NOW = Instant.parse("2026-04-15T10:00:00Z");
-
-	private MatchSeat createSeat(int rowNo, int colNo) {
-		return MatchSeat.builder()
-			.matchId(1L)
-			.seatId((long)(rowNo * 100 + colNo))
-			.areaId(1L)
-			.sectionId(1L)
-			.blockId(1L)
-			.rowNo(rowNo)
-			.seatNo(colNo)
-			.templateColNo(colNo)
-			.seatZone(SeatZone.LOW)
-			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
-			.build();
-	}
-
 	private void setupCommon() {
 		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
-
-		Block block = BlockFixture.cpBlock();
-		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(block);
+		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
 		given(seatBlockLock.tryLock(1L)).willReturn(true);
-		given(seatHoldRepository.findAllByUserIdAndMatchId(1L, 1L)).willReturn(List.of());
-	}
-
-	private void setupClockForHold() {
-		given(clock.instant()).willReturn(FIXED_NOW);
 	}
 
 	@Test
-	@DisplayName("진짜 연석이 있으면 해당 좌석을 배정한다")
-	void 진짜_연석_배정_성공() {
+	@DisplayName("정상 요청 시 락 획득 후 트랜잭션 서비스를 호출하고 락을 해제한다")
+	void 정상_요청_락_트랜잭션_순서() {
 		// given
 		setupCommon();
-		setupClockForHold();
-		List<MatchSeat> seats = List.of(createSeat(1, 1), createSeat(1, 2), createSeat(1, 3));
-		SeatGroup seatGroup = new SeatGroup(seats, 1, 1, 3, 0);
-		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.of(seatGroup));
+		Block block = BlockFixture.cpBlock();
+		SeatAssignmentResponse expectedResponse = SeatAssignmentResponse.of(
+			1L, block, List.of(), Instant.parse("2026-04-15T10:05:00Z"), false);
+		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false)))
+			.willReturn(expectedResponse);
 
 		// when
 		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false);
 
 		// then
-		assertThat(response.assignedSeats()).hasSize(3);
-		assertThat(response.semiConsecutive()).isFalse();
-		assertThat(response.holdExpiresAt()).isAfter(FIXED_NOW);
-		verify(seatHoldRepository).saveAll(anyList());
-		verify(seatBlockLock).unlock(1L);
-	}
-
-	@Test
-	@DisplayName("진짜 연석이 없고 toggle ON이면 준연석으로 fallback한다")
-	void 준연석_fallback_성공() {
-		// given
-		setupCommon();
-		setupClockForHold();
-		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
-
-		List<MatchSeat> upperSeats = List.of(createSeat(1, 1), createSeat(1, 2));
-		List<MatchSeat> lowerSeats = List.of(createSeat(2, 1));
-		SemiGroup semiGroup = new SemiGroup(upperSeats, lowerSeats, 1, 2, 1, 0);
-		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.of(semiGroup));
-
-		// when
-		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, true);
-
-		// then
-		assertThat(response.assignedSeats()).hasSize(3);
-		assertThat(response.semiConsecutive()).isTrue();
-	}
-
-	@Test
-	@DisplayName("진짜 연석이 없고 toggle OFF이면 예외가 발생한다")
-	void toggle_OFF_연석없음_예외() {
-		// given
-		setupCommon();
-		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
-
-		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false))
-			.isInstanceOf(CustomException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
-		verify(seatBlockLock).unlock(1L);
+		assertThat(response).isNotNull();
+		then(seatAssignmentTransactionalService).should().assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false));
+		then(seatBlockLock).should().unlock(1L);
 	}
 
 	@Test
@@ -159,17 +81,19 @@ class SeatAssignmentServiceTest {
 	}
 
 	@Test
-	@DisplayName("진짜 연석도 준연석도 없으면 예외가 발생한다")
-	void 연석_준연석_모두_없음_예외() {
+	@DisplayName("트랜잭션 서비스에서 예외 발생 시에도 락이 해제된다")
+	void 트랜잭션_예외시_락_해제() {
 		// given
 		setupCommon();
-		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
-		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(), eq(3), eq(false)))
+			.willThrow(new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE));
 
 		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, true))
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+
+		then(seatBlockLock).should().unlock(1L);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
@@ -1,0 +1,146 @@
+package com.goormgb.be.seat.recommendation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
+import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
+import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
+import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatAssignmentTransactionalServiceTest {
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+	@Mock
+	private RealConsecutiveFinder realConsecutiveFinder;
+	@Mock
+	private SemiConsecutiveFinder semiConsecutiveFinder;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private SeatAssignmentTransactionalService service;
+
+	private static final Instant FIXED_NOW = Instant.parse("2026-04-15T10:00:00Z");
+
+	private MatchSeat createSeat(int rowNo, int colNo) {
+		return MatchSeat.builder()
+			.matchId(1L)
+			.seatId((long)(rowNo * 100 + colNo))
+			.areaId(1L)
+			.sectionId(1L)
+			.blockId(1L)
+			.rowNo(rowNo)
+			.seatNo(colNo)
+			.templateColNo(colNo)
+			.seatZone(SeatZone.LOW)
+			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
+			.build();
+	}
+
+	private void setupCommon() {
+		given(seatHoldRepository.findAllByUserIdAndMatchId(1L, 1L)).willReturn(List.of());
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 있으면 해당 좌석을 배정한다")
+	void 진짜_연석_배정_성공() {
+		// given
+		setupCommon();
+		given(clock.instant()).willReturn(FIXED_NOW);
+		List<MatchSeat> seats = List.of(createSeat(1, 1), createSeat(1, 2), createSeat(1, 3));
+		SeatGroup seatGroup = new SeatGroup(seats, 1, 1, 3, 0);
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.of(seatGroup));
+
+		Block block = BlockFixture.cpBlock();
+
+		// when
+		SeatAssignmentResponse response = service.assignAndHold(1L, 1L, 1L, block, 3, false);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(3);
+		assertThat(response.semiConsecutive()).isFalse();
+		assertThat(response.holdExpiresAt()).isAfter(FIXED_NOW);
+		verify(seatHoldRepository).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 없고 toggle ON이면 준연석으로 fallback한다")
+	void 준연석_fallback_성공() {
+		// given
+		setupCommon();
+		given(clock.instant()).willReturn(FIXED_NOW);
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		List<MatchSeat> upperSeats = List.of(createSeat(1, 1), createSeat(1, 2));
+		List<MatchSeat> lowerSeats = List.of(createSeat(2, 1));
+		SemiGroup semiGroup = new SemiGroup(upperSeats, lowerSeats, 1, 2, 1, 0);
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.of(semiGroup));
+
+		Block block = BlockFixture.cpBlock();
+
+		// when
+		SeatAssignmentResponse response = service.assignAndHold(1L, 1L, 1L, block, 3, true);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(3);
+		assertThat(response.semiConsecutive()).isTrue();
+	}
+
+	@Test
+	@DisplayName("진짜 연석이 없고 toggle OFF이면 예외가 발생한다")
+	void toggle_OFF_연석없음_예외() {
+		// given
+		setupCommon();
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		Block block = BlockFixture.cpBlock();
+
+		// when & then
+		assertThatThrownBy(() -> service.assignAndHold(1L, 1L, 1L, block, 3, false))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+
+	@Test
+	@DisplayName("진짜 연석도 준연석도 없으면 예외가 발생한다")
+	void 연석_준연석_모두_없음_예외() {
+		// given
+		setupCommon();
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
+
+		Block block = BlockFixture.cpBlock();
+
+		// when & then
+		assertThatThrownBy(() -> service.assignAndHold(1L, 1L, 1L, block, 3, true))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용

- 좌석 선점(Hold) 서비스의 **트랜잭션-락 경계 불일치 문제를 해결**했습니다.
- 기존에는 `@Transactional`이 걸린 메서드 내부에서 분산 락을 획득/해제하여, **트랜잭션 커밋 전에 락이 해제**되는 구조.
=> 이로 인해 다른 스레드가 커밋되지 않은 데이터를 읽을 수 있는 동시성 위험이 존재.
- 트랜잭션 로직을 별도 빈으로 분리하여, **커밋 완료 → 락 해제** 순서를 보장하도록 개선했습니다.

### 대상 서비스 (2곳)
| 서비스 | 문제 | 해결 |
|--------|------|------|
| `SeatHoldService` (일반 좌석 선점) | `@Transactional` 메서드 내부에서 lock/unlock → 커밋 전 unlock | `SeatHoldTransactionalService`로 트랜잭션 분리 |
| `SeatAssignmentService` (추천 배정) | 같은 클래스 내부 `@Transactional` 호출 → self-invocation으로 AOP 미적용 | `SeatAssignmentTransactionalService`로 트랜잭션 분리 |

### 부가 수정
- `SeatHoldLockManager` WAIT_TIME **100ms → 500ms** 상향: 피크 트래픽 시 네트워크 지연/DB 부하로 인한 불필요한 락 획득 실패 방지
- `releaseUserActiveHolds` / `cleanupExistingHolds`에 **`flush()` 추가**: JPA 기본 flush 순서(INSERT → UPDATE → DELETE)로 인해 delete 후 insert 시 `seat_holds` 테이블의 unique constraint violation 발생 가능성 방지

---

## 🧩 구현 상세
### 핵심: 트랜잭션-락 경계 분리 패턴

> **변경 전** — 락 해제와 커밋 순서가 뒤바뀌는 문제

| 순서 | 실행 주체 | 동작 | 상태 |
|:---:|:---:|------|:---:|
| 1 | Thread A | 🔒 락 획득 | |
| 2 | Thread A | DB 작업 (INSERT, UPDATE) | |
| 3 | Thread A | 🔓 락 해제 (finally) | ⚠️ 아직 커밋 안 됨 |
| 4 | Thread B | 🔒 락 획득 → DB 조회 | ❌ 커밋 전 데이터를 읽음 |
| 5 | Thread A | 트랜잭션 커밋 (AOP 프록시) | 너무 늦음 |

> **변경 후** — 트랜잭션을 별도 빈으로 분리하여 커밋 → 락 해제 순서 보장

| 순서 | 실행 주체 | 동작 | 상태 |
|:---:|:---:|------|:---:|
| 1 | Thread A | 🔒 락 획득 | |
| 2 | Thread A | 별도 빈의 `@Transactional` 메서드 호출 | |
| 3 | Thread A | DB 작업 (INSERT, UPDATE) | |
| 4 | Thread A | ✅ 트랜잭션 커밋 (별도 빈 리턴 시점) | 커밋 완료 |
| 5 | Thread A | 🔓 락 해제 (finally) | 안전 |
| 6 | Thread B | 🔒 락 획득 → DB 조회 | ✅ 커밋된 데이터를 읽음 |


### 트레이드오프
- **빈 분리로 인한 클래스 수 증가**: 각 서비스가 2개 클래스로 분리되어 파일 수가 증가하지만, Spring AOP의 self-invocation 한계를 우회하기 위한 표준 패턴이며, 역할(락 관리 / 트랜잭션 비즈니스 로직)이 명확하게 분리됨
- **WAIT_TIME 500ms**: 사용자 체감에 영향 없으면서(HTTP 응답 전체 ~600ms) 정상 요청의 실패율을 낮추는 균형점

---

### 📌 관련 Jira Issue

- GRGB-263

---

## 🧪 테스트 방법

### 테스트 대상

| 클래스 | 검증 포인트 |
|--------|-----------|
| `SeatHoldServiceTest` | 입력 검증(중복, null, 티켓 수 불일치), 락 획득 → 위임 → 락 해제 순서, 예외 시에도 unlock 보장 |
| `SeatHoldTransactionalServiceTest` | Hold 만료 연장, 좌석 교체(delete→save), 타 사용자 충돌, SOLD 예외, 좌석 미존재 예외, flush 호출 검증 |
| `SeatAssignmentServiceTest` | 락 획득 → 위임 → 락 해제 순서, 락 실패 예외, 예외 시에도 unlock 보장 |
| `SeatAssignmentTransactionalServiceTest` | 진짜 연석 배정, 준연석 fallback, toggle OFF 예외, 연석/준연석 모두 없음 예외 |

---

## ❗ 참고 사항

- **후속 작업 예정**: 추천 배정 시 일반 유저와의 충돌 감지를 위한 `markBlockedIfAvailable` 조건부 UPDATE 적용
- **리뷰 시 유의할 점**: `SeatAssignmentService`의 기존 `doAssignAndHold()`는 같은 클래스 내부 호출이라 `@Transactional`이 실제로 동작하지 않았을 가능성이 높습니다. 이번 분리로 해당 이슈도 함께 해소됩니다.