### PR TITLE
fix(queue): admissionToken 쿠키 SameSite=None, Secure=true로 변경

### DIFF
--- a/Queue/src/main/java/com/goormgb/be/queue/queue/util/AdmissionTokenCookieUtils.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/util/AdmissionTokenCookieUtils.java
@@ -11,8 +11,8 @@ public class AdmissionTokenCookieUtils {
 	public ResponseCookie createAdmissionTokenCookie(String admissionToken, long maxAgeSeconds) {
 		return ResponseCookie.from(ADMISSION_TOKEN_COOKIE_NAME, admissionToken)
 			.httpOnly(true)
-			.secure(false)
-			.sameSite("Lax")
+			.secure(true)
+			.sameSite("None")
 			.path("/")
 			.maxAge(maxAgeSeconds)
 			.build();
@@ -21,8 +21,8 @@ public class AdmissionTokenCookieUtils {
 	public ResponseCookie deleteAdmissionTokenCookie() {
 		return ResponseCookie.from(ADMISSION_TOKEN_COOKIE_NAME, "")
 			.httpOnly(true)
-			.secure(false)
-			.sameSite("Lax")
+			.secure(true)
+			.sameSite("None")
 			.path("/")
 			.maxAge(0)
 			.build();


### PR DESCRIPTION
## 🔧 작업 내용

- 프론트(localhost) → API(https://api.dev.goormgb.space) 크로스 오리진 환경에서 admissionToken 쿠키가 Seat API 요청에 포함되지 않아 401 발생
- secure tru e로 해결
- sameSite NONE 설정