### PR TITLE
feat(seat): 추천 배정 시 조건부 UPDATE 기반 충돌 감지 및 재탐색 로직 구현 [GRGB-262]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -68,18 +68,18 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 	int markBlockedIfAvailable(@Param("matchSeatId") Long matchSeatId);
 
 	/**
-	 * 좌석이 BLOCKED 상태일 때만 AVAILABLE로 복원한다.
+	 * BLOCKED 상태인 좌석들을 일괄로 AVAILABLE로 복원한다.
 	 *
-	 * <p>충돌 감지 시 이미 BLOCKED로 변경한 좌석을 롤백하기 위해 사용한다.</p>
+	 * <p>충돌 감지 시 이미 BLOCKED로 변경한 좌석들을 한 번의 쿼리로 롤백한다.</p>
 	 *
-	 * @return 변경된 행 수 (0 또는 1)
+	 * @return 변경된 행 수
 	 */
 	@Modifying(clearAutomatically = true)
 	@Query("""
 		UPDATE MatchSeat ms
 		SET ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.AVAILABLE
-		WHERE ms.id = :matchSeatId
+		WHERE ms.id IN :matchSeatIds
 		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.BLOCKED
 		""")
-	int markAvailableIfBlocked(@Param("matchSeatId") Long matchSeatId);
+	int markAvailableIfBlockedInBatch(@Param("matchSeatIds") List<Long> matchSeatIds);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -3,6 +3,7 @@ package com.goormgb.be.seat.matchSeat.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -48,4 +49,37 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 	);
 
 	List<MatchSeat> findAllByMatchIdAndSeatIdIn(Long matchId, List<Long> seatIds);
