### PR TITLE
feat(queue): 큐 전용 Redis 분리 및 연결 설정 적용 [GRGB-265]

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-
+  # 1. 기존 캐시용 레디스 (6379)
   local-redis:
     image: redis:7
     container_name: goormgb-redis
@@ -32,7 +32,22 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  # 2. 추가된 큐 전용 레디스 (6380)
+  queue-redis:
+    image: redis:7
+    container_name: goormgb-redis-queue
+    ports:
+      - "6380:6379" # 외부 포트만 6380으로 매핑
+    platform: linux/arm64
+    networks:
+      - goormgb-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
+  
   api-gateway:
     build:
       context: ..
@@ -95,14 +110,14 @@ services:
       DB_URL: jdbc:postgresql://local-postgres:5432/goormgb
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
-      REDIS_HOST: local-redis
+      REDIS_HOST: queue-redis
       REDIS_PORT: 6379
       JWT_PRIVATE_KEY: ${JWT_PRIVATE_KEY}
       JWT_PUBLIC_KEY: ${JWT_PUBLIC_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy
-      local-redis:
+      queue-redis:
         condition: service_healthy
     networks:
       - goormgb-network


### PR DESCRIPTION
 ## 🔧 작업 내용

  - Queue 모듈의 Redis 연결을 기존 공용 Redis와 분리하고, 큐 전용 Redis를 사용하도록 설정.
  - 대기열 트래픽이 다른 모듈의 Redis 사용과 섞이지 않도록 분리.
  - 로컬 실행과 Docker 실행 모두 Queue가 별도 Redis를 바라보도록 설정.

  ## 🧩 구현 상세

  - application-local.yaml에서 Queue 모듈의 Redis 포트를 6380으로 설정.
  - docker-compose.yml에 큐 전용 Redis 컨테이너를 추가하고, Queue 서비스가 해당 Redis를 사용하도록 변경.
  - 검증 과정에서 IntelliJ 실행 환경변수가 기존 Redis 포트를 바라보고 있어, 실행 설정도 함께 수정해 큐 전용 Redis 연결을 확인.

  ### 📌 관련 Jira Issue

  - GRGB-265

  ## 🧪 테스트 방법

  - 대상: Queue 모듈 Redis 연결 대상
  - 체크 포인트:
      - Queue 실행 후 goormgb-redis-queue에 queue 관련 key가 생성되는지 확인
      - 기존 goormgb-redis에는 queue 관련 명령이 기록되지 않는지 확인
      - REDIS_PORT=6380 설정 후 대기열 API가 정상 동작하는지 확인
      
<img width="401" height="567" alt="image" src="https://github.com/user-attachments/assets/47258152-4bb9-43ae-8207-608a952ec2ad" />


  ## ❗ 참고 사항

  - Queue 모듈만 큐 전용 Redis를 사용하고, 다른 모듈은 기존 Redis를 그대로 사용.
  - (로컬)IntelliJ에서 Queue 모듈을 직접 실행할 경우 REDIS_PORT=6380이 반영.
  - IntelliJ에서 실행 시
 
<img width="340" height="67" alt="image" src="https://github.com/user-attachments/assets/8334ccfe-c32d-45c1-b11b-2ec3bcf363bf" />
