### PR TITLE
refactor(order-core): 결제 수단 VIRTUAL_ACCOUNT를 BANK_TRANSFER로 리네이밍

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
@@ -38,7 +38,7 @@ public class PaymentController {
 		summary = "결제 처리",
 		description = """
 			결제 수단을 선택하여 결제를 진행합니다.
-			- VIRTUAL_ACCOUNT: 가상계좌 발급, 입금 대기 상태 유지
+			- BANK_TRANSFER: 무통장 입금, 입금 대기 상태 유지
 			- TOSS_PAY / KAKAO_PAY: 즉시 결제 완료 처리 (목업)
 			""",
 		security = @SecurityRequirement(name = "BearerAuth")

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
@@ -13,10 +13,10 @@ public record PaymentProcessResponse(
 	PaymentMethod paymentMethod,
 	PaymentStatus paymentStatus,
 	Instant paidAt,
-	VirtualAccountInfo virtualAccount
+	AccountInfo account
 ) {
 
-	public record VirtualAccountInfo(
+	public record AccountInfo(
 		String bank,
 		String accountNumber,
 		String holder,
@@ -24,12 +24,12 @@ public record PaymentProcessResponse(
 	) {}
 
 	public static PaymentProcessResponse of(Payment payment) {
-		VirtualAccountInfo vaInfo = null;
-		if (payment.getVirtualAccountBank() != null) {
-			vaInfo = new VirtualAccountInfo(
-				payment.getVirtualAccountBank(),
-				payment.getVirtualAccountNumber(),
-				payment.getVirtualAccountHolder(),
+		AccountInfo accountInfo = null;
+		if (payment.getAccountBank() != null) {
+			accountInfo = new AccountInfo(
+				payment.getAccountBank(),
+				payment.getAccountNumber(),
+				payment.getAccountHolder(),
 				payment.getDepositDeadline()
 			);
 		}
@@ -40,7 +40,7 @@ public record PaymentProcessResponse(
 			payment.getPaymentMethod(),
 			payment.getStatus(),
 			payment.getPaidAt(),
-			vaInfo
+			accountInfo
 		);
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
@@ -24,13 +24,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
-	name = "payments",
-	indexes = {
-		@Index(name = "idx_payments_status", columnList = "status")
-	},
-	uniqueConstraints = {
-		@UniqueConstraint(name = "uk_payments_order_id", columnNames = {"order_id"})
-	}
+		name = "payments",
+		indexes = {
+				@Index(name = "idx_payments_status", columnList = "status")
+		},
+		uniqueConstraints = {
+				@UniqueConstraint(name = "uk_payments_order_id", columnNames = {"order_id"})
+		}
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,34 +51,34 @@ public class Payment extends BaseEntity {
 	@Column(name = "paid_at")
 	private Instant paidAt;
 
-	// 무통장 입금 전용 필드 (VIRTUAL_ACCOUNT 선택 시에만 값 존재)
-	@Column(name = "virtual_account_bank", length = 50)
-	private String virtualAccountBank;
+	// 무통장 입금 전용 필드 (BANK_TRANSFER 선택 시에만 값 존재)
+	@Column(name = "account_bank", length = 50)
+	private String accountBank;
 
-	@Column(name = "virtual_account_number", length = 50)
-	private String virtualAccountNumber;
+	@Column(name = "account_number", length = 50)
+	private String accountNumber;
 
-	@Column(name = "virtual_account_holder", length = 50)
-	private String virtualAccountHolder;
+	@Column(name = "account_holder", length = 50)
+	private String accountHolder;
 
 	@Column(name = "deposit_deadline")
 	private Instant depositDeadline;
 
 	@Builder
 	public Payment(
-		Order order,
-		PaymentMethod paymentMethod,
-		String virtualAccountBank,
-		String virtualAccountNumber,
-		String virtualAccountHolder,
-		Instant depositDeadline
+			Order order,
+			PaymentMethod paymentMethod,
+			String accountBank,
+			String accountNumber,
+			String accountHolder,
+			Instant depositDeadline
 	) {
 		this.order = order;
 		this.paymentMethod = paymentMethod;
 		this.status = PaymentStatus.PENDING;
-		this.virtualAccountBank = virtualAccountBank;
-		this.virtualAccountNumber = virtualAccountNumber;
-		this.virtualAccountHolder = virtualAccountHolder;
+		this.accountBank = accountBank;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
 		this.depositDeadline = depositDeadline;
 	}
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentMethod.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/enums/PaymentMethod.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PaymentMethod {
 
-	VIRTUAL_ACCOUNT("무통장 입금"),
+	BANK_TRANSFER("무통장 입금"),
 	TOSS_PAY("토스페이"),
 	KAKAO_PAY("카카오페이");
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -31,10 +31,11 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PaymentService {
 
-	// 무통장 입금 가상계좌 목업 정보
-	private static final String VIRTUAL_ACCOUNT_BANK = "국민은행";
-	private static final String VIRTUAL_ACCOUNT_HOLDER = "구름GB";
-	private static final int VIRTUAL_ACCOUNT_DEADLINE_DAYS = 3;
+	// 무통장 입금 목업 계좌 정보
+	private static final String ACCOUNT_BANK = "신한은행";
+	private static final String ACCOUNT_NUMBER = "110-123-456789";
+	private static final String ACCOUNT_HOLDER = "주식회사 구름공방";
+	private static final int DEPOSIT_DEADLINE_DAYS = 3;
 
 	private final OrderRepository orderRepository;
 	private final PaymentRepository paymentRepository;
@@ -42,32 +43,32 @@ public class PaymentService {
 
 	/**
 	 * 결제 처리.
-	 * - VIRTUAL_ACCOUNT: 가상계좌 발급(목업), 입금 대기 상태 유지
+	 * - BANK_TRANSFER: 무통장 입금 계좌 안내(목업), 입금 대기 상태 유지
 	 * - TOSS_PAY / KAKAO_PAY: 외부 PG 연동 없이 즉시 결제 완료 처리(목업)
 	 */
 	public PaymentProcessResponse processPayment(Long userId, Long orderId, PaymentProcessRequest request) {
 		Order order = findOrderAndValidateOwnership(userId, orderId);
 
 		Preconditions.validate(
-			order.getStatus() == OrderStatus.PAYMENT_PENDING,
-			ErrorCode.PAYMENT_ALREADY_COMPLETED
+				order.getStatus() == OrderStatus.PAYMENT_PENDING,
+				ErrorCode.PAYMENT_ALREADY_COMPLETED
 		);
 
 		Preconditions.validate(
-			!paymentRepository.findByOrderId(orderId).isPresent(),
-			ErrorCode.PAYMENT_ALREADY_COMPLETED
+				!paymentRepository.findByOrderId(orderId).isPresent(),
+				ErrorCode.PAYMENT_ALREADY_COMPLETED
 		);
 
 		Payment payment = buildPayment(order, request.paymentMethod());
 		paymentRepository.save(payment);
 
-		if (request.paymentMethod() != PaymentMethod.VIRTUAL_ACCOUNT) {
+		if (request.paymentMethod() != PaymentMethod.BANK_TRANSFER) {
 			// 간편결제(토스페이, 카카오페이) 목업 즉시 완료
 			payment.complete();
 			order.updateStatus(OrderStatus.PAID);
 			log.info("[PaymentService] 간편결제 완료(목업) - orderId={}, method={}", orderId, request.paymentMethod());
 		} else {
-			log.info("[PaymentService] 무통장 입금 가상계좌 발급 - orderId={}", orderId);
+			log.info("[PaymentService] 무통장 입금 계좌 안내 - orderId={}", orderId);
 		}
 
 		return PaymentProcessResponse.of(payment);
@@ -81,18 +82,18 @@ public class PaymentService {
 		Order order = findOrderAndValidateOwnership(userId, orderId);
 
 		Payment payment = paymentRepository.findByOrderId(orderId)
-			.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
 		Preconditions.validate(
-			!cashReceiptRepository.findByPaymentId(payment.getId()).isPresent(),
-			ErrorCode.CASH_RECEIPT_ALREADY_EXISTS
+				!cashReceiptRepository.findByPaymentId(payment.getId()).isPresent(),
+				ErrorCode.CASH_RECEIPT_ALREADY_EXISTS
 		);
 
 		CashReceipt cashReceipt = CashReceipt.builder()
-			.payment(payment)
-			.purpose(request.purpose())
-			.number(request.number())
-			.build();
+				.payment(payment)
+				.purpose(request.purpose())
+				.number(request.number())
+				.build();
 
 		cashReceiptRepository.save(cashReceipt);
 
@@ -103,38 +104,33 @@ public class PaymentService {
 
 	private Order findOrderAndValidateOwnership(Long userId, Long orderId) {
 		Order order = orderRepository.findById(orderId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 		Preconditions.validate(
-			order.getUser().getId().equals(userId),
-			ErrorCode.ORDER_ACCESS_DENIED
+				order.getUser().getId().equals(userId),
+				ErrorCode.ORDER_ACCESS_DENIED
 		);
 
 		return order;
 	}
 
 	private Payment buildPayment(Order order, PaymentMethod method) {
-		if (method == PaymentMethod.VIRTUAL_ACCOUNT) {
-			String mockAccountNumber = generateMockAccountNumber(order.getId());
-			Instant depositDeadline = Instant.now().plus(VIRTUAL_ACCOUNT_DEADLINE_DAYS, ChronoUnit.DAYS);
+		if (method == PaymentMethod.BANK_TRANSFER) {
+			Instant depositDeadline = Instant.now().plus(DEPOSIT_DEADLINE_DAYS, ChronoUnit.DAYS);
 
 			return Payment.builder()
-				.order(order)
-				.paymentMethod(method)
-				.virtualAccountBank(VIRTUAL_ACCOUNT_BANK)
-				.virtualAccountNumber(mockAccountNumber)
-				.virtualAccountHolder(VIRTUAL_ACCOUNT_HOLDER)
-				.depositDeadline(depositDeadline)
-				.build();
+					.order(order)
+					.paymentMethod(method)
+					.accountBank(ACCOUNT_BANK)
+					.accountNumber(ACCOUNT_NUMBER)
+					.accountHolder(ACCOUNT_HOLDER)
+					.depositDeadline(depositDeadline)
+					.build();
 		}
 
 		return Payment.builder()
-			.order(order)
-			.paymentMethod(method)
-			.build();
-	}
-
-	private String generateMockAccountNumber(Long orderId) {
-		return String.format("047-000-%08d", orderId);
+				.order(order)
+				.paymentMethod(method)
+				.build();
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/payment/PaymentFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/payment/PaymentFixture.java
@@ -18,24 +18,24 @@ public final class PaymentFixture {
 	private PaymentFixture() {
 	}
 
-	public static Payment createVirtualAccountPayment(Order order) {
+	public static Payment createBankTransferPayment(Order order) {
 		Payment payment = Payment.builder()
-			.order(order)
-			.paymentMethod(PaymentMethod.VIRTUAL_ACCOUNT)
-			.virtualAccountBank("국민은행")
-			.virtualAccountNumber("047-000-00000001")
-			.virtualAccountHolder("구름GB")
-			.depositDeadline(Instant.now().plus(3, ChronoUnit.DAYS))
-			.build();
+				.order(order)
+				.paymentMethod(PaymentMethod.BANK_TRANSFER)
+				.accountBank("신한은행")
+				.accountNumber("110-123-456789")
+				.accountHolder("주식회사 구름공방")
+				.depositDeadline(Instant.now().plus(3, ChronoUnit.DAYS))
+				.build();
 		ReflectionTestUtils.setField(payment, "id", 1L);
 		return payment;
 	}
 
 	public static Payment createCompletedTossPayPayment(Order order) {
 		Payment payment = Payment.builder()
-			.order(order)
-			.paymentMethod(PaymentMethod.TOSS_PAY)
-			.build();
+				.order(order)
+				.paymentMethod(PaymentMethod.TOSS_PAY)
+				.build();
 		ReflectionTestUtils.setField(payment, "id", 2L);
 		payment.complete();
 		return payment;
@@ -43,9 +43,9 @@ public final class PaymentFixture {
 
 	public static Payment createCompletedKakaoPayPayment(Order order) {
 		Payment payment = Payment.builder()
-			.order(order)
-			.paymentMethod(PaymentMethod.KAKAO_PAY)
-			.build();
+				.order(order)
+				.paymentMethod(PaymentMethod.KAKAO_PAY)
+				.build();
 		ReflectionTestUtils.setField(payment, "id", 3L);
 		payment.complete();
 		return payment;
@@ -53,26 +53,26 @@ public final class PaymentFixture {
 
 	public static CashReceipt createPersonalDeductionReceipt(Payment payment) {
 		CashReceipt cashReceipt = CashReceipt.builder()
-			.payment(payment)
-			.purpose(CashReceiptPurpose.PERSONAL_DEDUCTION)
-			.number("010-1234-5678")
-			.build();
+				.payment(payment)
+				.purpose(CashReceiptPurpose.PERSONAL_DEDUCTION)
+				.number("010-1234-5678")
+				.build();
 		ReflectionTestUtils.setField(cashReceipt, "id", 1L);
 		return cashReceipt;
 	}
 
 	public static CashReceipt createBusinessExpenseReceipt(Payment payment) {
 		CashReceipt cashReceipt = CashReceipt.builder()
-			.payment(payment)
-			.purpose(CashReceiptPurpose.BUSINESS_EXPENSE)
-			.number("123-45-67890")
-			.build();
+				.payment(payment)
+				.purpose(CashReceiptPurpose.BUSINESS_EXPENSE)
+				.number("123-45-67890")
+				.build();
 		ReflectionTestUtils.setField(cashReceipt, "id", 2L);
 		return cashReceipt;
 	}
 
-	public static PaymentProcessRequest createVirtualAccountRequest() {
-		return new PaymentProcessRequest(PaymentMethod.VIRTUAL_ACCOUNT);
+	public static PaymentProcessRequest createBankTransferRequest() {
+		return new PaymentProcessRequest(PaymentMethod.BANK_TRANSFER);
 	}
 
 	public static PaymentProcessRequest createTossPayRequest() {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
@@ -106,17 +106,17 @@ class PaymentControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("가상계좌 결제 성공 시 200과 가상계좌 정보를 반환한다")
-		void processPayment_VIRTUAL_ACCOUNT_성공() throws Exception {
-			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
+		@DisplayName("무통장 입금 성공 시 200과 계좌 정보를 반환한다")
+		void processPayment_BANK_TRANSFER_성공() throws Exception {
+			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
 			Instant deadline = Instant.now().plus(3, ChronoUnit.DAYS);
-			PaymentProcessResponse.VirtualAccountInfo vaInfo = new PaymentProcessResponse.VirtualAccountInfo(
-				"국민은행", "047-000-00000001", "구름GB", deadline
+			PaymentProcessResponse.AccountInfo accountInfo = new PaymentProcessResponse.AccountInfo(
+				"신한은행", "110-123-456789", "주식회사 구름공방", deadline
 			);
 			PaymentProcessResponse response = new PaymentProcessResponse(
 				1L, OrderStatus.PAYMENT_PENDING,
-				PaymentMethod.VIRTUAL_ACCOUNT, PaymentStatus.PENDING,
-				null, vaInfo
+				PaymentMethod.BANK_TRANSFER, PaymentStatus.PENDING,
+				null, accountInfo
 			);
 
 			given(paymentService.processPayment(eq(1L), eq(1L), any(PaymentProcessRequest.class)))
@@ -126,12 +126,12 @@ class PaymentControllerTest extends WebMvcTestSupport {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(request)))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.paymentMethod").value("VIRTUAL_ACCOUNT"))
+				.andExpect(jsonPath("$.data.paymentMethod").value("BANK_TRANSFER"))
 				.andExpect(jsonPath("$.data.paymentStatus").value("PENDING"))
 				.andExpect(jsonPath("$.data.orderStatus").value("PAYMENT_PENDING"))
-				.andExpect(jsonPath("$.data.virtualAccount.bank").value("국민은행"))
-				.andExpect(jsonPath("$.data.virtualAccount.holder").value("구름GB"))
-				.andExpect(jsonPath("$.data.virtualAccount.accountNumber").value("047-000-00000001"));
+				.andExpect(jsonPath("$.data.account.bank").value("신한은행"))
+				.andExpect(jsonPath("$.data.account.holder").value("주식회사 구름공방"))
+				.andExpect(jsonPath("$.data.account.accountNumber").value("110-123-456789"));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/entity/PaymentEntityTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/entity/PaymentEntityTest.java
@@ -19,16 +19,16 @@ class PaymentEntityTest {
 
 	private Order createOrder() {
 		return OrderFixture.createOrder(
-			OrderFixture.createUser(),
-			OrderFixture.createWeekdayMatch()
+				OrderFixture.createUser(),
+				OrderFixture.createWeekdayMatch()
 		);
 	}
 
 	private Payment createPendingPayment(PaymentMethod method) {
 		return Payment.builder()
-			.order(createOrder())
-			.paymentMethod(method)
-			.build();
+				.order(createOrder())
+				.paymentMethod(method)
+				.build();
 	}
 
 	@Nested
@@ -50,32 +50,32 @@ class PaymentEntityTest {
 		}
 
 		@Test
-		@DisplayName("간편결제 생성 시 가상계좌 정보는 null이다")
-		void 간편결제_생성시_가상계좌_null() {
+		@DisplayName("간편결제 생성 시 계좌 정보는 null이다")
+		void 간편결제_생성시_계좌_null() {
 			Payment payment = createPendingPayment(PaymentMethod.KAKAO_PAY);
-			assertThat(payment.getVirtualAccountBank()).isNull();
-			assertThat(payment.getVirtualAccountNumber()).isNull();
-			assertThat(payment.getVirtualAccountHolder()).isNull();
+			assertThat(payment.getAccountBank()).isNull();
+			assertThat(payment.getAccountNumber()).isNull();
+			assertThat(payment.getAccountHolder()).isNull();
 			assertThat(payment.getDepositDeadline()).isNull();
 		}
 
 		@Test
-		@DisplayName("가상계좌 생성 시 계좌 정보가 올바르게 설정된다")
-		void 가상계좌_생성시_계좌정보_설정() {
+		@DisplayName("무통장 입금 생성 시 계좌 정보가 올바르게 설정된다")
+		void 무통장입금_생성시_계좌정보_설정() {
 			Instant deadline = Instant.now().plus(3, ChronoUnit.DAYS);
 			Payment payment = Payment.builder()
-				.order(createOrder())
-				.paymentMethod(PaymentMethod.VIRTUAL_ACCOUNT)
-				.virtualAccountBank("국민은행")
-				.virtualAccountNumber("047-000-00000001")
-				.virtualAccountHolder("구름GB")
-				.depositDeadline(deadline)
-				.build();
+					.order(createOrder())
+					.paymentMethod(PaymentMethod.BANK_TRANSFER)
+					.accountBank("신한은행")
+					.accountNumber("110-123-456789")
+					.accountHolder("주식회사 구름공방")
+					.depositDeadline(deadline)
+					.build();
 
-			assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
-			assertThat(payment.getVirtualAccountBank()).isEqualTo("국민은행");
-			assertThat(payment.getVirtualAccountNumber()).isEqualTo("047-000-00000001");
-			assertThat(payment.getVirtualAccountHolder()).isEqualTo("구름GB");
+			assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.BANK_TRANSFER);
+			assertThat(payment.getAccountBank()).isEqualTo("신한은행");
+			assertThat(payment.getAccountNumber()).isEqualTo("110-123-456789");
+			assertThat(payment.getAccountHolder()).isEqualTo("주식회사 구름공방");
 			assertThat(payment.getDepositDeadline()).isEqualTo(deadline);
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
 		}
@@ -85,11 +85,11 @@ class PaymentEntityTest {
 		void 결제수단_저장() {
 			Payment tossPay = createPendingPayment(PaymentMethod.TOSS_PAY);
 			Payment kakaoPay = createPendingPayment(PaymentMethod.KAKAO_PAY);
-			Payment virtualAccount = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			Payment bankTransfer = createPendingPayment(PaymentMethod.BANK_TRANSFER);
 
 			assertThat(tossPay.getPaymentMethod()).isEqualTo(PaymentMethod.TOSS_PAY);
 			assertThat(kakaoPay.getPaymentMethod()).isEqualTo(PaymentMethod.KAKAO_PAY);
-			assertThat(virtualAccount.getPaymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
+			assertThat(bankTransfer.getPaymentMethod()).isEqualTo(PaymentMethod.BANK_TRANSFER);
 		}
 	}
 
@@ -116,9 +116,9 @@ class PaymentEntityTest {
 		}
 
 		@Test
-		@DisplayName("가상계좌 결제도 complete() 호출 시 COMPLETED 상태가 된다")
-		void 가상계좌_complete() {
-			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+		@DisplayName("무통장 입금 결제도 complete() 호출 시 COMPLETED 상태가 된다")
+		void 무통장입금_complete() {
+			Payment payment = createPendingPayment(PaymentMethod.BANK_TRANSFER);
 			payment.complete();
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
 		}
@@ -131,7 +131,7 @@ class PaymentEntityTest {
 		@Test
 		@DisplayName("cancel() 호출 시 상태가 CANCELLED로 변경된다")
 		void cancel_상태가_CANCELLED() {
-			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			Payment payment = createPendingPayment(PaymentMethod.BANK_TRANSFER);
 			payment.cancel();
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
 		}
@@ -162,7 +162,7 @@ class PaymentEntityTest {
 		@Test
 		@DisplayName("PENDING 상태에서도 refund() 호출 가능하다")
 		void refund_PENDING_상태에서_호출가능() {
-			Payment payment = createPendingPayment(PaymentMethod.VIRTUAL_ACCOUNT);
+			Payment payment = createPendingPayment(PaymentMethod.BANK_TRANSFER);
 			payment.refund();
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
 		}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -82,7 +82,7 @@ class PaymentServiceTest {
 			assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
 			assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAID);
 			assertThat(response.paidAt()).isNotNull();
-			assertThat(response.virtualAccount()).isNull();
+			assertThat(response.account()).isNull();
 		}
 
 		@Test
@@ -105,13 +105,13 @@ class PaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("가상계좌 결제 시 PENDING 상태를 유지하고 가상계좌 정보를 반환한다")
-		void processPayment_VIRTUAL_ACCOUNT_대기상태() {
+		@DisplayName("무통장 입금 시 PENDING 상태를 유지하고 계좌 정보를 반환한다")
+		void processPayment_BANK_TRANSFER_대기상태() {
 			Long userId = 1L;
 			Long orderId = 1L;
 			Order order = createOrderWithUser(orderId, userId);
 			ReflectionTestUtils.setField(order, "id", orderId);
-			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
+			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
 
 			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
@@ -119,31 +119,14 @@ class PaymentServiceTest {
 
 			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
 
-			assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.VIRTUAL_ACCOUNT);
+			assertThat(response.paymentMethod()).isEqualTo(PaymentMethod.BANK_TRANSFER);
 			assertThat(response.paymentStatus()).isEqualTo(PaymentStatus.PENDING);
 			assertThat(response.orderStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
-			assertThat(response.virtualAccount()).isNotNull();
-			assertThat(response.virtualAccount().bank()).isEqualTo("국민은행");
-			assertThat(response.virtualAccount().holder()).isEqualTo("구름GB");
-			assertThat(response.virtualAccount().accountNumber()).startsWith("047-000-");
-			assertThat(response.virtualAccount().depositDeadline()).isNotNull();
-		}
-
-		@Test
-		@DisplayName("가상계좌 번호는 orderId 기반으로 생성된다")
-		void processPayment_가상계좌번호_orderId_기반() {
-			Long userId = 1L;
-			Long orderId = 42L;
-			Order order = createOrderWithUser(orderId, userId);
-			PaymentProcessRequest request = PaymentFixture.createVirtualAccountRequest();
-
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
-			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
-
-			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
-
-			assertThat(response.virtualAccount().accountNumber()).isEqualTo("047-000-00000042");
+			assertThat(response.account()).isNotNull();
+			assertThat(response.account().bank()).isEqualTo("신한은행");
+			assertThat(response.account().holder()).isEqualTo("주식회사 구름공방");
+			assertThat(response.account().accountNumber()).isEqualTo("110-123-456789");
+			assertThat(response.account().depositDeadline()).isNotNull();
 		}
 
 		@Test
@@ -152,10 +135,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -168,10 +151,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -184,10 +167,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 
 		@Test
@@ -196,16 +179,16 @@ class PaymentServiceTest {
 			Long userId = 1L;
 			Long orderId = 1L;
 			Order order = createOrderWithUser(orderId, userId);
-			Payment existingPayment = PaymentFixture.createVirtualAccountPayment(order);
+			Payment existingPayment = PaymentFixture.createBankTransferPayment(order);
 
 			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(existingPayment));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 	}
 
@@ -265,10 +248,11 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(userId, orderId, PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(userId, orderId,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -285,10 +269,11 @@ class PaymentServiceTest {
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.of(existing));
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(userId, orderId, PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(userId, orderId,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
 		}
 
 		@Test
@@ -301,10 +286,11 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(attackerId, 1L, PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(attackerId, 1L,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -313,10 +299,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
기존 버츄얼이라는 가상느낌의 단어들을 일반 계좌로 리네이밍 작업 했습니당

- PaymentMethod enum: VIRTUAL_ACCOUNT → BANK_TRANSFER
- Payment 엔티티: virtualAccount* 필드 → account* 필드로 변경
- PaymentProcessResponse: VirtualAccountInfo → AccountInfo
- PaymentService: PG 가상계좌 대신 고정 계좌 목업 (신한은행, 주식회사 구름공방)
- 테스트 전체 수정 (Fixture, Service, Controller, Entity)
