### PR TITLE
fix(order-core): 선호 블럭 수정 시 unique constraint 위반 수정

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
@@ -3,6 +3,7 @@ package com.goormgb.be.domain.onboarding.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,5 +18,7 @@ public interface OnboardingPreferredBlockRepository extends JpaRepository<Onboar
 
 	long countByUserId(Long userId);
 
-	void deleteAllByUserId(Long userId);
+	@Modifying
+	@Query("DELETE FROM OnboardingPreferredBlock opb WHERE opb.user.id = :userId")
+	void deleteAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 작업내용
- `PUT /onboarding/preferred-blocks` 호출 시 `deleteAllByUserId` → `saveAll` 과정에서 JPA flush 순서로 인해 `(user_id, block_id)` unique constraint 위반 발생
- `@Modifying` JPQL DELETE 쿼리로 변경하여 즉시 삭제 실행되도록 수정

## Hotfix 건이라 self merge 하겠습니다!