### PR TITLE
fix(match-seat-scheduler): 스케줄러 미동작 수정 [GRGB-267]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
@@ -1,5 +1,8 @@
 package com.goormgb.be.seat.matchSeat.scheduler;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +23,7 @@ public class MatchSeatScheduler {
 	 */
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void prepareMatchSeats() {
+		log.info("[MatchSeatScheduler] 스케줄러 실행 시각(KST): {}", ZonedDateTime.now(ZoneId.of("Asia/Seoul")));
 		matchSeatPreparationService.prepareMatchSeats();
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
@@ -4,7 +4,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -32,30 +31,18 @@ public class MatchSeatPreparationService {
 
 	public void prepareMatchSeats() {
 
-		// KST 기준 현재 시각
-		ZonedDateTime nowKst = ZonedDateTime.now(clock)
-			.withZoneSameInstant(KST);
+		Instant now = clock.instant();
+		LocalDate todayKst = now.atZone(KST).toLocalDate();
 
-		// 오늘 기준 +7일 날짜
-		LocalDate targetDate = nowKst.toLocalDate().plusDays(7);
-
-		// 7일 뒤 날짜의 00:00 ~ 다음날 00:00 범위
-		Instant targetStart = targetDate
-			.atStartOfDay(KST)
-			.toInstant();
-
-		Instant targetEnd = targetDate
-			.plusDays(1)
-			.atStartOfDay(KST)
-			.toInstant();
-
-		// 생성 대상 경기 조회
-		List<Match> matchesToPrepare =
-			matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
-				SaleStatus.UPCOMING,
-				targetStart,
-				targetEnd
-			);
+		List<Match> matchesToPrepare = matchRepository.findBySaleStatus(SaleStatus.UPCOMING)
+			.stream()
+			.filter(match ->
+				match.getMatchAt()
+					.atZone(KST)
+					.toLocalDate()
+					.equals(todayKst.plusDays(7))
+			)
+			.toList();
 
 		if (matchesToPrepare.isEmpty()) {
 			log.info("[MatchSeatPreparationService] 생성 대상 경기 없음");

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
@@ -46,16 +46,6 @@ public class MatchSeatPreparationService {
 			endOfDay
 		);
 
-		// List<Match> matchesToPrepare = matchRepository.findBySaleStatus(SaleStatus.UPCOMING)
-		// 	.stream()
-		// 	.filter(match ->
-		// 		match.getMatchAt()
-		// 			.atZone(KST)
-		// 			.toLocalDate()
-		// 			.equals(todayKst.plusDays(7))
-		// 	)
-		// 	.toList();
-
 		if (matchesToPrepare.isEmpty()) {
 			log.info("[MatchSeatPreparationService] 생성 대상 경기 없음");
 			return;

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
@@ -31,9 +31,6 @@ public class MatchSeatPreparationService {
 
 	public void prepareMatchSeats() {
 
-		// Instant now = clock.instant();
-		// LocalDate todayKst = now.atZone(KST).toLocalDate();
-
 		LocalDate todayKst = clock.instant().atZone(KST).toLocalDate();
 		LocalDate targetDate = todayKst.plusDays(7);
 

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationService.java
@@ -31,18 +31,30 @@ public class MatchSeatPreparationService {
 
 	public void prepareMatchSeats() {
 
-		Instant now = clock.instant();
-		LocalDate todayKst = now.atZone(KST).toLocalDate();
+		// Instant now = clock.instant();
+		// LocalDate todayKst = now.atZone(KST).toLocalDate();
 
-		List<Match> matchesToPrepare = matchRepository.findBySaleStatus(SaleStatus.UPCOMING)
-			.stream()
-			.filter(match ->
-				match.getMatchAt()
-					.atZone(KST)
-					.toLocalDate()
-					.equals(todayKst.plusDays(7))
-			)
-			.toList();
+		LocalDate todayKst = clock.instant().atZone(KST).toLocalDate();
+		LocalDate targetDate = todayKst.plusDays(7);
+
+		Instant startOfDay = targetDate.atStartOfDay(KST).toInstant();
+		Instant endOfDay = targetDate.plusDays(1).atStartOfDay(KST).toInstant();
+
+		List<Match> matchesToPrepare = matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			SaleStatus.UPCOMING,
+			startOfDay,
+			endOfDay
+		);
+
+		// List<Match> matchesToPrepare = matchRepository.findBySaleStatus(SaleStatus.UPCOMING)
+		// 	.stream()
+		// 	.filter(match ->
+		// 		match.getMatchAt()
+		// 			.atZone(KST)
+		// 			.toLocalDate()
+		// 			.equals(todayKst.plusDays(7))
+		// 	)
+		// 	.toList();
 
 		if (matchesToPrepare.isEmpty()) {
 			log.info("[MatchSeatPreparationService] 생성 대상 경기 없음");

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
@@ -33,15 +33,14 @@ class MatchSeatPreparationServiceTest {
 	@Mock
 	private MatchSeatPreparationTransactionalService transactionalService;
 
-	private Clock clock;
-
 	private MatchSeatPreparationService matchSeatPreparationService;
 
 	@BeforeEach
 	void setUp() {
-		clock = Clock.fixed(
-			Instant.parse("2026-03-13T00:00:00Z"),
-			ZoneId.of("UTC")
+		// 테스트 기준 시각: KST 2026-03-17 00:00
+		Clock clock = Clock.fixed(
+			Instant.parse("2026-03-16T15:00:00Z"),
+			ZoneId.of("Asia/Seoul")
 		);
 
 		matchSeatPreparationService = new MatchSeatPreparationService(
@@ -54,11 +53,9 @@ class MatchSeatPreparationServiceTest {
 
 	@Test
 	@DisplayName("생성 대상 경기가 없으면 종료한다")
-	void prepareMatchSeats_noMatches() {
+	void 생성_대상_경기가_없으면_종료한다() {
 		// given
-		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
-			eq(SaleStatus.UPCOMING), any(), any()
-		)).thenReturn(List.of());
+		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of());
 
 		// when
 		matchSeatPreparationService.prepareMatchSeats();
@@ -69,14 +66,44 @@ class MatchSeatPreparationServiceTest {
 	}
 
 	@Test
-	@DisplayName("좌석 템플릿이 없으면 종료한다")
-	void prepareMatchSeats_noTemplates() {
+	@DisplayName("오늘 KST 기준 7일 뒤 경기만 생성 대상에 포함한다")
+	void 오늘_KST_기준_7일_뒤_경기만_생성_대상에_포함한다() {
 		// given
-		Match match = org.mockito.Mockito.mock(Match.class);
-		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
-			eq(SaleStatus.UPCOMING), any(), any()
-		)).thenReturn(List.of(match));
+		// todayKst = 2026-03-17
+		// 생성 대상 경기일 = 2026-03-24 (KST)
+		Match targetMatch = mock(Match.class);
+		Match nonTargetMatch = mock(Match.class);
 
+		// 생성 대상 경기
+		when(targetMatch.getId()).thenReturn(1L);
+		when(targetMatch.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 2026-03-24 12:00
+
+		// 생성 대상이 아닌 경기
+		when(nonTargetMatch.getMatchAt()).thenReturn(Instant.parse("2026-03-25T03:00:00Z")); // KST 2026-03-25 12:00
+
+		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING)))
+			.thenReturn(List.of(targetMatch, nonTargetMatch));
+
+		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
+		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
+
+		// when
+		matchSeatPreparationService.prepareMatchSeats();
+
+		// then
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(1L), any());
+		verify(transactionalService, never()).prepareSingleMatchSeats(eq(2L), any());
+	}
+
+	@Test
+	@DisplayName("좌석 템플릿이 없으면 종료한다")
+	void 좌석_템플릿이_없으면_종료한다() {
+		// given
+		// 생성 대상 경기는 있지만 좌석 템플릿이 없어서 실제 생성은 진행되지 않아야 한다.
+		Match match = mock(Match.class);
+		when(match.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 2026-03-24 12:00
+
+		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of(match));
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of());
 
 		// when
@@ -87,23 +114,30 @@ class MatchSeatPreparationServiceTest {
 	}
 
 	@Test
-	@DisplayName("대상 경기마다 match seat 생성을 시도한다")
-	void prepareMatchSeats_callsTransactionalServiceForEachMatch() {
+	@DisplayName("한 경기 생성 실패해도 다음 경기는 계속 처리한다")
+	void 한_경기_생성에_실패해도_다음_경기는_계속_처리한다() {
 		// given
-		Match match1 = org.mockito.Mockito.mock(Match.class);
-		Match match2 = org.mockito.Mockito.mock(Match.class);
+		// 두 경기 모두 생성 대상 날짜(KST 2026-03-24)로 설정
+		Match match1 = mock(Match.class);
+		Match match2 = mock(Match.class);
 
 		when(match1.getId()).thenReturn(1L);
 		when(match2.getId()).thenReturn(2L);
 
-		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
-			eq(SaleStatus.UPCOMING), any(), any()
-		)).thenReturn(List.of(match1, match2));
+		when(match1.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 12:00
+		when(match2.getMatchAt()).thenReturn(Instant.parse("2026-03-24T09:00:00Z")); // KST 18:00
 
-		SeatTemplateProjection template = org.mockito.Mockito.mock(SeatTemplateProjection.class);
+		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING)))
+			.thenReturn(List.of(match1, match2));
+
+		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
 
-		when(transactionalService.prepareSingleMatchSeats(eq(1L), any())).thenReturn(true);
+		// 첫 번째 경기 생성은 실패
+		doThrow(new RuntimeException("DB 오류"))
+			.when(transactionalService).prepareSingleMatchSeats(eq(1L), any());
+
+		// 두 번째 경기는 정상 생성
 		when(transactionalService.prepareSingleMatchSeats(eq(2L), any())).thenReturn(true);
 
 		// when
@@ -115,32 +149,24 @@ class MatchSeatPreparationServiceTest {
 	}
 
 	@Test
-	@DisplayName("한 경기 생성 실패해도 다음 경기는 계속 처리한다")
-	void prepareMatchSeats_continueWhenOneMatchFails() {
+	@DisplayName("대상 경기이고 템플릿이 있으면 생성에 성공한다")
+	void 대상_경기이고_템플릿이_있으면_생성에_성공한다() {
 		// given
-		Match match1 = org.mockito.Mockito.mock(Match.class);
-		Match match2 = org.mockito.Mockito.mock(Match.class);
+		// KST 기준 2026-03-24 경기이므로 생성 대상
+		Match match = mock(Match.class);
+		when(match.getId()).thenReturn(100L);
+		when(match.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 12:00
 
-		when(match1.getId()).thenReturn(1L);
-		when(match2.getId()).thenReturn(2L);
+		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of(match));
 
-		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
-			eq(SaleStatus.UPCOMING), any(), any()
-		)).thenReturn(List.of(match1, match2));
-
-		SeatTemplateProjection template = org.mockito.Mockito.mock(SeatTemplateProjection.class);
+		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
-
-		doThrow(new RuntimeException("DB 오류"))
-			.when(transactionalService).prepareSingleMatchSeats(eq(1L), any());
-
-		when(transactionalService.prepareSingleMatchSeats(eq(2L), any())).thenReturn(true);
+		when(transactionalService.prepareSingleMatchSeats(eq(100L), any())).thenReturn(true);
 
 		// when
 		matchSeatPreparationService.prepareMatchSeats();
 
 		// then
-		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(1L), any());
-		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(2L), any());
+		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(100L), any());
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatPreparationServiceTest.java
@@ -55,7 +55,11 @@ class MatchSeatPreparationServiceTest {
 	@DisplayName("생성 대상 경기가 없으면 종료한다")
 	void 생성_대상_경기가_없으면_종료한다() {
 		// given
-		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of());
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			any(Instant.class),
+			any(Instant.class)
+		)).thenReturn(List.of());
 
 		// when
 		matchSeatPreparationService.prepareMatchSeats();
@@ -66,44 +70,48 @@ class MatchSeatPreparationServiceTest {
 	}
 
 	@Test
-	@DisplayName("오늘 KST 기준 7일 뒤 경기만 생성 대상에 포함한다")
-	void 오늘_KST_기준_7일_뒤_경기만_생성_대상에_포함한다() {
+	@DisplayName("오늘 KST 기준 7일 뒤 날짜 범위의 경기만 조회한다")
+	void 오늘_KST_기준_7일_뒤_날짜_범위의_경기만_조회한다() {
 		// given
-		// todayKst = 2026-03-17
-		// 생성 대상 경기일 = 2026-03-24 (KST)
 		Match targetMatch = mock(Match.class);
-		Match nonTargetMatch = mock(Match.class);
-
-		// 생성 대상 경기
 		when(targetMatch.getId()).thenReturn(1L);
-		when(targetMatch.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 2026-03-24 12:00
-
-		// 생성 대상이 아닌 경기
-		when(nonTargetMatch.getMatchAt()).thenReturn(Instant.parse("2026-03-25T03:00:00Z")); // KST 2026-03-25 12:00
-
-		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING)))
-			.thenReturn(List.of(targetMatch, nonTargetMatch));
 
 		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
+
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			any(Instant.class),
+			any(Instant.class)
+		)).thenReturn(List.of(targetMatch));
 
 		// when
 		matchSeatPreparationService.prepareMatchSeats();
 
 		// then
+		Instant expectedStart = Instant.parse("2026-03-23T15:00:00Z"); // KST 2026-03-24 00:00
+		Instant expectedEnd = Instant.parse("2026-03-24T15:00:00Z");   // KST 2026-03-25 00:00
+
+		verify(matchRepository).findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			eq(expectedStart),
+			eq(expectedEnd)
+		);
 		verify(transactionalService, times(1)).prepareSingleMatchSeats(eq(1L), any());
