### PR TITLE
refactor(queue, seat, common-core): 선호 블럭 데이터 흐름 정리 - Redis 중복 제거 및 DB 직접 조회 전환   [GRGB-273]

### DIFF
--- a/Queue/src/main/java/com/goormgb/be/queue/queue/dto/request/QueueEnterRequest.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/dto/request/QueueEnterRequest.java
@@ -1,19 +1,13 @@
 package com.goormgb.be.queue.queue.dto.request;
 
-import java.util.List;
-
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
 
 public record QueueEnterRequest(
 	boolean recommendationEnabled,
 
 	@Min(1)
 	@Max(10)
-	int ticketCount,
-
-	@Size(max = 10)
-	List<Long> preferredBlockIds
+	int ticketCount
 ) {
 }

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
@@ -2,7 +2,6 @@ package com.goormgb.be.queue.queue.service;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -67,7 +66,6 @@ public class QueueService {
 			matchId,
 			request.recommendationEnabled(),
 			request.ticketCount(),
-			normalizePreferredBlockIds(request.preferredBlockIds()),
 			Instant.now()
 		);
 
@@ -130,15 +128,6 @@ public class QueueService {
 		if (request.ticketCount() < 1 || request.ticketCount() > 10) {
 			throw new CustomException(ErrorCode.INVALID_TICKET_COUNT);
 		}
-
-		List<Long> blockIds = normalizePreferredBlockIds(request.preferredBlockIds());
-		if (blockIds.size() != blockIds.stream().distinct().count()) {
-			throw new CustomException(ErrorCode.DUPLICATE_PREFERRED_BLOCK);
-		}
-	}
-
-	private List<Long> normalizePreferredBlockIds(List<Long> preferredBlockIds) {
-		return preferredBlockIds == null ? List.of() : preferredBlockIds;
 	}
 
 	private void requireAuthenticated(Long userId) {

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatEntryResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatEntryResponse.java
@@ -1,7 +1,6 @@
 package com.goormgb.be.seat.recommendation.dto.response;
 
 import java.time.Instant;
-import java.util.List;
 
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.match.entity.Match;
@@ -69,15 +68,13 @@ public record SeatEntryResponse(
 
 	public record SeatSessionInfo(
 		boolean recommendationEnabled,
-		int ticketCount,
-		List<Long> preferredBlockIds
+		int ticketCount
 	) {
 
 		public static SeatSessionInfo from(SeatSession seatPreferenceCache) {
 			return new SeatSessionInfo(
 				seatPreferenceCache.isRecommendationEnabled(),
-				seatPreferenceCache.getTicketCount(),
-				seatPreferenceCache.getPreferredBlockIds()
+				seatPreferenceCache.getTicketCount()
 			);
 		}
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -10,8 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
 import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
 import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
 import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
 import com.goormgb.be.global.exception.ErrorCode;
@@ -38,6 +40,7 @@ public class SeatRecommendationService {
 	private final SeatPreferenceRedisRepository seatPreferenceRedisRepository;
 	private final BlockRepository blockRepository;
 	private final MatchSeatRepository matchSeatRepository;
+	private final OnboardingPreferredBlockRepository onboardingPreferredBlockRepository;
 	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
 	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
 	private final ConsecutiveSeatCounter consecutiveSeatCounter;
@@ -54,7 +57,10 @@ public class SeatRecommendationService {
 	public BlockRecommendationResponse getRecommendedBlocks(Long matchId, Long userId) {
 		SeatSession seatSession = seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 		int ticketCount = seatSession.getTicketCount();
-		List<Long> preferredBlockIds = seatSession.getPreferredBlockIds();
+		List<Long> preferredBlockIds = onboardingPreferredBlockRepository.findAllByUserId(userId)
+			.stream()
+			.map(OnboardingPreferredBlock::getBlockId)
+			.toList();
 
 		Match match = matchRepository.findDetailByIdOrThrow(matchId);
 		List<Block> preferredBlocks = blockRepository.findAllByIdInWithSectionAndArea(preferredBlockIds);

--- a/Seat/src/main/java/com/goormgb/be/seat/redis/SeatPreferenceRedisRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/redis/SeatPreferenceRedisRepository.java
@@ -51,8 +51,7 @@ public class SeatPreferenceRedisRepository {
 				cache.userId(),
 				cache.matchId(),
 				cache.recommendationEnabled(),
-				cache.ticketCount(),
-				cache.preferredBlockIds()
+				cache.ticketCount()
 			);
 		} catch (IOException e) {
 			throw new IllegalStateException("Failed to deserialize redis seat preference for key: " + key, e);

--- a/Seat/src/main/java/com/goormgb/be/seat/redis/SeatSession.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/redis/SeatSession.java
@@ -1,7 +1,6 @@
 package com.goormgb.be.seat.redis;
 
 import java.io.Serializable;
-import java.util.List;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,20 +16,16 @@ public class SeatSession implements Serializable {
 
 	private int ticketCount;
 
-	private List<Long> preferredBlockIds;
-
 	public SeatSession(
 		Long userId,
 		Long matchId,
 		boolean recommendationEnabled,
-		int ticketCount,
-		List<Long> preferredBlockIds
+		int ticketCount
 	) {
 		this.userId = userId;
 		this.matchId = matchId;
 		this.recommendationEnabled = recommendationEnabled;
 		this.ticketCount = ticketCount;
-		this.preferredBlockIds = preferredBlockIds;
 	}
 
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
@@ -22,6 +22,7 @@ import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.common.service.SeatCommonService;
 import com.goormgb.be.seat.common.service.SeatHoldService;
+import com.goormgb.be.seat.security.AdmissionTokenValidator;
 import com.goormgb.be.seat.support.WebMvcTestSupport;
 
 @WebMvcTest(SeatCommonController.class)
@@ -33,6 +34,9 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 
 	@MockitoBean
 	private SeatHoldService seatHoldService;
+
+	@MockitoBean
+	private AdmissionTokenValidator admissionTokenValidator;
 
 	private void setAuthentication(Long userId) {
 		SecurityContextHolder.getContext().setAuthentication(
@@ -78,7 +82,8 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 		given(seatCommonService.getSeatGroupsEntry(eq(matchId), eq(userId))).willReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/matches/{matchId}/seat-groups", matchId))
+		mockMvc.perform(get("/matches/{matchId}/seat-groups", matchId)
+				.cookie(new jakarta.servlet.http.Cookie("admissionToken", "test-token")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.message").value("성공"))
@@ -159,7 +164,8 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 		given(seatCommonService.getSectionBlocks(eq(matchId), eq(sectionId), eq(userId))).willReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/matches/{matchId}/sections/{sectionId}/blocks", matchId, sectionId))
+		mockMvc.perform(get("/matches/{matchId}/sections/{sectionId}/blocks", matchId, sectionId)
+				.cookie(new jakarta.servlet.http.Cookie("admissionToken", "test-token")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.message").value("성공"))

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
@@ -19,8 +19,8 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
+import com.goormgb.be.seat.fixture.SeatSessionFixture;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
-import com.goormgb.be.seat.redis.SeatSession;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldServiceTest {
@@ -40,7 +40,7 @@ class SeatHoldServiceTest {
 
 	private void setupSession(int ticketCount) {
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
-			.willReturn(new SeatSession(USER_ID, MATCH_ID, true, ticketCount, List.of(1L)));
+			.willReturn(SeatSessionFixture.of(USER_ID, MATCH_ID, true, ticketCount));
 	}
 
 	@Test

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
@@ -2,6 +2,8 @@ package com.goormgb.be.seat.fixture;
 
 import java.util.List;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.area.enums.AreaCode;
@@ -114,5 +116,20 @@ public final class BlockFixture {
 
 	public static BlockItemDto cpBlockItemDto() {
 		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
+	}
+
+	public static Block block(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint,
+		Integer homeCheerRank, Integer awayCheerRank) {
+		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
+		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
+		Block block = Block.builder()
+			.area(area).section(section).blockCode(blockCode)
+			.viewpoint(viewpoint).homeCheerRank(homeCheerRank).awayCheerRank(awayCheerRank).build();
+		ReflectionTestUtils.setField(block, "id", id);
+		return block;
+	}
+
+	public static Block block(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint) {
+		return block(id, blockCode, areaCode, viewpoint, 1, 81);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/CommonFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/CommonFixture.java
@@ -1,0 +1,51 @@
+package com.goormgb.be.seat.fixture;
+
+import java.time.Instant;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.stadium.entity.Stadium;
+import com.goormgb.be.user.entity.User;
+
+public final class CommonFixture {
+
+	private CommonFixture() {
+	}
+
+	public static Club club(Long id, String name) {
+		Club club = Club.builder()
+			.koName(name).enName(name).logoImg("logo.png").clubColor("#000").build();
+		ReflectionTestUtils.setField(club, "id", id);
+		return club;
+	}
+
+	public static Club lgClub() {
+		return club(1L, "LG 트윈스");
+	}
+
+	public static Club doosanClub() {
+		return club(2L, "두산 베어스");
+	}
+
+	public static Club samsungClub() {
+		return club(3L, "삼성 라이온즈");
+	}
+
+	public static User user(Long id) {
+		User user = User.builder().build();
+		ReflectionTestUtils.setField(user, "id", id);
+		return user;
+	}
+
+	public static Stadium jamsil() {
+		return Stadium.builder()
+			.region("서울").koName("잠실").enName("Jamsil").address("서울시").build();
+	}
+
+	public static Match match(Club home, Club away) {
+		return Match.create(Instant.now(), home, away, jamsil(), SaleStatus.ON_SALE);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/OnboardingFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/OnboardingFixture.java
@@ -1,0 +1,47 @@
+package com.goormgb.be.seat.fixture;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.user.entity.User;
+
+public final class OnboardingFixture {
+
+	private OnboardingFixture() {
+	}
+
+	public static OnboardingPreference preference(User user, Club favoriteClub, CheerProximityPref cheerPref) {
+		return OnboardingPreference.builder()
+			.user(user)
+			.favoriteClub(favoriteClub)
+			.cheerProximityPref(cheerPref)
+			.build();
+	}
+
+	public static OnboardingViewpointPriority viewpointPriority(User user, Viewpoint viewpoint, int priority) {
+		return OnboardingViewpointPriority.builder()
+			.user(user)
+			.viewpoint(viewpoint)
+			.priority(priority)
+			.build();
+	}
+
+	public static OnboardingPreferredBlock preferredBlock(User user, Long blockId) {
+		return OnboardingPreferredBlock.builder()
+			.user(user)
+			.blockId(blockId)
+			.build();
+	}
+
+	public static List<OnboardingPreferredBlock> preferredBlocks(User user, Long... blockIds) {
+		return Arrays.stream(blockIds)
+			.map(id -> preferredBlock(user, id))
+			.toList();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/SeatSessionFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/SeatSessionFixture.java
@@ -1,0 +1,17 @@
+package com.goormgb.be.seat.fixture;
+
+import com.goormgb.be.seat.redis.SeatSession;
+
+public final class SeatSessionFixture {
+
+	private SeatSessionFixture() {
+	}
+
+	public static SeatSession of(Long userId, Long matchId, boolean recommendationEnabled, int ticketCount) {
+		return new SeatSession(userId, matchId, recommendationEnabled, ticketCount);
+	}
+
+	public static SeatSession defaultSession(int ticketCount) {
+		return new SeatSession(1L, 1L, true, ticketCount);
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.recommendation.service.SeatAssignmentService;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
+import com.goormgb.be.seat.security.AdmissionTokenValidator;
 
 @WebMvcTest(SeatRecommendationController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -36,6 +37,9 @@ class SeatAssignmentControllerTest {
 
 	@MockitoBean
 	private SeatAssignmentService seatAssignmentService;
+
+	@MockitoBean
+	private AdmissionTokenValidator admissionTokenValidator;
 
 	private void setAuthentication(Long userId) {
 		SecurityContextHolder.getContext().setAuthentication(

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.goormgb.be.seat.recommendation.dto.response.SeatEntryResponse;
 import com.goormgb.be.seat.recommendation.service.SeatAssignmentService;
 import com.goormgb.be.seat.recommendation.service.SeatRecommendationService;
+import com.goormgb.be.seat.security.AdmissionTokenValidator;
 
 @WebMvcTest(SeatRecommendationController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -35,6 +36,9 @@ class SeatRecommendationControllerTest {
 
 	@MockitoBean
 	private SeatAssignmentService seatAssignmentService;
+
+	@MockitoBean
+	private AdmissionTokenValidator admissionTokenValidator;
 
 	private void setAuthentication(Long userId) {
 		SecurityContextHolder.getContext().setAuthentication(
@@ -60,8 +64,7 @@ class SeatRecommendationControllerTest {
 			),
 			new SeatEntryResponse.SeatSessionInfo(
 				true,
-				2,
-				List.of(206L, 208L, 105L)
+				2
 			)
 		);
 
@@ -69,7 +72,8 @@ class SeatRecommendationControllerTest {
 			.willReturn(response);
 
 		// when & then
-		mockMvc.perform(get("/matches/{matchId}/recommendations/seat-entry", matchId))
+		mockMvc.perform(get("/matches/{matchId}/recommendations/seat-entry", matchId)
+				.cookie(new jakarta.servlet.http.Cookie("admissionToken", "test-token")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.data.match.matchId").value(10))
@@ -80,9 +84,6 @@ class SeatRecommendationControllerTest {
 			.andExpect(jsonPath("$.data.match.stadium.stadiumId").value(3))
 			.andExpect(jsonPath("$.data.match.stadium.koName").value("잠실 야구장"))
 			.andExpect(jsonPath("$.data.seatSession.recommendationEnabled").value(true))
-			.andExpect(jsonPath("$.data.seatSession.ticketCount").value(2))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[0]").value(206))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[1]").value(208))
-			.andExpect(jsonPath("$.data.seatSession.preferredBlockIds[2]").value(105));
+			.andExpect(jsonPath("$.data.seatSession.ticketCount").value(2));
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculatorTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/PreferenceScoreCalculatorTest.java
@@ -2,7 +2,6 @@ package com.goormgb.be.seat.recommendation.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -10,97 +9,34 @@ import org.junit.jupiter.api.Test;
 
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.match.entity.Match;
-import com.goormgb.be.domain.match.enums.SaleStatus;
-import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
 import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
-import com.goormgb.be.domain.stadium.entity.Stadium;
-import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
-import com.goormgb.be.seat.section.entity.Section;
-import com.goormgb.be.seat.section.enums.SectionCode;
+import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.fixture.CommonFixture;
+import com.goormgb.be.seat.fixture.OnboardingFixture;
 import com.goormgb.be.user.entity.User;
-
-import org.springframework.test.util.ReflectionTestUtils;
 
 class PreferenceScoreCalculatorTest {
 
 	private final PreferenceScoreCalculator calculator = new PreferenceScoreCalculator();
 
-	private Club createClub(Long id, String name) {
-		Club club = Club.builder()
-			.koName(name)
-			.enName(name)
-			.logoImg("logo.png")
-			.clubColor("#000")
-			.build();
-		ReflectionTestUtils.setField(club, "id", id);
-		return club;
-	}
-
-	private User createUser(Long id) {
-		User user = User.builder().build();
-		ReflectionTestUtils.setField(user, "id", id);
-		return user;
-	}
-
-	private Match createMatch(Club home, Club away) {
-		Stadium stadium = Stadium.builder()
-			.region("서울")
-			.koName("잠실")
-			.enName("Jamsil")
-			.address("서울시")
-			.build();
-		return Match.create(Instant.now(), home, away, stadium, SaleStatus.ON_SALE);
-	}
-
-	private Block createBlock(AreaCode areaCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
-		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
-		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
-		return Block.builder()
-			.area(area)
-			.section(section)
-			.blockCode("205")
-			.viewpoint(viewpoint)
-			.homeCheerRank(homeCheerRank)
-			.awayCheerRank(awayCheerRank)
-			.build();
-	}
-
-	private OnboardingPreference createPref(User user, Club favoriteClub, CheerProximityPref cheerPref) {
-		return OnboardingPreference.builder()
-			.user(user)
-			.favoriteClub(favoriteClub)
-			.cheerProximityPref(cheerPref)
-			.build();
-	}
-
-	private OnboardingViewpointPriority createViewpointPriority(User user, Viewpoint viewpoint, int priority) {
-		return OnboardingViewpointPriority.builder()
-			.user(user)
-			.viewpoint(viewpoint)
-			.priority(priority)
-			.build();
-	}
-
 	@Test
 	@DisplayName("뷰포인트 1순위 블럭은 30점을 받는다")
 	void 뷰포인트_1순위_30점() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
-		OnboardingPreference pref = createPref(user, createClub(3L, "삼성 라이온즈"), CheerProximityPref.ANY);
-		List<OnboardingViewpointPriority> viewpoints = List.of(
-			createViewpointPriority(user, Viewpoint.OUTFIELD_C, 1)
-		);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, viewpoints, match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, CommonFixture.samsungClub(), CheerProximityPref.ANY),
+			List.of(OnboardingFixture.viewpointPriority(user, Viewpoint.OUTFIELD_C, 1)),
+			match);
 
 		// then
 		assertThat(score).isEqualTo(30);
@@ -110,15 +46,16 @@ class PreferenceScoreCalculatorTest {
 	@DisplayName("응원구단이 홈팀이고 블럭이 HOME이면 구단 가중치 25점을 받는다")
 	void 응원구단_홈팀_HOME블럭_25점() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
-		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.ANY);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, lgClub, CheerProximityPref.ANY),
+			List.of(), match);
 
 		// then
 		assertThat(score).isEqualTo(25);
@@ -128,15 +65,16 @@ class PreferenceScoreCalculatorTest {
 	@DisplayName("NEAR 선호 + 응원석 가까운 블럭(rank<=3)이면 15점을 받는다")
 	void NEAR_응원석_가까운_블럭_15점() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 2, 80);
-		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.NEAR);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B, 2, 80);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, lgClub, CheerProximityPref.NEAR),
+			List.of(), match);
 
 		// then
 		// clubPref(25) + cheerProximity(15) = 40
@@ -147,15 +85,16 @@ class PreferenceScoreCalculatorTest {
 	@DisplayName("FAR 선호 + 응원석 먼 블럭(rank>3)이면 15점을 받는다")
 	void FAR_응원석_먼_블럭_15점() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
-		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.FAR);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C, 70, 70);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, lgClub, CheerProximityPref.FAR),
+			List.of(), match);
 
 		// then
 		assertThat(score).isEqualTo(15);
@@ -165,18 +104,17 @@ class PreferenceScoreCalculatorTest {
 	@DisplayName("모든 조건이 맞으면 최대 점수를 받는다")
 	void 모든_조건_최대점수() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
-		OnboardingPreference pref = createPref(user, lgClub, CheerProximityPref.NEAR);
-		List<OnboardingViewpointPriority> viewpoints = List.of(
-			createViewpointPriority(user, Viewpoint.INFIELD_1B, 1)
-		);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, viewpoints, match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, lgClub, CheerProximityPref.NEAR),
+			List.of(OnboardingFixture.viewpointPriority(user, Viewpoint.INFIELD_1B, 1)),
+			match);
 
 		// then
 		// viewpoint(30) + clubPref(25) + cheerProximity(15) = 70
@@ -187,16 +125,17 @@ class PreferenceScoreCalculatorTest {
 	@DisplayName("비참가 구단 팬은 구단 가중치를 받지 않는다")
 	void 비참가_구단_팬_구단가중치_없음() {
 		// given
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		Club samsungClub = createClub(3L, "삼성 라이온즈");
-		User user = createUser(1L);
-		Match match = createMatch(lgClub, doosanClub);
-		Block block = createBlock(AreaCode.HOME, Viewpoint.INFIELD_1B, 1, 81);
-		OnboardingPreference pref = createPref(user, samsungClub, CheerProximityPref.ANY);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		Club samsungClub = CommonFixture.samsungClub();
+		User user = CommonFixture.user(1L);
+		Match match = CommonFixture.match(lgClub, doosanClub);
+		Block block = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
 
 		// when
-		int score = calculator.calculatePreferenceScore(block, pref, List.of(), match);
+		int score = calculator.calculatePreferenceScore(block,
+			OnboardingFixture.preference(user, samsungClub, CheerProximityPref.ANY),
+			List.of(), match);
 
 		// then
 		assertThat(score).isEqualTo(0);

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -18,9 +18,9 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.fixture.SeatSessionFixture;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
-import com.goormgb.be.seat.redis.SeatSession;
 
 @ExtendWith(MockitoExtension.class)
 class SeatAssignmentServiceTest {
@@ -38,8 +38,8 @@ class SeatAssignmentServiceTest {
 	private SeatAssignmentService seatAssignmentService;
 
 	private void setupCommon() {
-		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
-		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
+			.willReturn(SeatSessionFixture.defaultSession(3));
 		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
 		given(seatBlockLock.tryLock(1L, 1L)).willReturn(true);
 	}
@@ -68,8 +68,8 @@ class SeatAssignmentServiceTest {
 	@DisplayName("락 획득 실패 시 예외가 발생한다")
 	void 락_획득_실패_예외() {
 		// given
-		SeatSession session = new SeatSession(1L, 1L, true, 3, List.of(1L));
-		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L)).willReturn(session);
+		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
+			.willReturn(SeatSessionFixture.defaultSession(3));
 		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
 		given(seatBlockLock.tryLock(1L, 1L)).willReturn(false);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -3,7 +3,6 @@ package com.goormgb.be.seat.recommendation.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,31 +11,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goormgb.be.domain.club.entity.Club;
 import com.goormgb.be.domain.match.entity.Match;
-import com.goormgb.be.domain.match.enums.SaleStatus;
 import com.goormgb.be.domain.match.repository.MatchRepository;
-import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
-import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
 import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
 import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
 import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
 import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
-import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
-import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.fixture.BlockFixture;
+import com.goormgb.be.seat.fixture.CommonFixture;
+import com.goormgb.be.seat.fixture.OnboardingFixture;
+import com.goormgb.be.seat.fixture.SeatSessionFixture;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.seat.redis.SeatPreferenceRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
-import com.goormgb.be.seat.section.entity.Section;
-import com.goormgb.be.seat.section.enums.SectionCode;
 import com.goormgb.be.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +47,8 @@ class SeatRecommendationServiceTest {
 	@Mock
 	private MatchSeatRepository matchSeatRepository;
 	@Mock
+	private OnboardingPreferredBlockRepository onboardingPreferredBlockRepository;
+	@Mock
 	private OnboardingPreferenceRepository onboardingPreferenceRepository;
 	@Mock
 	private OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
@@ -62,68 +60,30 @@ class SeatRecommendationServiceTest {
 	@InjectMocks
 	private SeatRecommendationService seatRecommendationService;
 
-	private Club createClub(Long id, String name) {
-		Club club = Club.builder()
-			.koName(name).enName(name).logoImg("logo.png").clubColor("#000").build();
-		ReflectionTestUtils.setField(club, "id", id);
-		return club;
-	}
-
-	private User createUser(Long id) {
-		User user = User.builder().build();
-		ReflectionTestUtils.setField(user, "id", id);
-		return user;
-	}
-
-	private Block createBlock(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint) {
-		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
-		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
-		Block block = Block.builder()
-			.area(area).section(section).blockCode(blockCode)
-			.viewpoint(viewpoint).homeCheerRank(1).awayCheerRank(81).build();
-		ReflectionTestUtils.setField(block, "id", id);
-		return block;
-	}
-
-	private SeatSession createSeatSession(int ticketCount, List<Long> blockIds) {
-		SeatSession session = new SeatSession();
-		ReflectionTestUtils.setField(session, "userId", 1L);
-		ReflectionTestUtils.setField(session, "matchId", 1L);
-		ReflectionTestUtils.setField(session, "recommendationEnabled", true);
-		ReflectionTestUtils.setField(session, "ticketCount", ticketCount);
-		ReflectionTestUtils.setField(session, "preferredBlockIds", blockIds);
-		return session;
-	}
-
-	private Match createMatch(Club home, Club away) {
-		Stadium stadium = Stadium.builder()
-			.region("서울").koName("잠실").enName("Jamsil").address("서울시").build();
-		return Match.create(Instant.now(), home, away, stadium, SaleStatus.ON_SALE);
-	}
-
 	@Test
 	@DisplayName("추천 블럭 리스트를 연석 개수 기준으로 정렬하여 반환한다")
 	void 추천_블럭_리스트_연석개수_정렬() {
 		// given
 		Long userId = 1L;
 		Long matchId = 1L;
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(userId);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(userId);
 
-		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
-		Block block206 = createBlock(206L, "206", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block205 = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block206 = BlockFixture.block(206L, "206", AreaCode.HOME, Viewpoint.INFIELD_1B);
 
-		SeatSession session = createSeatSession(5, List.of(205L, 206L));
-		Match match = createMatch(lgClub, doosanClub);
-		OnboardingPreference pref = OnboardingPreference.builder()
-			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.ANY).build();
+		SeatSession session = SeatSessionFixture.defaultSession(5);
+		Match match = CommonFixture.match(lgClub, doosanClub);
 
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(onboardingPreferredBlockRepository.findAllByUserId(userId))
+			.willReturn(OnboardingFixture.preferredBlocks(user, 205L, 206L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
 		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 206L)))
 			.willReturn(List.of(block205, block206));
-		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
+			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.ANY));
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
 
 		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());
@@ -150,27 +110,26 @@ class SeatRecommendationServiceTest {
 		// given
 		Long userId = 1L;
 		Long matchId = 1L;
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(userId);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(userId);
 
-		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
-		Block block408 = createBlock(408L, "408", AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C);
+		Block block205 = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block408 = BlockFixture.block(408L, "408", AreaCode.OUTFIELD, Viewpoint.OUTFIELD_C);
 
-		SeatSession session = createSeatSession(3, List.of(205L, 408L));
-		Match match = createMatch(lgClub, doosanClub);
-		OnboardingPreference pref = OnboardingPreference.builder()
-			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.NEAR).build();
-		List<OnboardingViewpointPriority> viewpoints = List.of(
-			OnboardingViewpointPriority.builder().user(user).viewpoint(Viewpoint.INFIELD_1B).priority(1).build()
-		);
+		SeatSession session = SeatSessionFixture.defaultSession(3);
+		Match match = CommonFixture.match(lgClub, doosanClub);
 
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(onboardingPreferredBlockRepository.findAllByUserId(userId))
+			.willReturn(OnboardingFixture.preferredBlocks(user, 205L, 408L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
 		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 408L)))
 			.willReturn(List.of(block205, block408));
-		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
-		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(viewpoints);
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
+			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.NEAR));
+		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId))
+			.willReturn(List.of(OnboardingFixture.viewpointPriority(user, Viewpoint.INFIELD_1B, 1)));
 
 		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());
 
@@ -197,21 +156,22 @@ class SeatRecommendationServiceTest {
 		// given
 		Long userId = 1L;
 		Long matchId = 1L;
-		Club lgClub = createClub(1L, "LG 트윈스");
-		Club doosanClub = createClub(2L, "두산 베어스");
-		User user = createUser(userId);
+		Club lgClub = CommonFixture.lgClub();
+		Club doosanClub = CommonFixture.doosanClub();
+		User user = CommonFixture.user(userId);
 
-		Block block205 = createBlock(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
+		Block block205 = BlockFixture.block(205L, "205", AreaCode.HOME, Viewpoint.INFIELD_1B);
 
-		SeatSession session = createSeatSession(5, List.of(205L));
-		Match match = createMatch(lgClub, doosanClub);
-		OnboardingPreference pref = OnboardingPreference.builder()
-			.user(user).favoriteClub(lgClub).cheerProximityPref(CheerProximityPref.ANY).build();
+		SeatSession session = SeatSessionFixture.defaultSession(5);
+		Match match = CommonFixture.match(lgClub, doosanClub);
 
 		given(seatPreferenceRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId)).willReturn(session);
+		given(onboardingPreferredBlockRepository.findAllByUserId(userId))
+			.willReturn(OnboardingFixture.preferredBlocks(user, 205L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
 		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L))).willReturn(List.of(block205));
-		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any())).willReturn(pref);
+		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
+			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.ANY));
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());
 
 		given(matchSeatRepository.countRemainingSeatsByMatchIdAndBlockIdIn(eq(matchId), any())).willReturn(List.of());

--- a/Seat/src/test/java/com/goormgb/be/seat/redis/repository/SeatPreferenceRedisRepositoryTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/redis/repository/SeatPreferenceRedisRepositoryTest.java
@@ -38,7 +38,6 @@ class SeatPreferenceRedisRepositoryTest {
 			  "matchId": 10,
 			  "recommendationEnabled": false,
 			  "ticketCount": 2,
-			  "preferredBlockIds": [220, 221],
 			  "enteredAt": "2026-03-29T05:00:00Z"
 			}
 			""";
@@ -53,7 +52,6 @@ class SeatPreferenceRedisRepositoryTest {
 		assertThat(session.getMatchId()).isEqualTo(10L);
 		assertThat(session.isRecommendationEnabled()).isFalse();
 		assertThat(session.getTicketCount()).isEqualTo(2);
-		assertThat(session.getPreferredBlockIds()).containsExactly(220L, 221L);
 	}
 
 	@Test

--- a/common-core/src/main/java/com/goormgb/be/global/model/SeatPreferenceCache.java
+++ b/common-core/src/main/java/com/goormgb/be/global/model/SeatPreferenceCache.java
@@ -1,14 +1,15 @@
 package com.goormgb.be.global.model;
 
 import java.time.Instant;
-import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record SeatPreferenceCache(
 	Long userId,
 	Long matchId,
 	boolean recommendationEnabled,
 	int ticketCount,
-	List<Long> preferredBlockIds,
 	Instant enteredAt
 ) {
 }


### PR DESCRIPTION
## 한줄요약
- 추천블럭 알고리즘에서 유저 선호도 블럭을 REdis에서 빼왔는데, 레디스 큐, 레디스 캐시 분리되면서 역할과 책임 명확하게 하려고,
유저선호블럭 테이들 RDB에 있는 정보로 알고리즘 작동하게 수정함
## 🔧 작업 내용
- 유저 선호 블럭(preferredBlockIds)이 DB(onboarding_preferred_blocks)와 Queue Redis에 중복 저장되고, Seat이 분리된 Redis 인스턴스의 데이터를 읽으려는 구조 문제 해결
- Queue에서 선호 블럭을 Redis에 저장하지 않도록 변경하고, Seat 추천 알고리즘에서 DB onboarding_preferred_blocks 테이블을 직접 조회하도록 전환
- 테스트 코드에서 중복되는 팩토리 메서드를 공통 Fixture 클래스로 추출

## 🧩 구현 상세
### 문제 배경
- Queue Redis(6380)에 seat:preference:{matchId}:{userId} 키로 선호 블럭을 저장
- Seat은 자체 Redis(6379)에서 해당 키를 읽으려 함 → 인스턴스가 다르므로 로컬에서 접근 불가
- 동일 데이터가 이미 DB onboarding_preferred_blocks 테이블에 존재하므로 Redis 저장 자체가 불필요

#### common-core 변경
 SeatPreferenceCache record에서 preferredBlockIds 필드 제거
- @JsonIgnoreProperties(ignoreUnknown = true) 추가로 기존 Redis 데이터 역직렬화 하위 호환

#### Queue 모듈 변경                                                                                                  
 - QueueEnterRequest에서 preferredBlockIds 필드 제거
- QueueService.enter()에서 선호 블럭 중복 검증, normalizePreferredBlockIds() 메서드 제거

#### Seat 모듈 변경
- SeatSession에서 preferredBlockIds 필드 제거
- SeatPreferenceRedisRepository에서 preferredBlockIds 매핑 제거
- SeatRecommendationService에 OnboardingPreferredBlockRepository 의존성 추가
- 추천 알고리즘에서 onboardingPreferredBlockRepository.findAllByUserId(userId)로 DB 직접 조회
- SeatEntryResponse.SeatSessionInfo에서 preferredBlockIds 제거

####  테스트 Fixture 공통화                                                                                            
- CommonFixture: Club, User, Match, Stadium 팩토리 메서드
- SeatSessionFixture: SeatSession 생성 팩토리 메서드
- OnboardingFixture: OnboardingPreference, ViewpointPriority, PreferredBlock 팩토리 메서드
- BlockFixture: ID 지정 가능한 block() 오버로드 메서드 추가

###  📌 관련 Jira Issue
  - GRGB-273

##  🧪 테스트 방법
  - ./gradlew :Seat:test 전체 테스트 통과 확인 (85건)
  - 추천 블럭 조회 시 DB onboarding_preferred_blocks 테이블에서 선호 블럭을 정상 조회하는지 확인
  - Queue 진입 시 preferredBlockIds 없이 정상 동작하는지 확인

## ❗ 참고 사항
  - 기존 Redis에 preferredBlockIds가 포함된 데이터가 남아있을 수 있으나, @JsonIgnoreProperties로 역직렬화 시 무시됨
   (TTL 900초 후 자연 만료)
    - 컨트롤러 테스트에 AdmissionTokenValidator mock 및 admissionToken 쿠키 추가 (이전 어드미션 토큰 커밋 반영) 