### PR TITLE
제목: fix(seat): 포도알 blockId 응답값 DB PK → blockCode로 수정 [GRGB-288]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
@@ -4,7 +4,7 @@ import com.goormgb.be.domain.onboarding.enums.Viewpoint;
 import com.goormgb.be.seat.block.entity.Block;
 
 public record BlockItemDto(
-	Long blockId,
+	String blockId,
 	String blockCode,
 	String sectionName,
 	String areaName,
@@ -13,7 +13,7 @@ public record BlockItemDto(
 
 	public static BlockItemDto from(Block block) {
 		return new BlockItemDto(
-			block.getId(),
+			block.getBlockCode(),
 			block.getBlockCode(),
 			block.getSection().getName(),
 			block.getArea().getName(),

--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -30,4 +30,12 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 		return findByIdWithSectionAndArea(blockId)
 			.orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
 	}
+
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.blockCode = :blockCode")
+	Optional<Block> findByBlockCodeWithSectionAndArea(@Param("blockCode") String blockCode);
+
+	default Block findByBlockCodeWithSectionOrThrow(String blockCode) {
+		return findByBlockCodeWithSectionAndArea(blockCode)
+			.orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
+	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatGroupsEntryResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SeatGroupsEntryResponse.java
@@ -96,7 +96,7 @@ public record SeatGroupsEntryResponse(
 		Long sectionId,
 		String sectionName,
 		String displayName,
-		List<Long> blockIds,
+		List<String> blockIds,
 		long remainingSeatCount
 	) {
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/response/SectionBlocksResponse.java
@@ -11,12 +11,12 @@ public record SectionBlocksResponse(
 	}
 
 	public record BlockInfo(
-		Long blockId,
+		String blockId,
 		String blockCode,
 		String displayName,
 		List<RowInfo> rows
 	) {
-		public static BlockInfo of(Long blockId, String blockCode, List<RowInfo> rows) {
+		public static BlockInfo of(String blockId, String blockCode, List<RowInfo> rows) {
 			return new BlockInfo(
 				blockId,
 				blockCode,

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -50,7 +50,7 @@ public class SeatCommonService {
 		List<Section> sections = sectionRepository.findAllWithAreaOrderByAreaIdAscSectionIdAsc();
 		List<Long> sectionIds = sections.stream().map(Section::getId).toList();
 
-		Map<Long, List<Long>> blockIdsBySectionId = createBlockIdsBySectionId(sectionIds);
+		Map<Long, List<String>> blockIdsBySectionId = createBlockIdsBySectionId(sectionIds);
 		Map<Long, Long> remainingSeatCountBySectionId = createRemainingSeatCountBySectionId(matchId);
 
 		Map<Long, SeatGroupAccumulator> groupMap = new LinkedHashMap<>();
@@ -104,7 +104,7 @@ public class SeatCommonService {
 
 		Map<Long, BlockAccumulator> blockMap = new LinkedHashMap<>();
 		for (Block block : blocks) {
-			blockMap.put(block.getId(), new BlockAccumulator(block.getId(), block.getBlockCode()));
+			blockMap.put(block.getId(), new BlockAccumulator(block.getBlockCode()));
 		}
 
 		for (MatchSeat matchSeat : matchSeats) {
@@ -137,15 +137,15 @@ public class SeatCommonService {
 		return new SectionBlocksResponse(blockInfos);
 	}
 
-	private Map<Long, List<Long>> createBlockIdsBySectionId(List<Long> sectionIds) {
+	private Map<Long, List<String>> createBlockIdsBySectionId(List<Long> sectionIds) {
 		if (sectionIds.isEmpty()) {
 			return Map.of();
 		}
 
-		Map<Long, List<Long>> blockIdsBySectionId = new LinkedHashMap<>();
+		Map<Long, List<String>> blockIdsBySectionId = new LinkedHashMap<>();
 		for (Block block : blockRepository.findBySectionIdInOrderBySectionIdAscBlockCodeAsc(sectionIds)) {
 			blockIdsBySectionId.computeIfAbsent(block.getSection().getId(), ignored -> new ArrayList<>())
-				.add(block.getId());
+				.add(block.getBlockCode());
 		}
 		return blockIdsBySectionId;
 	}
@@ -194,17 +194,16 @@ public class SeatCommonService {
 	}
 
 	private record BlockAccumulator(
-		Long blockId,
 		String blockCode,
 		Map<Integer, RowAccumulator> rowsByRowNo
 	) {
-		private BlockAccumulator(Long blockId, String blockCode) {
-			this(blockId, blockCode, new LinkedHashMap<>());
+		private BlockAccumulator(String blockCode) {
+			this(blockCode, new LinkedHashMap<>());
 		}
 
 		private SectionBlocksResponse.BlockInfo toResponse() {
 			return SectionBlocksResponse.BlockInfo.of(
-				blockId,
+				blockCode,
 				blockCode,
 				rowsByRowNo.values().stream()
 					.map(RowAccumulator::toResponse)

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/controller/SeatRecommendationController.java
@@ -85,7 +85,7 @@ public class SeatRecommendationController {
 	@PostMapping("/blocks/{blockId}/assign")
 	public ApiResult<SeatAssignmentResponse> assignSeats(
 		@PathVariable Long matchId,
-		@PathVariable Long blockId,
+		@PathVariable String blockId,
 		@AuthenticationPrincipal Long userId,
 		@CookieValue(name = "admissionToken") String admissionToken
 	) {

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -23,7 +23,7 @@ public record BlockRecommendationResponse(
 	}
 
 	public record RecommendedBlock(
-		Long blockId,
+		String blockId,
 		String blockCode,
 		String sectionName,
 		String areaName,
@@ -36,7 +36,7 @@ public record BlockRecommendationResponse(
 		public static RecommendedBlock from(BlockRecommendation recommendation, int rank) {
 			var block = recommendation.block();
 			return new RecommendedBlock(
-				block.getId(),
+				block.getBlockCode(),
 				block.getBlockCode(),
 				block.getSection().getName(),
 				block.getArea().getName(),

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -34,7 +34,7 @@ public class SeatAssignmentService {
 	private final SeatBlockLock seatBlockLock;
 	private final SeatAssignmentTransactionalService seatAssignmentTransactionalService;
 
-	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockId) {
+	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, String blockCode) {
 
 		BookingOptions bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 
@@ -44,7 +44,8 @@ public class SeatAssignmentService {
 		Integer requiredSeats = bookingOptions.ticketCount();
 		boolean nearAdjacentToggle = bookingOptions.nearAdjacentToggle();
 
-		Block block = blockRepository.findByIdWithSectionOrThrow(blockId);
+		Block block = blockRepository.findByBlockCodeWithSectionOrThrow(blockCode);
+		Long blockId = block.getId();
 
 		Preconditions.validate(seatBlockLock.tryLock(matchId, blockId), ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
@@ -34,7 +34,9 @@ class BlockServiceTest {
 
 		// then
 		assertThat(result.blocks()).hasSize(3);
+		assertThat(result.blocks().get(0).blockId()).isEqualTo("CP");
 		assertThat(result.blocks().get(0).blockCode()).isEqualTo("CP");
+		assertThat(result.blocks().get(0).blockId()).isEqualTo(result.blocks().get(0).blockCode());
 		assertThat(result.blocks().get(0).sectionName()).isEqualTo("테라존(중앙 프리미엄석)");
 		assertThat(result.blocks().get(0).areaName()).isEqualTo("중앙");
 		assertThat(result.blocks().get(0).viewpoint()).isEqualTo(BlockFixture.cpBlock().getViewpoint());

--- a/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
@@ -66,14 +66,14 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 					11L,
 					"프리미엄",
 					List.of(
-						new SeatGroupsEntryResponse.SectionInfo(101L, "테라존", "테라존", List.of(1001L, 1002L), 25L)
+						new SeatGroupsEntryResponse.SectionInfo(101L, "테라존", "테라존", List.of("CP", "CP2"), 25L)
 					)
 				),
 				new SeatGroupsEntryResponse.SeatGroupInfo(
 					12L,
 					"1루 구역",
 					List.of(
-						new SeatGroupsEntryResponse.SectionInfo(201L, "내야", "1루 내야", List.of(2001L), 120L)
+						new SeatGroupsEntryResponse.SectionInfo(201L, "내야", "1루 내야", List.of("201"), 120L)
 					)
 				)
 			)
@@ -94,7 +94,7 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.data.seatGroups.length()").value(2))
 			.andExpect(jsonPath("$.data.seatGroups[0].areaName").value("프리미엄"))
 			.andExpect(jsonPath("$.data.seatGroups[0].sections[0].sectionId").value(101))
-			.andExpect(jsonPath("$.data.seatGroups[0].sections[0].blockIds[0]").value(1001))
+			.andExpect(jsonPath("$.data.seatGroups[0].sections[0].blockIds[0]").value("CP"))
 			.andExpect(jsonPath("$.data.seatGroups[1].sections[0].displayName").value("1루 내야"))
 			.andExpect(jsonPath("$.data.seatGroups[1].sections[0].remainingSeatCount").value(120));
 
@@ -144,7 +144,7 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 		SectionBlocksResponse response = new SectionBlocksResponse(
 			List.of(
 				new SectionBlocksResponse.BlockInfo(
-					205L,
+					"205",
 					"205",
 					"205블럭",
 					List.of(
@@ -171,7 +171,7 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.message").value("성공"))
 			.andExpect(jsonPath("$.data.blocks.length()").value(1))
-			.andExpect(jsonPath("$.data.blocks[0].blockId").value(205))
+			.andExpect(jsonPath("$.data.blocks[0].blockId").value("205"))
 			.andExpect(jsonPath("$.data.blocks[0].displayName").value("205블럭"))
 			.andExpect(jsonPath("$.data.blocks[0].rows[0].rowNo").value(1))
 			.andExpect(jsonPath("$.data.blocks[0].rows[0].remainingSeatCount").value(2))

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
@@ -109,6 +109,45 @@ class SeatCommonServiceTest {
 	}
 
 	@Test
+	@DisplayName("섹션 블럭 조회 시 blockId가 DB PK가 아닌 blockCode를 반환한다")
+	void 섹션_블럭_blockId는_blockCode를_반환한다() {
+		Long userId = 1L;
+		Long matchId = 10L;
+		Long sectionId = 20L;
+
+		Section section = createSection(sectionId);
+		// PK(48, 49)와 blockCode("205", "206")를 의도적으로 다르게 설정
+		Block block205 = createBlock(48L, "205", section);
+		Block block206 = createBlock(49L, "206", section);
+
+		MatchSeat s1 = createMatchSeat(1001L, matchId, 205001L, sectionId, 48L, 1, 1, MatchSeatSaleStatus.AVAILABLE);
+		MatchSeat s2 = createMatchSeat(1002L, matchId, 206001L, sectionId, 49L, 1, 1, MatchSeatSaleStatus.AVAILABLE);
+
+		lenient().when(sectionRepository.findById(sectionId)).thenReturn(Optional.of(section));
+		lenient().when(blockRepository.findBySectionIdOrderByBlockCodeAsc(sectionId))
+			.thenReturn(List.of(block205, block206));
+		lenient().when(
+				matchSeatRepository.findByMatchIdAndSectionIdOrderByBlockIdAscRowNoAscSeatNoAsc(matchId, sectionId))
+			.thenReturn(List.of(s1, s2));
+		lenient().when(
+			seatHoldRepository.findAllByMatchIdAndMatchSeatIdInAndExpiresAtAfter(
+				eq(matchId), anyList(), any(Instant.class)
+			)
+		).thenReturn(List.of());
+
+		SectionBlocksResponse result = seatCommonService.getSectionBlocks(matchId, sectionId, userId);
+
+		assertThat(result.blocks()).hasSize(2);
+		// blockId가 PK("48")가 아닌 blockCode("205")를 반환하는지 검증
+		assertThat(result.blocks().get(0).blockId()).isEqualTo("205");
+		assertThat(result.blocks().get(0).blockId()).isNotEqualTo("48");
+		assertThat(result.blocks().get(1).blockId()).isEqualTo("206");
+		assertThat(result.blocks().get(1).blockId()).isNotEqualTo("49");
+		// blockId와 blockCode가 동일한 값인지 검증
+		assertThat(result.blocks().get(0).blockId()).isEqualTo(result.blocks().get(0).blockCode());
+	}
+
+	@Test
 	@DisplayName("섹션 블럭 좌석 현황 조회 시 HELD 좌석을 반영하고 행별 남은 좌석 수를 계산한다")
 	void 섹션_블럭_좌석_현황_HELD_반영_성공() {
 		Long userId = 1L;

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
@@ -22,6 +22,7 @@ import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
 import com.goormgb.be.seat.seat.enums.SeatZone;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.seatHold.entity.SeatHold;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
@@ -32,6 +33,8 @@ class SeatHoldTransactionalServiceTest {
 	private static final Long MATCH_ID = 10L;
 	private static final Instant NOW = Instant.parse("2026-04-15T10:00:00Z");
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private MatchSeatRepository matchSeatRepository;
 	@Mock

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
@@ -115,7 +115,7 @@ public final class BlockFixture {
 	}
 
 	public static BlockItemDto cpBlockItemDto() {
-		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
+		return new BlockItemDto("CP", "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
 	}
 
 	public static Block block(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint,

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/controller/SeatAssignmentControllerTest.java
@@ -52,7 +52,7 @@ class SeatAssignmentControllerTest {
 	void 좌석_배정_성공() throws Exception {
 		// given
 		Long matchId = 1L;
-		Long blockId = 10L;
+		String blockId = "CP";
 		Long userId = 1L;
 		setAuthentication(userId);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.fixture.BlockFixture;
@@ -37,44 +39,54 @@ class SeatAssignmentServiceTest {
 	@InjectMocks
 	private SeatAssignmentService seatAssignmentService;
 
+	private static final Long MATCH_ID = 1L;
+	private static final Long USER_ID = 1L;
+	private static final String BLOCK_CODE = "CP";
+
+	private Block cpBlock;
+
 	private void setupCommon() {
-		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
-			.willReturn(new BookingOptions(1L, 1L, true, 3, false, Instant.now()));
-		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L, 1L)).willReturn(true);
+		cpBlock = BlockFixture.cpBlock();
+		ReflectionTestUtils.setField(cpBlock, "id", 1L);
+		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
+			.willReturn(new BookingOptions(USER_ID, MATCH_ID, true, 3, false, Instant.now()));
+		given(blockRepository.findByBlockCodeWithSectionOrThrow(BLOCK_CODE)).willReturn(cpBlock);
+		given(seatBlockLock.tryLock(MATCH_ID, 1L)).willReturn(true);
 	}
 
 	@Test
-	@DisplayName("정상 요청 시 락 획득 후 트랜잭션 서비스를 호출하고 락을 해제한다")
+	@DisplayName("정상 요청 시 blockCode로 Block을 조회하고 락 획득 후 트랜잭션 서비스를 호출한다")
 	void 정상_요청_락_트랜잭션_순서() {
 		// given
 		setupCommon();
-		Block block = BlockFixture.cpBlock();
 		SeatAssignmentResponse expectedResponse = SeatAssignmentResponse.of(
-			1L, block, List.of(), Instant.parse("2026-04-15T10:05:00Z"), false);
-		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false)))
+			MATCH_ID, cpBlock, List.of(), Instant.parse("2026-04-15T10:05:00Z"), false);
+		given(seatAssignmentTransactionalService.assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(1L), any(Block.class), eq(3), eq(false)))
 			.willReturn(expectedResponse);
 
 		// when
-		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L);
+		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_CODE);
 
 		// then
 		assertThat(response).isNotNull();
-		then(seatAssignmentTransactionalService).should().assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false));
-		then(seatBlockLock).should().unlock(1L, 1L);
+		then(blockRepository).should().findByBlockCodeWithSectionOrThrow(BLOCK_CODE);
+		then(seatAssignmentTransactionalService).should().assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(1L), any(Block.class), eq(3), eq(false));
+		then(seatBlockLock).should().unlock(MATCH_ID, 1L);
 	}
 
 	@Test
 	@DisplayName("락 획득 실패 시 예외가 발생한다")
 	void 락_획득_실패_예외() {
 		// given
-		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
-			.willReturn(new BookingOptions(1L, 1L, true, 3, false, Instant.now()));
-		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L, 1L)).willReturn(false);
+		cpBlock = BlockFixture.cpBlock();
+		ReflectionTestUtils.setField(cpBlock, "id", 1L);
+		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
+			.willReturn(new BookingOptions(USER_ID, MATCH_ID, true, 3, false, Instant.now()));
+		given(blockRepository.findByBlockCodeWithSectionOrThrow(BLOCK_CODE)).willReturn(cpBlock);
+		given(seatBlockLock.tryLock(MATCH_ID, 1L)).willReturn(false);
 
 		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L))
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_CODE))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
@@ -85,15 +97,15 @@ class SeatAssignmentServiceTest {
 	void 트랜잭션_예외시_락_해제() {
 		// given
 		setupCommon();
-		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(), eq(3), eq(false)))
+		given(seatAssignmentTransactionalService.assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(1L), any(), eq(3), eq(false)))
 			.willThrow(new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE));
 
 		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L))
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_CODE))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
 
-		then(seatBlockLock).should().unlock(1L, 1L);
+		then(seatBlockLock).should().unlock(MATCH_ID, 1L);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
@@ -23,6 +23,7 @@ import com.goormgb.be.seat.fixture.BlockFixture;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
@@ -32,6 +33,8 @@ import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 @ExtendWith(MockitoExtension.class)
 class SeatAssignmentTransactionalServiceTest {
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private MatchSeatRepository matchSeatRepository;
 	@Mock

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -32,6 +32,7 @@ import com.goormgb.be.seat.fixture.OnboardingFixture;
 import com.goormgb.be.seat.booking.model.BookingOptions;
 import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.user.entity.User;
 
@@ -56,6 +57,8 @@ class SeatRecommendationServiceTest {
 	private ConsecutiveSeatCounter consecutiveSeatCounter;
 	@Mock
 	private PreferenceScoreCalculator preferenceScoreCalculator;
+	@Mock
+	private SeatMetricsService seatMetricsService;
 
 	@InjectMocks
 	private SeatRecommendationService seatRecommendationService;

--- a/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
@@ -14,11 +14,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldCleanupSchedulerTest {
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private SeatHoldRepository seatHoldRepository;
 	@Mock


### PR DESCRIPTION
## 🔧 작업 내용
- 좌석 선택 화면(포도알)에서 `blockId`가 DB PK(13, 12, 11...)로 응답되던 버그 수정
- `blockId` 필드에 `block.getId()` (PK) 대신 `block.getBlockCode()` ("201", "202"...)를 매핑하도록 변경
**- `blockId` 타입을 `Long` → `String`으로 변경하여 blockCode 문자열을 사용하도록 수정** >- 얘가 문제 였음 ‼️

## 🧩 구현 상세 (선택)
- `Block` 엔티티에 `id` (PK, BaseEntity 상속)와 `blockCode` (비즈니스 식별자) 두 필드가 존재했으나, 모든 응답 DTO에서 PK를 blockId로 반환하고 있었음

### 📌 관련 Jira Issue
- GRGB-288

## 🧪 테스트 방법 (선택)
- `GET /matches/{matchId}/seat-groups` 호출 → `SectionInfo.blockIds` 값이 blockCode("201", "202"...)인지 확인
- `GET /matches/{matchId}/sections/{sectionId}/blocks` 호출 → `BlockInfo.blockId` 값 확인
- `GET /matches/{matchId}/recommendations/blocks` 호출 → `RecommendedBlock.blockId` 값 확인
<img width="1231" height="421" alt="스크린샷 2026-03-23 오후 1 48 31" src="https://github.com/user-attachments/assets/598afdd0-478f-4b29-8f8c-d31ee685bb31" />

## ❗ 참고 사항
- `blockId` 필드 타입이 `Long` → `String`으로 변경되었으므로 프론트엔드 타입 확인 필요
- API 경로 `POST /blocks/{blockId}/assign`은 변경 없음, 내부 조회만 blockCode 기반으로 전환