-		verify(transactionalService, never()).prepareSingleMatchSeats(eq(2L), any());
 	}
 
 	@Test
 	@DisplayName("좌석 템플릿이 없으면 종료한다")
 	void 좌석_템플릿이_없으면_종료한다() {
 		// given
-		// 생성 대상 경기는 있지만 좌석 템플릿이 없어서 실제 생성은 진행되지 않아야 한다.
 		Match match = mock(Match.class);
-		when(match.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 2026-03-24 12:00
 
-		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of(match));
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			any(Instant.class),
+			any(Instant.class)
+		)).thenReturn(List.of(match));
+
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of());
 
 		// when
@@ -117,27 +125,24 @@ class MatchSeatPreparationServiceTest {
 	@DisplayName("한 경기 생성 실패해도 다음 경기는 계속 처리한다")
 	void 한_경기_생성에_실패해도_다음_경기는_계속_처리한다() {
 		// given
-		// 두 경기 모두 생성 대상 날짜(KST 2026-03-24)로 설정
 		Match match1 = mock(Match.class);
 		Match match2 = mock(Match.class);
 
 		when(match1.getId()).thenReturn(1L);
 		when(match2.getId()).thenReturn(2L);
 
-		when(match1.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 12:00
-		when(match2.getMatchAt()).thenReturn(Instant.parse("2026-03-24T09:00:00Z")); // KST 18:00
-
-		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING)))
-			.thenReturn(List.of(match1, match2));
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			any(Instant.class),
+			any(Instant.class)
+		)).thenReturn(List.of(match1, match2));
 
 		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));
 
