### PR TITLE
fix(seat): 추천 비활성화 시 ticketCount null 허용

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/booking/dto/request/BookingOptionsRequest.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/dto/request/BookingOptionsRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Min;
 
 public record BookingOptionsRequest(
 	boolean recommendationEnabled,
-	@Min(1) @Max(10) int ticketCount,
+	@Min(1) @Max(10) Integer ticketCount,
 	boolean nearAdjacentToggle
 ) {
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/booking/dto/response/BookingOptionsResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/dto/response/BookingOptionsResponse.java
@@ -3,7 +3,7 @@ package com.goormgb.be.seat.booking.dto.response;
 public record BookingOptionsResponse(
 	Long matchId,
 	boolean recommendationEnabled,
-	int ticketCount,
+	Integer ticketCount,
 	boolean nearAdjacentToggle
 ) {
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/booking/model/BookingOptions.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/model/BookingOptions.java
@@ -6,7 +6,7 @@ public record BookingOptions(
 	Long userId,
 	Long matchId,
 	boolean recommendationEnabled,
-	int ticketCount,
+	Integer ticketCount,
 	boolean nearAdjacentToggle,
 	Instant createdAt
 ) {

--- a/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.booking.dto.request.BookingOptionsRequest;
 import com.goormgb.be.seat.booking.dto.response.BookingOptionsResponse;
 import com.goormgb.be.seat.booking.model.BookingOptions;
@@ -22,6 +23,10 @@ public class BookingOptionsService {
 
 	public BookingOptionsResponse saveBookingOptions(Long matchId, Long userId, BookingOptionsRequest request) {
 		matchRepository.findByIdOrThrow(matchId, ErrorCode.MATCH_NOT_FOUND);
+
+		if (request.recommendationEnabled()) {
+			Preconditions.validate(request.ticketCount() != null, ErrorCode.INVALID_TICKET_COUNT);
+		}
 
 		BookingOptions options = new BookingOptions(
 			userId,

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatGroupsEntryResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatGroupsEntryResponse.java
@@ -72,7 +72,7 @@ public record SeatGroupsEntryResponse(
 
 	public record SeatSessionInfo(
 		boolean recommendationEnabled,
-		int ticketCount,
+		Integer ticketCount,
 		boolean nearAdjacentToggle
 	) {
 

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -78,8 +78,9 @@ public class SeatHoldService {
 		BookingOptions bookingOptions =
 			bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 
+		Integer ticketCount = bookingOptions.ticketCount();
 		Preconditions.validate(
-			bookingOptions.ticketCount() == requestedCount,
+			ticketCount != null && ticketCount == requestedCount,
 			ErrorCode.INVALID_SEAT_HOLD_REQUEST
 		);
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -6,13 +6,13 @@ import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
 
 public record BlockRecommendationResponse(
 	Long matchId,
-	int ticketCount,
+	Integer ticketCount,
 	List<RecommendedBlock> blocks
 ) {
 
 	public static BlockRecommendationResponse of(
 		Long matchId,
-		int ticketCount,
+		Integer ticketCount,
 		List<BlockRecommendation> recommendations
 	) {
 		List<RecommendedBlock> blocks = new java.util.ArrayList<>();

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatEntryResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/SeatEntryResponse.java
@@ -68,7 +68,7 @@ public record SeatEntryResponse(
 
 	public record SeatSessionInfo(
 		boolean recommendationEnabled,
-		int ticketCount,
+		Integer ticketCount,
 		boolean nearAdjacentToggle
 	) {
 

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -37,7 +37,11 @@ public class SeatAssignmentService {
 	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockId) {
 
 		BookingOptions bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
-		int requiredSeats = bookingOptions.ticketCount();
+
+		Preconditions.validate(bookingOptions.recommendationEnabled(), ErrorCode.BAD_REQUEST);
+		Preconditions.validate(bookingOptions.ticketCount() != null, ErrorCode.INVALID_TICKET_COUNT);
+
+		Integer requiredSeats = bookingOptions.ticketCount();
 		boolean nearAdjacentToggle = bookingOptions.nearAdjacentToggle();
 
 		Block block = blockRepository.findByIdWithSectionOrThrow(blockId);

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -56,6 +56,10 @@ public class SeatRecommendationService {
 	@Transactional(readOnly = true)
 	public BlockRecommendationResponse getRecommendedBlocks(Long matchId, Long userId) {
 		var bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+
+		Preconditions.validate(bookingOptions.recommendationEnabled(), ErrorCode.BAD_REQUEST);
+		Preconditions.validate(bookingOptions.ticketCount() != null, ErrorCode.INVALID_TICKET_COUNT);
+
 		SeatSession seatSession = SeatSession.from(bookingOptions);
 		int ticketCount = seatSession.getTicketCount();
 		List<Long> preferredBlockIds = onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);

--- a/Seat/src/main/java/com/goormgb/be/seat/redis/SeatSession.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/redis/SeatSession.java
@@ -16,7 +16,7 @@ public class SeatSession implements Serializable {
 
 	private boolean recommendationEnabled;
 
-	private int ticketCount;
+	private Integer ticketCount;
 
 	private boolean nearAdjacentToggle;
 
@@ -24,7 +24,7 @@ public class SeatSession implements Serializable {
 		Long userId,
 		Long matchId,
 		boolean recommendationEnabled,
-		int ticketCount,
+		Integer ticketCount,
 		boolean nearAdjacentToggle
 	) {
 		this.userId = userId;


### PR DESCRIPTION
## 🔧 작업 내용
- 예매 옵션 요청/응답 및 세션/모델에서 ticketCount nullable 처리
- 추천 비활성화일 때 ticketCount null 허용하도록 검증 조건 보완

### 배경
ticketcount 를 Refernece 참조 타입으로 받아야 nullable 이 가능한 상황에서, primitive 타입인 int로 받아 Notnull이 되는 상황 발생

## ❗ 참고 사항
- 추천 ON인 경우 ticketCount 필수 유지
