### PR TITLE
hotfix(gateway): DB health check 제거로 기동 실패 해결

### DIFF
--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -62,7 +62,7 @@ management:
         enabled: true
       group:
         readiness:
-          include: readinessState, db
+          include: readinessState
 
 logging:
   config: classpath:logback-spring.xml


### PR DESCRIPTION
## 🔧 작업 내용

- API Gateway의 readiness health check에서 DB 체크 제거
- Gateway는 DB를 사용하지 않는데 공통 설정으로 인해 기동 실패 발생하던 문제 해결


## 🧩 구현 상세 (선택)

- management.endpoint.health.group.readiness.include에서 db 제거


## ❗ 참고 사항
