### PR TITLE
chore: Swagger UI URL 설정을 api-gateway로 통합

### DIFF
--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -45,20 +45,6 @@ jwt:
     # SameSite=Lax, secure=false로 되돌릴 것.
     secure: true
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -43,20 +43,6 @@ jwt:
   cookie:
     secure: false
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -30,20 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 management:
   endpoints:
     web:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -30,20 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 management:
   endpoint:
     health:

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -41,8 +41,6 @@ springdoc:
         url: http://localhost:8082/seat/v3/api-docs
       - name: Order-Core
         url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
 
 management:
   endpoints:

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -30,17 +30,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
 
 management:
   endpoints:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -57,20 +57,6 @@ queue:
       public-key: ${JWT_PUBLIC_KEY}
       issuer: queue-service
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 management:
   endpoint:
     health:

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -33,20 +33,6 @@ spring:
 queue:
   preference-key-prefix: seat:preference
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 management:
   endpoints:
     web:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -33,20 +33,6 @@ spring:
 queue:
   preference-key-prefix: seat:preference
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
-
 management:
   endpoint:
     health:


### PR DESCRIPTION
- Recommendation 모듈 제거
- api-gateway에서만 swagger-ui urls를 관리하도록 변경

## 🔧 작업 내용
`application.yaml`에 남아 있던 `springdoc.swagger-ui.urls` 설정을 제거합니다.

 ## 배경
Queue 서비스의 서명/검증 키 보안 취약점 확인 중, `application.yaml` 파일을 확인하다가 Recommendation 모듈 제거 후에도 각 모듈에 swagger-ui urls 설정이 남아 있는 것을 발견.
확인해보니 auth-guard, queue, seat, order-core 전 모듈의 application 파일에 동일한 swagger-ui urls 블록이 남아 있어, 일괄 제거함.