+
+	/**
+	 * 좌석이 AVAILABLE 상태일 때만 BLOCKED로 변경한다.
+	 *
+	 * <p>DB row-level lock이 원자성을 보장하므로 동시 요청 시에도 1명만 성공한다.
+	 * 반환값이 0이면 다른 유저가 이미 선점한 것으로 판단한다.</p>
+	 *
+	 * @return 변경된 행 수 (0 또는 1)
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("""
+		UPDATE MatchSeat ms
+		SET ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.BLOCKED
+		WHERE ms.id = :matchSeatId
+		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.AVAILABLE
+		""")
+	int markBlockedIfAvailable(@Param("matchSeatId") Long matchSeatId);
+
+	/**
+	 * 좌석이 BLOCKED 상태일 때만 AVAILABLE로 복원한다.
+	 *
+	 * <p>충돌 감지 시 이미 BLOCKED로 변경한 좌석을 롤백하기 위해 사용한다.</p>
+	 *
+	 * @return 변경된 행 수 (0 또는 1)
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("""
+		UPDATE MatchSeat ms
+		SET ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.AVAILABLE
+		WHERE ms.id = :matchSeatId
+		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.BLOCKED
+		""")
+	int markAvailableIfBlocked(@Param("matchSeatId") Long matchSeatId);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -2,8 +2,8 @@ package com.goormgb.be.seat.recommendation.service;
 
 import org.springframework.stereotype.Service;
 
-import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
  * <h3>처리 흐름</h3>
  * <ol>
  *   <li>SeatSession에서 ticketCount 조회</li>
- *   <li>Redis 분산 락 획득 (block_lock:{blockId})</li>
+ *   <li>Redis 분산 락 획득 (seat:recommendation:match:{matchId}:block:{blockId})</li>
  *   <li>트랜잭션 내에서 좌석 배정 + Hold 생성</li>
  *   <li>트랜잭션 커밋 후 락 해제</li>
  * </ol>
@@ -42,15 +42,13 @@ public class SeatAssignmentService {
 
 		Block block = blockRepository.findByIdWithSectionOrThrow(blockId);
 
-		if (!seatBlockLock.tryLock(blockId)) {
-			throw new CustomException(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
-		}
+		Preconditions.validate(seatBlockLock.tryLock(matchId, blockId), ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
 
 		try {
 			return seatAssignmentTransactionalService.assignAndHold(
 				userId, matchId, blockId, block, requiredSeats, nearAdjacentToggle);
 		} finally {
-			seatBlockLock.unlock(blockId);
+			seatBlockLock.unlock(matchId, blockId);
 		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
@@ -3,7 +3,9 @@ package com.goormgb.be.seat.recommendation.service;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import com.goormgb.be.seat.seatHold.entity.SeatHold;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 좌석 자동 배정의 트랜잭션 전담 서비스.
@@ -31,17 +34,19 @@ import lombok.RequiredArgsConstructor;
  * <h3>처리 흐름</h3>
  * <ol>
  *   <li>기존 Hold 정리 (재요청 시)</li>
- *   <li>진짜 연석 탐색 ({@link RealConsecutiveFinder})</li>
- *   <li>(fallback) nearAdjacentToggle이 true이면 준연석 탐색 ({@link SemiConsecutiveFinder})</li>
- *   <li>좌석 상태를 BLOCKED로 변경</li>
+ *   <li>진짜 연석 탐색 → 충돌 시 재탐색 (최대 {@value #MAX_RETRY}회)</li>
+ *   <li>(fallback) 준연석 탐색 → 충돌 시 재탐색 (최대 {@value #MAX_RETRY}회)</li>
+ *   <li>조건부 UPDATE로 좌석 상태를 BLOCKED로 변경 (일반 유저 충돌 감지)</li>
  *   <li>SeatHold 생성 (5분 TTL)</li>
  * </ol>
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatAssignmentTransactionalService {
 
 	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+	private static final int MAX_RETRY = 3;
 
 	private final MatchSeatRepository matchSeatRepository;
 	private final SeatHoldRepository seatHoldRepository;
@@ -52,7 +57,8 @@ public class SeatAssignmentTransactionalService {
 	/**
 	 * 블럭 내 최적 연석을 탐색하여 좌석을 배정하고 Hold를 생성한다.
 	 *
-	 * <p>진짜 연석을 우선 탐색하고, 없으면 준연석으로 fallback한다.
+	 * <p>진짜 연석을 우선 탐색하고, 충돌 발생 시 다른 연석 구간을 재탐색한다.
+	 * 진짜 연석이 모두 소진되면 준연석으로 fallback하며, 준연석도 동일하게 재탐색한다.
 	 * 이 메서드는 반드시 분산 락이 획득된 상태에서 호출되어야 한다.</p>
 	 *
 	 * @param userId              사용자 ID
@@ -62,7 +68,7 @@ public class SeatAssignmentTransactionalService {
 	 * @param requiredSeats       필요 좌석 수
 	 * @param nearAdjacentToggle  준연석 허용 여부
 	 * @return 배정된 좌석 정보 및 Hold 만료 시각
-	 * @throws CustomException 연석/준연석 모두 없을 경우 {@code NO_CONSECUTIVE_SEAT_AVAILABLE}
+	 * @throws CustomException 연석/준연석 모두 없거나 재시도 소진 시 {@code NO_CONSECUTIVE_SEAT_AVAILABLE}
 	 */
 	@Transactional
 	public SeatAssignmentResponse assignAndHold(
@@ -71,19 +77,43 @@ public class SeatAssignmentTransactionalService {
 	) {
 		cleanupExistingHolds(userId, matchId);
 
-		var realResult = realConsecutiveFinder.findBestRealConsecutive(matchId, blockId, requiredSeats);
+		// 1. 진짜 연석 탐색 + 충돌 시 재탐색
+		for (int retry = 0; retry < MAX_RETRY; retry++) {
+			var realResult = realConsecutiveFinder.findBestRealConsecutive(matchId, blockId, requiredSeats);
 
-		if (realResult.isPresent()) {
+			if (realResult.isEmpty()) {
+				break;
+			}
+
 			SeatGroup seatGroup = realResult.get();
-			return holdSeats(userId, matchId, block, seatGroup.seats(), false);
+			var response = tryHoldSeats(userId, matchId, block, seatGroup.seats(), false);
+
+			if (response.isPresent()) {
+				return response.get();
+			}
+
+			log.info("진짜 연석 충돌 발생 - matchId: {}, blockId: {}, retry: {}/{}", matchId, blockId, retry + 1,
+				MAX_RETRY);
 		}
 
+		// 2. 준연석 탐색 + 충돌 시 재탐색
 		if (nearAdjacentToggle) {
-			var semiResult = semiConsecutiveFinder.findBestSemiConsecutive(matchId, blockId, requiredSeats);
+			for (int retry = 0; retry < MAX_RETRY; retry++) {
+				var semiResult = semiConsecutiveFinder.findBestSemiConsecutive(matchId, blockId, requiredSeats);
 
-			if (semiResult.isPresent()) {
+				if (semiResult.isEmpty()) {
+					break;
+				}
+
 				SemiGroup semiGroup = semiResult.get();
-				return holdSeats(userId, matchId, block, semiGroup.allSeats(), true);
+				var response = tryHoldSeats(userId, matchId, block, semiGroup.allSeats(), true);
+
+				if (response.isPresent()) {
+					return response.get();
+				}
+
+				log.info("준연석 충돌 발생 - matchId: {}, blockId: {}, retry: {}/{}", matchId, blockId, retry + 1,
+					MAX_RETRY);
 			}
 		}
 
@@ -91,15 +121,29 @@ public class SeatAssignmentTransactionalService {
 	}
 
 	/**
-	 * 탐색된 좌석들의 상태를 BLOCKED로 변경하고 SeatHold 레코드를 생성한다.
+	 * 조건부 UPDATE로 좌석 선점을 시도한다.
+	 *
+	 * <p>{@code markBlockedIfAvailable}을 사용하여 AVAILABLE 상태인 좌석만 변경한다.
+	 * 일반 유저가 먼저 선점한 좌석이 포함된 경우 이미 변경한 좌석을 롤백하고
+	 * {@code Optional.empty()}를 반환하여 호출부에서 재탐색하도록 유도한다.</p>
+	 *
+	 * @return 성공 시 배정 응답, 충돌 시 Optional.empty()
 	 */
-	private SeatAssignmentResponse holdSeats(
+	private Optional<SeatAssignmentResponse> tryHoldSeats(
 		Long userId, Long matchId, Block block,
 		List<MatchSeat> seats, boolean semiConsecutive
 	) {
 		Instant expiresAt = clock.instant().plus(HOLD_TTL);
 
-		seats.forEach(MatchSeat::markBlocked);
+		List<MatchSeat> blockedSeats = new ArrayList<>();
+		for (MatchSeat seat : seats) {
+			int updated = matchSeatRepository.markBlockedIfAvailable(seat.getId());
+			if (updated == 0) {
+				rollbackBlockedSeats(blockedSeats);
+				return Optional.empty();
+			}
+			blockedSeats.add(seat);
+		}
 
 		List<SeatHold> holds = seats.stream()
 			.map(seat -> SeatHold.builder()
@@ -113,7 +157,16 @@ public class SeatAssignmentTransactionalService {
 
 		seatHoldRepository.saveAll(holds);
 
-		return SeatAssignmentResponse.of(matchId, block, seats, expiresAt, semiConsecutive);
+		return Optional.of(SeatAssignmentResponse.of(matchId, block, seats, expiresAt, semiConsecutive));
+	}
+
+	/**
+	 * 충돌 감지 시 이미 BLOCKED로 변경한 좌석들을 AVAILABLE로 롤백한다.
+	 */
+	private void rollbackBlockedSeats(List<MatchSeat> blockedSeats) {
+		for (MatchSeat seat : blockedSeats) {
+			matchSeatRepository.markAvailableIfBlocked(seat.getId());
+		}
 	}
 
 	/**

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalService.java
@@ -161,12 +161,16 @@ public class SeatAssignmentTransactionalService {
 	}
 
 	/**
-	 * 충돌 감지 시 이미 BLOCKED로 변경한 좌석들을 AVAILABLE로 롤백한다.
+	 * 충돌 감지 시 이미 BLOCKED로 변경한 좌석들을 AVAILABLE로 일괄 롤백한다.
 	 */
 	private void rollbackBlockedSeats(List<MatchSeat> blockedSeats) {
-		for (MatchSeat seat : blockedSeats) {
-			matchSeatRepository.markAvailableIfBlocked(seat.getId());
+		if (blockedSeats.isEmpty()) {
+			return;
 		}
+		List<Long> idsToRollback = blockedSeats.stream()
+			.map(MatchSeat::getId)
+			.toList();
+		matchSeatRepository.markAvailableIfBlockedInBatch(idsToRollback);
 	}
 
 	/**

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatBlockLock.java
@@ -12,7 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Redisson 기반 블럭 단위 분산 락.
  *
- * <p>좌석 배정 시 동일 블럭에 대한 동시 접근을 방지한다.
+ * <p>좌석 배정 시 동일 경기의 동일 블럭에 대한 동시 접근을 방지한다.
+ * 락 키에 matchId를 포함하여 서로 다른 경기의 같은 blockId가 간섭하지 않도록 한다.
  * 락 획득에 실패하면 다른 사용자가 해당 블럭에서 좌석을 선택 중임을 의미한다.</p>
  *
  * <ul>
@@ -26,13 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SeatBlockLock {
 
-	private static final String LOCK_KEY_PREFIX = "block_lock:";
+	private static final String LOCK_KEY_FORMAT = "seat:recommendation:match:%d:block:%d";
 	private static final long WAIT_TIME_SECONDS = 3;
 
 	private final RedissonClient redissonClient;
 
-	public boolean tryLock(Long blockId) {
-		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
+	public boolean tryLock(Long matchId, Long blockId) {
+		RLock lock = redissonClient.getLock(buildKey(matchId, blockId));
 		try {
 			return lock.tryLock(WAIT_TIME_SECONDS, TimeUnit.SECONDS);
 		} catch (InterruptedException e) {
@@ -41,14 +42,18 @@ public class SeatBlockLock {
 		}
 	}
 
-	public void unlock(Long blockId) {
-		RLock lock = redissonClient.getLock(LOCK_KEY_PREFIX + blockId);
+	public void unlock(Long matchId, Long blockId) {
+		RLock lock = redissonClient.getLock(buildKey(matchId, blockId));
 		if (lock.isHeldByCurrentThread()) {
 			try {
 				lock.unlock();
 			} catch (Exception e) {
-				log.error("Failed to unlock seat block lock for blockId: {}", blockId, e);
+				log.error("블럭 분산 락 해제 실패 - matchId: {}, blockId: {}", matchId, blockId, e);
 			}
 		}
+	}
+
+	private String buildKey(Long matchId, Long blockId) {
+		return String.format(LOCK_KEY_FORMAT, matchId, blockId);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -12,8 +12,8 @@ import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
 import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
 import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
 import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
-import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
@@ -60,9 +60,7 @@ public class SeatRecommendationService {
 
 		List<BlockRecommendation> recommendations = buildRecommendations(matchId, ticketCount, preferredBlocks);
 
-		if (recommendations.isEmpty()) {
-			throw new CustomException(ErrorCode.NO_AVAILABLE_BLOCK);
-		}
+		Preconditions.validate(!recommendations.isEmpty(), ErrorCode.NO_AVAILABLE_BLOCK);
 
 		sortRecommendations(recommendations, pref, viewpoints, match);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -41,7 +41,7 @@ class SeatAssignmentServiceTest {
 		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
 		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L)).willReturn(true);
+		given(seatBlockLock.tryLock(1L, 1L)).willReturn(true);
 	}
 
 	@Test
@@ -61,7 +61,7 @@ class SeatAssignmentServiceTest {
 		// then
 		assertThat(response).isNotNull();
 		then(seatAssignmentTransactionalService).should().assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false));
-		then(seatBlockLock).should().unlock(1L);
+		then(seatBlockLock).should().unlock(1L, 1L);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class SeatAssignmentServiceTest {
 		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
 		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L)).willReturn(false);
+		given(seatBlockLock.tryLock(1L, 1L)).willReturn(false);
 
 		// when & then
 		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L, false))
@@ -94,6 +94,6 @@ class SeatAssignmentServiceTest {
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
 
-		then(seatBlockLock).should().unlock(1L);
+		then(seatBlockLock).should().unlock(1L, 1L);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
@@ -47,8 +48,8 @@ class SeatAssignmentTransactionalServiceTest {
 
 	private static final Instant FIXED_NOW = Instant.parse("2026-04-15T10:00:00Z");
 
-	private MatchSeat createSeat(int rowNo, int colNo) {
-		return MatchSeat.builder()
+	private MatchSeat createSeat(Long id, int rowNo, int colNo) {
+		MatchSeat seat = MatchSeat.builder()
 			.matchId(1L)
 			.seatId((long)(rowNo * 100 + colNo))
 			.areaId(1L)
@@ -60,6 +61,8 @@ class SeatAssignmentTransactionalServiceTest {
 			.seatZone(SeatZone.LOW)
 			.saleStatus(MatchSeatSaleStatus.AVAILABLE)
 			.build();
+		ReflectionTestUtils.setField(seat, "id", id);
+		return seat;
 	}
 
 	private void setupCommon() {
@@ -67,14 +70,15 @@ class SeatAssignmentTransactionalServiceTest {
 	}
 
 	@Test
-	@DisplayName("진짜 연석이 있으면 해당 좌석을 배정한다")
+	@DisplayName("진짜 연석이 있으면 조건부 UPDATE로 좌석을 배정한다")
 	void 진짜_연석_배정_성공() {
 		// given
 		setupCommon();
 		given(clock.instant()).willReturn(FIXED_NOW);
-		List<MatchSeat> seats = List.of(createSeat(1, 1), createSeat(1, 2), createSeat(1, 3));
+		List<MatchSeat> seats = List.of(createSeat(101L, 1, 1), createSeat(102L, 1, 2), createSeat(103L, 1, 3));
 		SeatGroup seatGroup = new SeatGroup(seats, 1, 1, 3, 0);
 		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.of(seatGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(anyLong())).willReturn(1);
 
 		Block block = BlockFixture.cpBlock();
 
@@ -85,6 +89,9 @@ class SeatAssignmentTransactionalServiceTest {
 		assertThat(response.assignedSeats()).hasSize(3);
 		assertThat(response.semiConsecutive()).isFalse();
 		assertThat(response.holdExpiresAt()).isAfter(FIXED_NOW);
+		verify(matchSeatRepository).markBlockedIfAvailable(101L);
+		verify(matchSeatRepository).markBlockedIfAvailable(102L);
+		verify(matchSeatRepository).markBlockedIfAvailable(103L);
 		verify(seatHoldRepository).saveAll(anyList());
 	}
 
@@ -96,10 +103,11 @@ class SeatAssignmentTransactionalServiceTest {
 		given(clock.instant()).willReturn(FIXED_NOW);
 		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3)).willReturn(Optional.empty());
 
-		List<MatchSeat> upperSeats = List.of(createSeat(1, 1), createSeat(1, 2));
-		List<MatchSeat> lowerSeats = List.of(createSeat(2, 1));
+		List<MatchSeat> upperSeats = List.of(createSeat(201L, 1, 1), createSeat(202L, 1, 2));
+		List<MatchSeat> lowerSeats = List.of(createSeat(203L, 2, 1));
 		SemiGroup semiGroup = new SemiGroup(upperSeats, lowerSeats, 1, 2, 1, 0);
 		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 3)).willReturn(Optional.of(semiGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(anyLong())).willReturn(1);
 
 		Block block = BlockFixture.cpBlock();
 
@@ -142,5 +150,121 @@ class SeatAssignmentTransactionalServiceTest {
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+	}
+
+	@Test
+	@DisplayName("충돌 발생 시 롤백 후 다른 연석 구간을 재탐색하여 배정한다")
+	void 충돌_후_재탐색_성공() {
+		// given
+		setupCommon();
+		given(clock.instant()).willReturn(FIXED_NOW);
+
+		// 1차 시도: 1열 1~3번 → 3번 좌석에서 충돌
+		List<MatchSeat> firstAttempt = List.of(createSeat(101L, 1, 1), createSeat(102L, 1, 2), createSeat(103L, 1, 3));
+		SeatGroup firstGroup = new SeatGroup(firstAttempt, 1, 1, 3, 0);
+
+		// 2차 시도: 2열 5~7번 → 성공
+		List<MatchSeat> secondAttempt = List.of(createSeat(205L, 2, 5), createSeat(206L, 2, 6), createSeat(207L, 2, 7));
+		SeatGroup secondGroup = new SeatGroup(secondAttempt, 2, 5, 7, 1);
+
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 3))
+			.willReturn(Optional.of(firstGroup))
+			.willReturn(Optional.of(secondGroup));
+
+		// 1차: seat1 성공, seat2 성공, seat3 충돌
+		given(matchSeatRepository.markBlockedIfAvailable(101L)).willReturn(1);
+		given(matchSeatRepository.markBlockedIfAvailable(102L)).willReturn(1);
+		given(matchSeatRepository.markBlockedIfAvailable(103L)).willReturn(0);
+		// 2차: 모두 성공
+		given(matchSeatRepository.markBlockedIfAvailable(205L)).willReturn(1);
+		given(matchSeatRepository.markBlockedIfAvailable(206L)).willReturn(1);
+		given(matchSeatRepository.markBlockedIfAvailable(207L)).willReturn(1);
+
+		Block block = BlockFixture.cpBlock();
+
+		// when
+		SeatAssignmentResponse response = service.assignAndHold(1L, 1L, 1L, block, 3, false);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(3);
+		assertThat(response.semiConsecutive()).isFalse();
+
+		// 1차 시도의 seat1, seat2 롤백 확인
+		verify(matchSeatRepository).markAvailableIfBlocked(101L);
+		verify(matchSeatRepository).markAvailableIfBlocked(102L);
+		verify(matchSeatRepository, never()).markAvailableIfBlocked(103L);
+
+		// finder가 2번 호출됨
+		verify(realConsecutiveFinder, times(2)).findBestRealConsecutive(1L, 1L, 3);
+		verify(seatHoldRepository).saveAll(anyList());
+	}
+
+	@Test
+	@DisplayName("진짜 연석 재시도 소진 후 준연석으로 fallback하여 성공한다")
+	void 진짜연석_재시도_소진_후_준연석_성공() {
+		// given
+		setupCommon();
+		given(clock.instant()).willReturn(FIXED_NOW);
+
+		// 진짜 연석: 3번 모두 충돌
+		List<MatchSeat> realSeats = List.of(createSeat(101L, 1, 1), createSeat(102L, 1, 2));
+		SeatGroup realGroup = new SeatGroup(realSeats, 1, 1, 2, 0);
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 2))
+			.willReturn(Optional.of(realGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(101L)).willReturn(0);
+
+		// 준연석: 성공
+		List<MatchSeat> upperSeats = List.of(createSeat(301L, 3, 1));
+		List<MatchSeat> lowerSeats = List.of(createSeat(401L, 4, 1));
+		SemiGroup semiGroup = new SemiGroup(upperSeats, lowerSeats, 3, 4, 1, 0);
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 2))
+			.willReturn(Optional.of(semiGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(301L)).willReturn(1);
+		given(matchSeatRepository.markBlockedIfAvailable(401L)).willReturn(1);
+
+		Block block = BlockFixture.cpBlock();
+
+		// when
+		SeatAssignmentResponse response = service.assignAndHold(1L, 1L, 1L, block, 2, true);
+
+		// then
+		assertThat(response.assignedSeats()).hasSize(2);
+		assertThat(response.semiConsecutive()).isTrue();
+
+		// 진짜 연석 3번 시도
+		verify(realConsecutiveFinder, times(3)).findBestRealConsecutive(1L, 1L, 2);
+		// 준연석 1번 시도 성공
+		verify(semiConsecutiveFinder, times(1)).findBestSemiConsecutive(1L, 1L, 2);
+	}
+
+	@Test
+	@DisplayName("진짜 연석, 준연석 모두 재시도 소진 시 예외가 발생한다")
+	void 모든_재시도_소진_예외() {
+		// given
+		setupCommon();
+		given(clock.instant()).willReturn(FIXED_NOW);
+
+		List<MatchSeat> seats = List.of(createSeat(101L, 1, 1));
+		SeatGroup realGroup = new SeatGroup(seats, 1, 1, 1, 0);
+		given(realConsecutiveFinder.findBestRealConsecutive(1L, 1L, 1))
+			.willReturn(Optional.of(realGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(101L)).willReturn(0);
+
+		List<MatchSeat> semiUpper = List.of(createSeat(201L, 2, 1));
+		SemiGroup semiGroup = new SemiGroup(semiUpper, List.of(), 2, 3, 0, 0);
+		given(semiConsecutiveFinder.findBestSemiConsecutive(1L, 1L, 1))
+			.willReturn(Optional.of(semiGroup));
+		given(matchSeatRepository.markBlockedIfAvailable(201L)).willReturn(0);
+
+		Block block = BlockFixture.cpBlock();
+
+		// when & then
+		assertThatThrownBy(() -> service.assignAndHold(1L, 1L, 1L, block, 1, true))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
+
+		verify(realConsecutiveFinder, times(3)).findBestRealConsecutive(1L, 1L, 1);
+		verify(semiConsecutiveFinder, times(3)).findBestSemiConsecutive(1L, 1L, 1);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
@@ -189,10 +189,8 @@ class SeatAssignmentTransactionalServiceTest {
 		assertThat(response.assignedSeats()).hasSize(3);
 		assertThat(response.semiConsecutive()).isFalse();
 
-		// 1차 시도의 seat1, seat2 롤백 확인
-		verify(matchSeatRepository).markAvailableIfBlocked(101L);
-		verify(matchSeatRepository).markAvailableIfBlocked(102L);
-		verify(matchSeatRepository, never()).markAvailableIfBlocked(103L);
+		// 1차 시도의 seat1, seat2 일괄 롤백 확인
+		verify(matchSeatRepository).markAvailableIfBlockedInBatch(List.of(101L, 102L));
 
 		// finder가 2번 호출됨
 		verify(realConsecutiveFinder, times(2)).findBestRealConsecutive(1L, 1L, 3);


### PR DESCRIPTION
## 🔧 작업 내용

- 추천 배정 시 일반 유저와의 **좌석 충돌을 감지**하도록 조건부 UPDATE(`markBlockedIfAvailable`) 적용
- 충돌 발생 시 즉시 실패 대신 **다른 연석 구간을 최대 3회 재탐색**하여 배정 성공률 향상
- `SeatBlockLock` 락 키에 `matchId`를 포함하여 **서로 다른 경기 간 락 간섭 방지**

## 🧩 구현 상세
### 이중 방어 전략: 분산 락 + 조건부 UPDATE

| 방어 계층 | 목적 | 메커니즘 |
|-----------|------|----------|
| **분산 락** (`SeatBlockLock`) | 추천 vs 추천 동시 접근 방지 | Redisson RLock (블럭 단위) |
| **조건부 UPDATE** (`markBlockedIfAvailable`) | 추천 vs 일반 유저 충돌 감지 | `UPDATE WHERE sale_status = 'AVAILABLE'` → 반환값 0이면 충돌 |

- 분산 락은 추천 배정끼리의 동시 접근을 막지만, 일반 유저는 별도 락(`SeatHoldLockManager`)을 사용하므로 블럭 락을 거치지 않음
- DB row-level lock 기반 조건부 UPDATE로 일반 유저가 먼저 선점한 좌석을 감지

### 충돌 시 재탐색 흐름
1. `tryHoldSeats`에서 좌석별로 `markBlockedIfAvailable` 실행
2. 반환값 0 → 이미 변경한 좌석을 `markAvailableIfBlocked`로 롤백 → `Optional.empty()` 반환
3. 호출부에서 finder를 다시 호출 (DB 쿼리가 BLOCKED 좌석을 자연스럽게 제외)
4. 진짜 연석 3회 → 준연석 3회까지 재시도 후 최종 실패 시 예외

### `SeatBlockLock` 키 변경
```
변경 전: block_lock:{blockId}
변경 후: seat:recommendation:match:{matchId}:block:{blockId}
```
- 서로 다른 경기의 동일 blockId가 같은 락을 공유하는 문제 해결

### 트레이드오프
- **`@Modifying(clearAutomatically = true)`**: 조건부 UPDATE 후 JPA 1차 캐시를 초기화하여 재시도 시 stale 데이터 방지. 매 쿼리마다 캐시가 클리어되는 비용이 있으나, 재시도 정합성이 더 중요
- **MAX_RETRY = 3**: 인기 응원석 블럭에서 충돌이 잦을 수 있으나, 3회면 대부분 빈 구간을 찾을 수 있고, 초과 시 사용자에게 즉시 피드백

### 📌 관련 Jira Issue
- GRGB-262

## 🧪 테스트 방법

| 클래스 | 검증 포인트 |
|--------|-------------|
| `SeatAssignmentTransactionalServiceTest` | 조건부 UPDATE로 좌석 배정, 준연석 fallback, toggle OFF 예외, 충돌 후 롤백+재탐색, 재시도 소진 후 준연석 성공, 모든 재시도 소진 예외 (6개 케이스) |
| `SeatAssignmentServiceTest` | 락 키에 matchId 포함 반영, tryLock/unlock 호출 검증 |

<img width="1050" height="424" alt="스크린샷 2026-03-17 오후 1 46 31" src="https://github.com/user-attachments/assets/dbfeff38-9f6d-467b-bac1-1ea9574ede2c" />

<img width="1088" height="543" alt="스크린샷 2026-03-17 오후 1 47 03" src="https://github.com/user-attachments/assets/23d1706a-fbf3-477e-bba8-851ca507985a" />

## ❗ 참고 사항
- **후속 작업 예정**: 분산락 통합 테스트 (추천 vs 일반 동시성 시나리오)
- **리뷰 시 유의할 점**: `tryHoldSeats`가 기존 `holdSeats`에서 반환 타입이 `Optional<SeatAssignmentResponse>`로 변경됨 — 충돌 시 예외 대신 empty 반환하여 호출부에서 재탐색 루프를 돌 수 있도록 설계