### PR TITLE
fix(seat): recommendationEnabled=false 검증 누락 및 SeatHold 400 에러 수정 [GRGB-281]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
@@ -26,6 +26,9 @@ public class BookingOptionsService {
 
 		if (request.recommendationEnabled()) {
 			Preconditions.validate(request.ticketCount() != null, ErrorCode.INVALID_TICKET_COUNT);
+		} else {
+			Preconditions.validate(request.ticketCount() == null, ErrorCode.INVALID_BOOKING_OPTIONS);
+			Preconditions.validate(!request.nearAdjacentToggle(), ErrorCode.INVALID_BOOKING_OPTIONS);
 		}
 
 		BookingOptions options = new BookingOptions(

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -55,33 +55,33 @@ public class SeatHoldService {
 
 	private List<Long> normalizeSeatIds(List<Long> seatIds) {
 		Preconditions.validate(
-			seatIds != null && !seatIds.isEmpty(),
-			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+				seatIds != null && !seatIds.isEmpty(),
+				ErrorCode.INVALID_SEAT_HOLD_REQUEST);
+
+		Preconditions.validate(
+				seatIds.stream().noneMatch(Objects::isNull),
+				ErrorCode.INVALID_SEAT_HOLD_REQUEST
 		);
 
 		Preconditions.validate(
-			seatIds.stream().noneMatch(Objects::isNull),
-			ErrorCode.INVALID_SEAT_HOLD_REQUEST
-		);
-
-		Preconditions.validate(
-			new HashSet<>(seatIds).size() == seatIds.size(),
-			ErrorCode.INVALID_SEAT_HOLD_REQUEST
+				new HashSet<>(seatIds).size() == seatIds.size(),
+				ErrorCode.INVALID_SEAT_HOLD_REQUEST
 		);
 
 		return seatIds.stream()
-			.sorted(Comparator.naturalOrder())
-			.toList();
+				.sorted(Comparator.naturalOrder())
+				.toList();
 	}
 
 	private void validateSeatCount(Long userId, Long matchId, int requestedCount) {
 		BookingOptions bookingOptions =
-			bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
+				bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 
 		Integer ticketCount = bookingOptions.ticketCount();
-		Preconditions.validate(
-			ticketCount != null && ticketCount == requestedCount,
-			ErrorCode.INVALID_SEAT_HOLD_REQUEST
-		);
+		if (ticketCount != null) {
+			Preconditions.validate(
+					ticketCount == requestedCount,
+					ErrorCode.INVALID_SEAT_HOLD_REQUEST);
+		}
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -8,6 +8,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+	// A004
+	// aop 가로채듯 404로 감싸버리는방법. 500 빼고는 전부다 감싸서 바꿔치기. (hotfix) 퇴근하다 일터졋을떄
+	// invalided parameter 하고, 메세지만 바꿔치는 구조 // 온보딩 완료, 이미 완료됨. 이런건 있어야하는데, 파라미터 잘못 입력한건 친절하게 줄 필요가 없다.
+
 	// Common
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 백엔드팀에 문의하세요."),
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
@@ -65,6 +69,7 @@ public enum ErrorCode {
 	QUEUE_ENTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경기의 대기열에 등록되어 있지 않습니다."),
 	ADMISSION_TOKEN_EXPIRED(HttpStatus.GONE, "입장 가능 시간이 만료되었습니다. 다시 대기열에 진입해주세요."),
 	INVALID_TICKET_COUNT(HttpStatus.BAD_REQUEST, "예매 티켓 수가 올바르지 않습니다."),
+	INVALID_BOOKING_OPTIONS(HttpStatus.BAD_REQUEST, "예매 옵션이 올바르지 않습니다."),
 	INVALID_PROMOTE_COUNT(HttpStatus.BAD_REQUEST, "승급 인원 수가 올바르지 않습니다."),
 	QUEUE_PROMOTION_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 대기열 승급 처리가 불가능합니다."),
 


### PR DESCRIPTION
## 🔧 작업 내용
- `recommendationEnabled=false`일 때 `ticketCount`, `nearAdjacentToggle` 검증이 누락되어 잘못된 값이 Redis에 저장되는 문제 수정
- 일반 티켓팅(포도알잡기) 좌석 선점 시 `ticketCount`가 null이면 무조건 400 에러가 발생하는 버그 수정
- QA/프론트에서 리포트된 "일반 좌석 티켓팅에서 API 연결 실패" 이슈의 근본 원인 해결

## 🧩 구현 상세
### 1. BookingOptionsService 검증 강화
`recommendationEnabled` 값에 따른 조건부 검증 로직 추가:

```java
if (request.recommendationEnabled()) {
    Preconditions.validate(request.ticketCount() != null, ErrorCode.INVALID_TICKET_COUNT);
} else {
    Preconditions.validate(request.ticketCount() == null, ErrorCode.INVALID_BOOKING_OPTIONS);
    Preconditions.validate(!request.nearAdjacentToggle(), ErrorCode.INVALID_BOOKING_OPTIONS);
}
```

| recommendationEnabled | ticketCount | nearAdjacentToggle | 결과 |
|----------------------|-------------|-------------------|------|
| true | null | any | INVALID_TICKET_COUNT |
| true | 1~10 | true/false | OK |
| false | 숫자 | any | INVALID_BOOKING_OPTIONS |
| false | null | true | INVALID_BOOKING_OPTIONS |
| false | null | false | OK |

### 2. SeatHoldService 좌석 선점 버그 수정
**변경 전 (버그):**

```java
Integer ticketCount = bookingOptions.ticketCount();
Preconditions.validate(
    ticketCount != null && ticketCount == requestedCount,
    ErrorCode.INVALID_SEAT_HOLD_REQUEST
);
```
- `ticketCount`가 null이면 `ticketCount != null`이 false → 무조건 예외 발생
- 일반 티켓팅에서는 `ticketCount`가 항상 null이므로 좌석 선점 자체가 불가능한 상태였음

**변경 후:**
```java
Integer ticketCount = bookingOptions.ticketCount();
if (ticketCount != null) {
    Preconditions.validate(
        ticketCount == requestedCount,
        ErrorCode.INVALID_SEAT_HOLD_REQUEST
    );
}
```

- 추천 모드(`ticketCount != null`): 저장된 ticketCount와 요청 좌석 수 일치 검증 유지
- 일반 모드(`ticketCount == null`): 좌석 수 제한 없이 통과 → 사용자가 자유롭게 좌석 선택 가능

### 📌 관련 Jira Issue
- GRGB-281

## 🧪 테스트 방법

### 검증 강화 테스트

**Endpoint:** `POST /matches/{matchId}/booking-options`

1. `recommendationEnabled=false`, `ticketCount=3` 요청 → 400 `INVALID_BOOKING_OPTIONS` 확인
2. `recommendationEnabled=false`, `nearAdjacentToggle=true` 요청 → 400 `INVALID_BOOKING_OPTIONS` 확인
3. `recommendationEnabled=false`, `ticketCount=null`, `nearAdjacentToggle=false` 요청 → 200 OK 확인
4. `recommendationEnabled=true`, `ticketCount=null` 요청 → 400 `INVALID_TICKET_COUNT` 확인
5. `recommendationEnabled=true`, `ticketCount=3`, `nearAdjacentToggle=true` 요청 → 200 OK 확인

### 일반 티켓팅 좌석 선점 테스트

**Endpoint:** `POST /matches/{matchId}/seat-holds`

1. `recommendationEnabled=false`로 예매 옵션 저장 후 좌석 선점 요청 → 200 OK 확인 (기존에는 400 에러)
2. `recommendationEnabled=true`, `ticketCount=2`로 저장 후 좌석 3개 선점 요청 → 400 에러 확인 (기존 검증 유지)

## ❗ 참고 사항
- 추천 플로우(`SeatRecommendationService`, `SeatAssignmentService`)는 자체적으로 `recommendationEnabled=true`, `ticketCount!=null` 이중 검증이 있어 영향 없음