-		// 첫 번째 경기 생성은 실패
 		doThrow(new RuntimeException("DB 오류"))
 			.when(transactionalService).prepareSingleMatchSeats(eq(1L), any());
 
-		// 두 번째 경기는 정상 생성
 		when(transactionalService.prepareSingleMatchSeats(eq(2L), any())).thenReturn(true);
 
 		// when
@@ -152,12 +157,14 @@ class MatchSeatPreparationServiceTest {
 	@DisplayName("대상 경기이고 템플릿이 있으면 생성에 성공한다")
 	void 대상_경기이고_템플릿이_있으면_생성에_성공한다() {
 		// given
-		// KST 기준 2026-03-24 경기이므로 생성 대상
 		Match match = mock(Match.class);
 		when(match.getId()).thenReturn(100L);
-		when(match.getMatchAt()).thenReturn(Instant.parse("2026-03-24T03:00:00Z")); // KST 12:00
 
-		when(matchRepository.findBySaleStatus(eq(SaleStatus.UPCOMING))).thenReturn(List.of(match));
+		when(matchRepository.findBySaleStatusAndMatchAtGreaterThanEqualAndMatchAtLessThan(
+			eq(SaleStatus.UPCOMING),
+			any(Instant.class),
+			any(Instant.class)
+		)).thenReturn(List.of(match));
 
 		SeatTemplateProjection template = mock(SeatTemplateProjection.class);
 		when(seatRepository.findAllSeatTemplates()).thenReturn(List.of(template));


### PR DESCRIPTION
## 🔧 작업 내용

- match_seats 데이터 생성 스케줄러 미동작 수정

## 🧩 구현 상세 (선택)

**match_seats 데이터 생성 스케줄러 미동작 수정**

> 이전
- 이전 구현에서는 KST 기준 +7일의 하루 범위를 Instant 구간으로 계산해 레포에서 바로 조회
- UTC/KST 및 쿼리 조건에 불일치로 데이터 조회 누락 현상이 있음

> 수정 후
- 조회 방식을 UPCOMING 필터링으로 변경
-  각 경기의 `matchAt`을 LocalDate로 변환해 `todayKst.plusDays(7)`와 정확히 일치하는 경기만 대상으로 선정
- 스케줄러 실행 시각을 로그로 추가


> 테스트
- 7일 뒤 경기만 포함하는 지 테스트 추가
- 경기 존재, 템플릿 존재인 경우 성공 테스트 추가


### 📌 관련 Jira Issue

- GRGB-267

## 🧪 테스트 방법(선택)

<img width="1100" height="461" alt="image" src="https://github.com/user-attachments/assets/1d69583a-711c-41cb-ad29-939b3285266d" />

## ❗ 참고 사항

- 도커 실행이 안되서 서비스 레벨로 테스트 해보지는 못했지만 우선은 시드 데이터로 작업하는 걸로하고 내일도 생성 안되어 있으면 재수정 해보겠습니다..
