### PR TITLE
feat(seat): 추천 블럭 잔여 좌석 수 응답 추가 및 만료 Hold 자동 정리 스케줄러 구현 [GRGB-270]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/BlockRemainingSeatProjection.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/BlockRemainingSeatProjection.java
@@ -1,0 +1,7 @@
+package com.goormgb.be.seat.matchSeat.repository;
+
+public interface BlockRemainingSeatProjection {
+	Long getBlockId();
+
+	long getRemainingSeatCount();
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -82,4 +82,17 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.BLOCKED
 		""")
 	int markAvailableIfBlockedInBatch(@Param("matchSeatIds") List<Long> matchSeatIds);
+
+	@Query("""
+		SELECT ms.blockId AS blockId, COUNT(ms) AS remainingSeatCount
+		FROM MatchSeat ms
+		WHERE ms.matchId = :matchId
+		  AND ms.blockId IN :blockIds
+		  AND ms.saleStatus = com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus.AVAILABLE
+		GROUP BY ms.blockId
+		""")
+	List<BlockRemainingSeatProjection> countRemainingSeatsByMatchIdAndBlockIdIn(
+		@Param("matchId") Long matchId,
+		@Param("blockIds") List<Long> blockIds
+	);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/BlockRecommendation.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/internal/BlockRecommendation.java
@@ -4,6 +4,7 @@ import com.goormgb.be.seat.block.entity.Block;
 
 public record BlockRecommendation(
 	Block block,
-	int realConsecutiveCount
+	int realConsecutiveCount,
+	long remainingSeatCount
 ) {
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -29,6 +29,7 @@ public record BlockRecommendationResponse(
 		String areaName,
 		String viewpoint,
 		int realConsecutiveCount,
+		long remainingSeatCount,
 		int rank
 	) {
 
@@ -41,6 +42,7 @@ public record BlockRecommendationResponse(
 				block.getArea().getName(),
 				block.getViewpoint().name(),
 				recommendation.realConsecutiveCount(),
+				recommendation.remainingSeatCount(),
 				rank
 			);
 		}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -2,6 +2,8 @@ package com.goormgb.be.seat.recommendation.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,8 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.matchSeat.repository.BlockRemainingSeatProjection;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
@@ -33,6 +37,7 @@ public class SeatRecommendationService {
 	private final MatchRepository matchRepository;
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	private final BlockRepository blockRepository;
+	private final MatchSeatRepository matchSeatRepository;
 	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
 	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
 	private final ConsecutiveSeatCounter consecutiveSeatCounter;
@@ -68,12 +73,22 @@ public class SeatRecommendationService {
 	}
 
 	private List<BlockRecommendation> buildRecommendations(Long matchId, int ticketCount, List<Block> blocks) {
-		List<BlockRecommendation> recommendations = new ArrayList<>();
+		List<Long> blockIds = blocks.stream().map(Block::getId).toList();
 
+		Map<Long, Long> remainingMap = matchSeatRepository
+			.countRemainingSeatsByMatchIdAndBlockIdIn(matchId, blockIds)
+			.stream()
+			.collect(Collectors.toMap(
+				BlockRemainingSeatProjection::getBlockId,
+				BlockRemainingSeatProjection::getRemainingSeatCount
+			));
+
+		List<BlockRecommendation> recommendations = new ArrayList<>();
 		for (Block block : blocks) {
 			int count = consecutiveSeatCounter.countRealConsecutiveSeats(matchId, block.getId(), ticketCount);
 			if (count > 0) {
-				recommendations.add(new BlockRecommendation(block, count));
+				long remaining = remainingMap.getOrDefault(block.getId(), 0L);
+				recommendations.add(new BlockRecommendation(block, count, remaining));
 			}
 		}
 

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -32,6 +32,6 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
 	List<Long> findExpiredMatchSeatIds(@Param("now") Instant now);
 
 	@Modifying
-	@Query("DELETE FROM SeatHold sh WHERE sh.expiresAt < :now")
-	int deleteExpiredHolds(@Param("now") Instant now);
+	@Query("DELETE FROM SeatHold sh WHERE sh.matchSeatId IN :matchSeatIds")
+	int deleteByMatchSeatIdIn(@Param("matchSeatIds") List<Long> matchSeatIds);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/repository/SeatHoldRepository.java
@@ -4,6 +4,9 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.seat.seatHold.entity.SeatHold;
 
@@ -24,4 +27,11 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, Long> {
 	List<SeatHold> findAllByUserIdAndMatchIdAndExpiresAtAfter(Long userId, Long matchId, Instant now);
 
 	List<SeatHold> findAllByMatchIdAndSeatIdInAndExpiresAtAfter(Long matchId, List<Long> seatIds, Instant now);
+
+	@Query("SELECT sh.matchSeatId FROM SeatHold sh WHERE sh.expiresAt < :now")
+	List<Long> findExpiredMatchSeatIds(@Param("now") Instant now);
+
+	@Modifying
+	@Query("DELETE FROM SeatHold sh WHERE sh.expiresAt < :now")
+	int deleteExpiredHolds(@Param("now") Instant now);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupScheduler.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupScheduler.java
@@ -41,7 +41,7 @@ public class SeatHoldCleanupScheduler {
 		}
 
 		int restoredCount = matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds);
-		int deletedCount = seatHoldRepository.deleteExpiredHolds(now);
+		int deletedCount = seatHoldRepository.deleteByMatchSeatIdIn(expiredMatchSeatIds);
 
 		log.info("만료 Hold 정리 완료 - 좌석 복원: {}건, Hold 삭제: {}건", restoredCount, deletedCount);
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupScheduler.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupScheduler.java
@@ -1,0 +1,48 @@
+package com.goormgb.be.seat.seatHold.scheduler;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 만료된 SeatHold를 주기적으로 정리하는 스케줄러.
+ *
+ * <p>1분 간격으로 실행되며, 만료된 Hold의 좌석을 AVAILABLE로 복원하고
+ * Hold 레코드를 삭제한다. SOLD 상태 좌석은 영향받지 않는다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatHoldCleanupScheduler {
+
+	private final SeatHoldRepository seatHoldRepository;
+	private final MatchSeatRepository matchSeatRepository;
+	private final Clock clock;
+
+	@Scheduled(fixedDelay = 60_000)
+	@Transactional
+	public void cleanupExpiredHolds() {
+		Instant now = clock.instant();
+
+		List<Long> expiredMatchSeatIds = seatHoldRepository.findExpiredMatchSeatIds(now);
+
+		if (expiredMatchSeatIds.isEmpty()) {
+			return;
+		}
+
+		int restoredCount = matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds);
+		int deletedCount = seatHoldRepository.deleteExpiredHolds(now);
+
+		log.info("만료 Hold 정리 완료 - 좌석 복원: {}건, Hold 삭제: {}건", restoredCount, deletedCount);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -31,6 +31,7 @@ import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
@@ -47,6 +48,8 @@ class SeatRecommendationServiceTest {
 	private SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	@Mock
 	private BlockRepository blockRepository;
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
 	@Mock
 	private OnboardingPreferenceRepository onboardingPreferenceRepository;
 	@Mock
@@ -123,6 +126,8 @@ class SeatRecommendationServiceTest {
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
 
+		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());
+
 		// block206이 연석 더 많음 (차이 > 10)
 		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 5)).willReturn(5);
 		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 206L, 5)).willReturn(20);
@@ -167,6 +172,8 @@ class SeatRecommendationServiceTest {
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(viewpoints);
 
+		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());
+
 		// 연석 차이 10 이내
 		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 3)).willReturn(12);
 		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 408L, 3)).willReturn(15);
@@ -206,6 +213,8 @@ class SeatRecommendationServiceTest {
 		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L))).willReturn(List.of(block205));
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
+
+		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());
 
 		// 모든 블럭에 연석 없음
 		given(consecutiveSeatCounter.countRealConsecutiveSeats(matchId, 205L, 5)).willReturn(0);

--- a/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
@@ -40,14 +40,14 @@ class SeatHoldCleanupSchedulerTest {
 		List<Long> expiredMatchSeatIds = List.of(100L, 200L, 300L);
 		given(seatHoldRepository.findExpiredMatchSeatIds(NOW)).willReturn(expiredMatchSeatIds);
 		given(matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds)).willReturn(3);
-		given(seatHoldRepository.deleteExpiredHolds(NOW)).willReturn(3);
+		given(seatHoldRepository.deleteByMatchSeatIdIn(expiredMatchSeatIds)).willReturn(3);
 
 		// when
 		seatHoldCleanupScheduler.cleanupExpiredHolds();
 
 		// then
 		then(matchSeatRepository).should().markAvailableIfBlockedInBatch(expiredMatchSeatIds);
-		then(seatHoldRepository).should().deleteExpiredHolds(NOW);
+		then(seatHoldRepository).should().deleteByMatchSeatIdIn(expiredMatchSeatIds);
 	}
 
 	@Test
@@ -62,7 +62,7 @@ class SeatHoldCleanupSchedulerTest {
 
 		// then
 		then(matchSeatRepository).should(never()).markAvailableIfBlockedInBatch(any());
-		then(seatHoldRepository).should(never()).deleteExpiredHolds(any());
+		then(seatHoldRepository).should(never()).deleteByMatchSeatIdIn(any());
 	}
 
 	@Test
@@ -75,13 +75,13 @@ class SeatHoldCleanupSchedulerTest {
 		given(seatHoldRepository.findExpiredMatchSeatIds(NOW)).willReturn(expiredMatchSeatIds);
 		// 2개 중 1개만 BLOCKED → 1개만 복원됨
 		given(matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds)).willReturn(1);
-		given(seatHoldRepository.deleteExpiredHolds(NOW)).willReturn(2);
+		given(seatHoldRepository.deleteByMatchSeatIdIn(expiredMatchSeatIds)).willReturn(2);
 
 		// when
 		seatHoldCleanupScheduler.cleanupExpiredHolds();
 
 		// then
 		then(matchSeatRepository).should().markAvailableIfBlockedInBatch(expiredMatchSeatIds);
-		then(seatHoldRepository).should().deleteExpiredHolds(NOW);
+		then(seatHoldRepository).should().deleteByMatchSeatIdIn(expiredMatchSeatIds);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
@@ -1,0 +1,87 @@
+package com.goormgb.be.seat.seatHold.scheduler;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldCleanupSchedulerTest {
+
+	@Mock
+	private SeatHoldRepository seatHoldRepository;
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private SeatHoldCleanupScheduler seatHoldCleanupScheduler;
+
+	private static final Instant NOW = Instant.parse("2026-03-17T12:00:00Z");
+
+	@Test
+	@DisplayName("만료된 Hold가 있으면 좌석 복원 후 Hold를 삭제한다")
+	void 만료된_Hold_정리() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		List<Long> expiredMatchSeatIds = List.of(100L, 200L, 300L);
+		given(seatHoldRepository.findExpiredMatchSeatIds(NOW)).willReturn(expiredMatchSeatIds);
+		given(matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds)).willReturn(3);
+		given(seatHoldRepository.deleteExpiredHolds(NOW)).willReturn(3);
+
+		// when
+		seatHoldCleanupScheduler.cleanupExpiredHolds();
+
+		// then
+		then(matchSeatRepository).should().markAvailableIfBlockedInBatch(expiredMatchSeatIds);
+		then(seatHoldRepository).should().deleteExpiredHolds(NOW);
+	}
+
+	@Test
+	@DisplayName("만료된 Hold가 없으면 아무 작업도 수행하지 않는다")
+	void 만료된_Hold_없음() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+		given(seatHoldRepository.findExpiredMatchSeatIds(NOW)).willReturn(List.of());
+
+		// when
+		seatHoldCleanupScheduler.cleanupExpiredHolds();
+
+		// then
+		then(matchSeatRepository).should(never()).markAvailableIfBlockedInBatch(any());
+		then(seatHoldRepository).should(never()).deleteExpiredHolds(any());
+	}
+
+	@Test
+	@DisplayName("SOLD 상태 좌석은 BLOCKED만 복원하므로 영향받지 않는다")
+	void SOLD_좌석_영향없음() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+
+		List<Long> expiredMatchSeatIds = List.of(100L, 200L);
+		given(seatHoldRepository.findExpiredMatchSeatIds(NOW)).willReturn(expiredMatchSeatIds);
+		// 2개 중 1개만 BLOCKED → 1개만 복원됨
+		given(matchSeatRepository.markAvailableIfBlockedInBatch(expiredMatchSeatIds)).willReturn(1);
+		given(seatHoldRepository.deleteExpiredHolds(NOW)).willReturn(2);
+
+		// when
+		seatHoldCleanupScheduler.cleanupExpiredHolds();
+
+		// then
+		then(matchSeatRepository).should().markAvailableIfBlockedInBatch(expiredMatchSeatIds);
+		then(seatHoldRepository).should().deleteExpiredHolds(NOW);
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- 추천 블럭 응답에 블럭별 잔여 좌석 수(`remainingSeatCount`)를 추가하여 프론트엔드에서 좌석 선택 시 참고 정보를 제공
- 만료된 SeatHold를 60초 간격으로 자동 정리하는 스케줄러를 구현하여, Hold 만료 후에도 좌석이 BLOCKED 상태로 남는 문제 해결
- 기존 `markAvailableIfBlockedInBatch` 쿼리를 재사용하여 SOLD 상태 좌석에 영향 없이 BLOCKED 좌석만 복원

## 🧩 구현 상세

### 잔여 좌석 수 응답 추가
- `BlockRemainingSeatProjection` 프로젝션 인터페이스를 추가하여 블럭별 AVAILABLE 좌석 수를 집계
- `MatchSeatRepository`에 `countRemainingSeatsByMatchIdAndBlockIdIn()` 배치 집계 쿼리 추가 (N+1 방지, 1회 GROUP BY 쿼리)
- `BlockRecommendation`, `BlockRecommendationResponse.RecommendedBlock`에 `remainingSeatCount` 필드 추가
- `SeatRecommendationService.buildRecommendations()`에서 잔여좌석을 Map으로 변환 후 블럭별 매핑

### 만료 Hold 자동 정리 스케줄러
- `SeatHoldRepository`에 만료 Hold의 matchSeatId 조회(`findExpiredMatchSeatIds`) 및 벌크 삭제(`deleteExpiredHolds`) 쿼리 추가
- `SeatHoldCleanupScheduler` 신규 생성 — `@Scheduled(fixedDelay = 60_000)`로 1분 간격 실행
- 만료된 Hold의 좌석을 `markAvailableIfBlockedInBatch`로 BLOCKED → AVAILABLE 복원 후 Hold 레코드 벌크 삭제
- `Clock` 주입으로 테스트 시 시간 제어 가능

### 📌 관련 Jira Issue
- GRGB-270

## 🧪 테스트 방법
- `SeatRecommendationServiceTest` — 기존 3개 테스트에 `MatchSeatRepository` mock 추가하여 통과 확인
- `SeatHoldCleanupSchedulerTest` — 3개 테스트 신규 작성
  - 만료된 Hold 존재 시 좌석 복원 + Hold 삭제 검증
  - 만료된 Hold 없을 때 아무 작업 수행하지 않음 검증
  - SOLD 상태 좌석은 복원 대상에서 제외됨 검증
- `./gradlew :Seat:test` 전체 통과 확인
- 
<img width="1035" height="433" alt="스크린샷 2026-03-17 오후 5 03 03" src="https://github.com/user-attachments/assets/c0553c76-4e72-40af-bba8-1f76912c3641" />

<img width="1016" height="445" alt="스크린샷 2026-03-17 오후 5 03 21" src="https://github.com/user-attachments/assets/24ee75d6-77bc-4aa4-aa6e-618bfd7ec502" />


## ❗ 참고 사항
- 잔여 좌석 수는 조회 시점 기준이며, Hold/결제 진행 중인 좌석은 BLOCKED/SOLD 상태이므로 카운트에서 제외됩니다