### PR TITLE
feat(seat): Seat 서비스 어드미션 토큰 검증 구현 [GRGB-273]

### DIFF
--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -8,6 +8,11 @@ dependencies {
     // Redisson 분산 락 (Spring Boot 4 버전 호환: starter 대신 core 라이브러리 직접 사용)
     implementation 'org.redisson:redisson:3.44.0'
 
+    // JWT 어드미션 토큰 검증
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
+
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/controller/SeatCommonController.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.seat.common.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
 import com.goormgb.be.seat.common.service.SeatHoldService;
+import com.goormgb.be.seat.security.AdmissionTokenValidator;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,6 +31,7 @@ public class SeatCommonController {
 
 	private final SeatCommonService seatCommonService;
 	private final SeatHoldService seatHoldService;
+	private final AdmissionTokenValidator admissionTokenValidator;
 
 	@Operation(
 		summary = "좌석 그룹 초기 조회",
@@ -42,9 +45,10 @@ public class SeatCommonController {
 	@GetMapping("/seat-groups")
 	public ApiResult<SeatGroupsEntryResponse> getCommonSeatGroup(
 		@PathVariable Long matchId,
-		@AuthenticationPrincipal Long userId
-		// TODO: 큐 진입 토큰 확인
+		@AuthenticationPrincipal Long userId,
+		@CookieValue(name = "admissionToken") String admissionToken
 	) {
+		admissionTokenValidator.validate(admissionToken, userId, matchId);
 		return ApiResult.ok(seatCommonService.getSeatGroupsEntry(matchId, userId));
 	}
 
@@ -81,9 +85,10 @@ public class SeatCommonController {
 	public ApiResult<SectionBlocksResponse> getSectionBlocks(
 		@PathVariable Long matchId,
 		@PathVariable Long sectionId,
-		@AuthenticationPrincipal Long userId
-		// TODO: 큐 진입 토큰 확인
+		@AuthenticationPrincipal Long userId,
+		@CookieValue(name = "admissionToken") String admissionToken
 	) {
+		admissionTokenValidator.validate(admissionToken, userId, matchId);
 		return ApiResult.ok(seatCommonService.getSectionBlocks(matchId, sectionId, userId));
 	}
 

--- a/Seat/src/main/java/com/goormgb/be/seat/config/AdmissionJwtProperties.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/AdmissionJwtProperties.java
@@ -1,0 +1,10 @@
+package com.goormgb.be.seat.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "admission.jwt")
+public record AdmissionJwtProperties(
+	String publicKey,
+	String issuer
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.seat.recommendation.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
 import com.goormgb.be.seat.recommendation.service.SeatAssignmentService;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
+import com.goormgb.be.seat.security.AdmissionTokenValidator;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,6 +31,7 @@ public class SeatRecommendationController {
 
 	private final SeatRecommendationService seatRecommendationService;
 	private final SeatAssignmentService seatAssignmentService;
+	private final AdmissionTokenValidator admissionTokenValidator;
 
 	@Operation(
 		summary = "추천 좌석 초기 조회",
@@ -41,9 +44,10 @@ public class SeatRecommendationController {
 	@GetMapping("/seat-entry")
 	public ApiResult<SeatEntryResponse> getRecommendationSeatEntry(
 		@PathVariable Long matchId,
-		@AuthenticationPrincipal Long userId
-		// TODO: 큐 진입 토큰 확인
+		@AuthenticationPrincipal Long userId,
+		@CookieValue(name = "admissionToken") String admissionToken
 	) {
+		admissionTokenValidator.validate(admissionToken, userId, matchId);
 		return ApiResult.ok(seatRecommendationService.getRecommendationSeatEntry(matchId, userId));
 	}
 

--- a/Seat/src/main/java/com/goormgb/be/seat/security/AdmissionTokenValidator.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/security/AdmissionTokenValidator.java
@@ -1,0 +1,56 @@
+package com.goormgb.be.seat.security;
+
+import java.security.interfaces.RSAPublicKey;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.global.util.RsaKeyUtils;
+import com.goormgb.be.seat.config.AdmissionJwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdmissionTokenValidator {
+
+	private static final String TOKEN_TYPE = "ADMISSION";
+	private static final String CLAIM_MATCH_ID = "matchId";
+	private static final String CLAIM_TYPE = "type";
+
+	private final AdmissionJwtProperties admissionJwtProperties;
+	private RSAPublicKey publicKey;
+
+	@PostConstruct
+	public void init() {
+		this.publicKey = RsaKeyUtils.parsePublicKey(admissionJwtProperties.publicKey());
+	}
+
+	public void validate(String token, Long expectedUserId, Long expectedMatchId) {
+		try {
+			Claims claims = Jwts.parser()
+				.verifyWith(publicKey)
+				.requireIssuer(admissionJwtProperties.issuer())
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+
+			Long userId = Long.valueOf(claims.getSubject());
+			Long matchId = claims.get(CLAIM_MATCH_ID, Long.class);
+			String type = claims.get(CLAIM_TYPE, String.class);
+
+			Preconditions.validate(TOKEN_TYPE.equals(type), ErrorCode.INVALID_TOKEN);
+			Preconditions.validate(expectedUserId.equals(userId), ErrorCode.INVALID_TOKEN);
+			Preconditions.validate(expectedMatchId.equals(matchId), ErrorCode.INVALID_TOKEN);
+		} catch (CustomException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.INVALID_TOKEN);
+		}
+	}
+}

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -33,19 +33,10 @@ spring:
 queue:
   preference-key-prefix: seat:preference
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
+admission:
+  jwt:
+    public-key: ${ADMISSION_PUBLIC_KEY}
+    issuer: ${JWT_ISSUER:goormgb-auth-service}
 
 management:
   endpoints:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -33,19 +33,10 @@ spring:
 queue:
   preference-key-prefix: seat:preference
 
-springdoc:
-  swagger-ui:
-    urls:
-      - name: Auth-Guard
-        url: http://localhost:8080/auth/v3/api-docs
-      - name: Queue
-        url: http://localhost:8081/queue/v3/api-docs
-      - name: Seat
-        url: http://localhost:8082/seat/v3/api-docs
-      - name: Order-Core
-        url: http://localhost:8083/order/v3/api-docs
-      - name: Recommendation
-        url: http://localhost:8084/recommendation/v3/api-docs
+admission:
+  jwt:
+    public-key: ${ADMISSION_PUBLIC_KEY}
+    issuer: ${JWT_ISSUER:goormgb-auth-service}
 
 management:
   endpoint:

--- a/Seat/src/test/java/com/goormgb/be/seat/security/AdmissionTokenValidatorTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/security/AdmissionTokenValidatorTest.java
@@ -1,0 +1,151 @@
+package com.goormgb.be.seat.security;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.global.exception.CustomException;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.config.AdmissionJwtProperties;
+
+import io.jsonwebtoken.Jwts;
+
+class AdmissionTokenValidatorTest {
+
+	private static AdmissionTokenValidator validator;
+	private static RSAPrivateKey privateKey;
+	private static RSAPublicKey publicKey;
+	private static final String ISSUER = "queue-service";
+
+	@BeforeAll
+	static void setUp() throws Exception {
+		KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+		keyGen.initialize(2048);
+		KeyPair keyPair = keyGen.generateKeyPair();
+		privateKey = (RSAPrivateKey)keyPair.getPrivate();
+		publicKey = (RSAPublicKey)keyPair.getPublic();
+
+		String publicKeyBase64 = Base64.getEncoder().encodeToString(publicKey.getEncoded());
+		AdmissionJwtProperties properties = new AdmissionJwtProperties(publicKeyBase64, ISSUER);
+
+		validator = new AdmissionTokenValidator(properties);
+		validator.init();
+	}
+
+	private String issueToken(Long userId, Long matchId, Duration ttl) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.subject(String.valueOf(userId))
+			.issuer(ISSUER)
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(now.plus(ttl)))
+			.id(UUID.randomUUID().toString())
+			.claim("matchId", matchId)
+			.claim("type", "ADMISSION")
+			.signWith(privateKey, Jwts.SIG.RS256)
+			.compact();
+	}
+
+	@Test
+	@DisplayName("유효한 어드미션 토큰 검증 성공")
+	void 유효한_토큰_검증_성공() {
+		String token = issueToken(1L, 100L, Duration.ofSeconds(30));
+
+		assertThatCode(() -> validator.validate(token, 1L, 100L))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("만료된 토큰이면 INVALID_TOKEN 예외")
+	void 만료된_토큰() {
+		Instant past = Instant.now().minusSeconds(60);
+		String token = Jwts.builder()
+			.subject("1")
+			.issuer(ISSUER)
+			.issuedAt(Date.from(past.minusSeconds(30)))
+			.expiration(Date.from(past))
+			.id(UUID.randomUUID().toString())
+			.claim("matchId", 100L)
+			.claim("type", "ADMISSION")
+			.signWith(privateKey, Jwts.SIG.RS256)
+			.compact();
+
+		assertThatThrownBy(() -> validator.validate(token, 1L, 100L))
+			.isInstanceOf(CustomException.class)
+			.satisfies(e -> assertThat(((CustomException)e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+	}
+
+	@Test
+	@DisplayName("다른 키로 서명된 토큰이면 INVALID_TOKEN 예외")
+	void 위조된_서명() throws Exception {
+		KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+		keyGen.initialize(2048);
+		RSAPrivateKey fakeKey = (RSAPrivateKey)keyGen.generateKeyPair().getPrivate();
+
+		String token = Jwts.builder()
+			.subject("1")
+			.issuer(ISSUER)
+			.issuedAt(Date.from(Instant.now()))
+			.expiration(Date.from(Instant.now().plusSeconds(30)))
+			.id(UUID.randomUUID().toString())
+			.claim("matchId", 100L)
+			.claim("type", "ADMISSION")
+			.signWith(fakeKey, Jwts.SIG.RS256)
+			.compact();
+
+		assertThatThrownBy(() -> validator.validate(token, 1L, 100L))
+			.isInstanceOf(CustomException.class)
+			.satisfies(e -> assertThat(((CustomException)e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+	}
+
+	@Test
+	@DisplayName("userId가 불일치하면 INVALID_TOKEN 예외")
+	void userId_불일치() {
+		String token = issueToken(1L, 100L, Duration.ofSeconds(30));
+
+		assertThatThrownBy(() -> validator.validate(token, 999L, 100L))
+			.isInstanceOf(CustomException.class)
+			.satisfies(e -> assertThat(((CustomException)e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+	}
+
+	@Test
+	@DisplayName("matchId가 불일치하면 INVALID_TOKEN 예외")
+	void matchId_불일치() {
+		String token = issueToken(1L, 100L, Duration.ofSeconds(30));
+
+		assertThatThrownBy(() -> validator.validate(token, 1L, 999L))
+			.isInstanceOf(CustomException.class)
+			.satisfies(e -> assertThat(((CustomException)e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+	}
+
+	@Test
+	@DisplayName("type이 ADMISSION이 아니면 INVALID_TOKEN 예외")
+	void 잘못된_토큰_타입() {
+		String token = Jwts.builder()
+			.subject("1")
+			.issuer(ISSUER)
+			.issuedAt(Date.from(Instant.now()))
+			.expiration(Date.from(Instant.now().plusSeconds(30)))
+			.id(UUID.randomUUID().toString())
+			.claim("matchId", 100L)
+			.claim("type", "ACCESS")
+			.signWith(privateKey, Jwts.SIG.RS256)
+			.compact();
+
+		assertThatThrownBy(() -> validator.validate(token, 1L, 100L))
+			.isInstanceOf(CustomException.class)
+			.satisfies(e -> assertThat(((CustomException)e).getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN));
+	}
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
+      ADMISSION_PUBLIC_KEY: ${ADMISSION_PUBLIC_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy


### PR DESCRIPTION
## 🔧 작업 내용
- Seat 진입 API 3곳에서 어드미션 토큰(JWT, RS256) 쿠키 검증을 구현하여 대기열을 통과한 유저만 접근 가능하도록 함
- Queue의 공개키(`ADMISSION_PUBLIC_KEY`)만으로 서명을 검증하며, 로그인 JWT 키와 완전 분리
- 기존 `// TODO: 큐 진입 토큰 확인` 주석 3곳을 실제 검증 로직으로 교체

## 🧩 구현 상세
### 어드미션 토큰 검증 모듈
- `AdmissionJwtProperties`: `admission.jwt.public-key`, `admission.jwt.issuer` 설정 바인딩
- `AdmissionTokenValidator`: RSA 공개키로 JWT 서명 검증 + issuer/type/userId/matchId 클레임 검증
  - 검증 실패 시 `Preconditions.validate()`로 `INVALID_TOKEN`(401) 예외 발생
  - `RsaKeyUtils`(common-core)를 재사용하여 base64 DER → RSAPublicKey 변환

### 컨트롤러 적용
- `@CookieValue(name = "admissionToken")`로 쿠키에서 토큰 수신
- Queue가 READY 응답 시 세팅하는 `admissionToken` 쿠키를 그대로 활용

| 컨트롤러 | 메서드 | 엔드포인트 |
|----------|--------|-----------|
| `SeatCommonController` | `getCommonSeatGroup` | `GET /matches/{matchId}/seat-groups` |
| `SeatCommonController` | `getSectionBlocks` | `GET /matches/{matchId}/sections/{sectionId}/blocks` |
| `SeatRecommendationController` | `getRecommendationSeatEntry` | `GET /matches/{matchId}/recommendations/seat-entry` |

> `seat-holds`, `assign`, `blocks` 등 진입 이후 API는 검증 대상에서 제외

### 키 분리
- Seat에는 공개키만 주입 (private키 불필요)
#157 
작업이 진행되기 전이기 때문에, 우선 로컬에서만 기능 개발, 로컬 테스트용으로 RSA 2048 pem 키로 발급하여 발급/검증 테스트 진행함. (queue, seat)

### 📌 관련 Jira Issue
- GRGB-273

## 🧪 테스트 방법
### `AdmissionTokenValidatorTest` (6개 테스트)
- 유효한 어드미션 토큰 검증 성공
- 만료된 토큰 → `INVALID_TOKEN` 예외
- 위조된 서명(다른 키로 서명) → `INVALID_TOKEN` 예외
- userId 불일치 → `INVALID_TOKEN` 예외
- matchId 불일치 → `INVALID_TOKEN` 예외
- type이 ADMISSION이 아닌 경우 → `INVALID_TOKEN` 예외
<img width="941" height="489" alt="스크린샷 2026-03-18 오전 3 27 33" src="https://github.com/user-attachments/assets/5cc2877b-45c5-4b66-bd4f-48cee60b546f" />
<img width="941" height="489" alt="스크린샷 2026-03-18 오전 3 27 33" src="https://github.com/user-attachments/assets/5cc2877b-45c5-4b66-bd4f-48cee60b546f" />


### 실행
```bash
./gradlew :Seat:test --tests "com.goormgb.be.seat.security.AdmissionTokenValidatorTest"
```

## ❗ 참고 사항
- Queue, Seat의 `application.yaml`, `application-dev.yaml`에 `admission.jwt` 설정 추가는 별도 작업 필요‼️ #157 @siyeon13 
- `docker-compose.yml` seat 서비스에 `ADMISSION_PUBLIC_KEY` 환경변수 추가 필요
- 클라우드 팀에 배포 환경 `ADMISSION_PUBLIC_KEY` 시크릿 등록 요청 필요
- 어드미션 토큰 키 분리 이슈(GRGB-XXX)와 병렬 진행 가능 (기존 키로도 임시 동작)
- 프론트에서 Seat API 호출 시 `credentials: 'include'`(fetch) 또는 `withCredentials: true`(axios) 설정 필요
