### PR TITLE
fix(seat): Spring Boot 4.x 호환을 위해 redisson-spring-boot-starter를 redisson core로 교체

### DIFF
--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -5,8 +5,8 @@ dependencies {
     implementation project(':common-core')
     testImplementation(testFixtures(project(':common-core')))
 
-    // Redisson 분산 락
-    implementation 'org.redisson:redisson-spring-boot-starter:3.44.0'
+    // Redisson 분산 락 (Spring Boot 4 버전 호환: starter 대신 core 라이브러리 직접 사용)
+    implementation 'org.redisson:redisson:3.44.0'
 
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
   # 1. 기존 캐시용 레디스 (6379)
   local-redis:
     image: redis:7
@@ -47,7 +48,6 @@ services:
       timeout: 5s
       retries: 5
 
-  
   api-gateway:
     build:
       context: ..


### PR DESCRIPTION
## 🔧 작업 내용

- redisson-spring-boot-starter의 RedissonAutoConfigurationV2가 Spring Boot 4.x에서 제거된 RedisAutoConfiguration 클래스를 참조하여 앱 구동 실패
- RedissonClient를 RedissonConfig에서 직접 수동 생성하므로 starter 불필요
- redisson-spring-boot-starter:3.44.0 → redisson:3.44.0 으로 교체
- 겸사겸사 도커 컴포즈 코드스타일 체크

## 참고사항
빌드그래들 수정이라 바로 핫픽스로 붙여서 올릴게요