### PR TITLE
feat(seat): Block blockNum 컬럼 추가 및 API 응답 blockId 교정 [GRGB-288]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/dto/BlockItemDto.java
@@ -13,7 +13,7 @@ public record BlockItemDto(
 
 	public static BlockItemDto from(Block block) {
 		return new BlockItemDto(
-			block.getId(),
+			block.getBlockNum(),
 			block.getBlockCode(),
 			block.getSection().getName(),
 			block.getArea().getName(),

--- a/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/entity/Block.java
@@ -52,6 +52,9 @@ public class Block extends BaseEntity {
 	@Column(name = "block_code", nullable = false, length = 20)
 	private String blockCode;
 
+	@Column(name = "block_num", nullable = false, unique = true)
+	private Long blockNum;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "viewpoint", nullable = false, length = 30)
 	private Viewpoint viewpoint;
@@ -67,6 +70,7 @@ public class Block extends BaseEntity {
 		Area area,
 		Section section,
 		String blockCode,
+		Long blockNum,
 		Viewpoint viewpoint,
 		Integer homeCheerRank,
 		Integer awayCheerRank
@@ -74,6 +78,7 @@ public class Block extends BaseEntity {
 		this.area = area;
 		this.section = section;
 		this.blockCode = blockCode;
+		this.blockNum = blockNum;
 		this.viewpoint = viewpoint;
 		this.homeCheerRank = homeCheerRank;
 		this.awayCheerRank = awayCheerRank;

--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -30,4 +30,12 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 		return findByIdWithSectionAndArea(blockId)
 			.orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
 	}
+
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.blockNum = :blockNum")
+	Optional<Block> findByBlockNumWithSectionAndArea(@Param("blockNum") Long blockNum);
+
+	default Block findByBlockNumWithSectionOrThrow(Long blockNum) {
+		return findByBlockNumWithSectionAndArea(blockNum)
+			.orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
+	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -104,7 +104,7 @@ public class SeatCommonService {
 
 		Map<Long, BlockAccumulator> blockMap = new LinkedHashMap<>();
 		for (Block block : blocks) {
-			blockMap.put(block.getId(), new BlockAccumulator(block.getId(), block.getBlockCode()));
+			blockMap.put(block.getId(), new BlockAccumulator(block.getBlockNum(), block.getBlockCode()));
 		}
 
 		for (MatchSeat matchSeat : matchSeats) {
@@ -145,7 +145,7 @@ public class SeatCommonService {
 		Map<Long, List<Long>> blockIdsBySectionId = new LinkedHashMap<>();
 		for (Block block : blockRepository.findBySectionIdInOrderBySectionIdAscBlockCodeAsc(sectionIds)) {
 			blockIdsBySectionId.computeIfAbsent(block.getSection().getId(), ignored -> new ArrayList<>())
-				.add(block.getId());
+				.add(block.getBlockNum());
 		}
 		return blockIdsBySectionId;
 	}
@@ -194,17 +194,17 @@ public class SeatCommonService {
 	}
 
 	private record BlockAccumulator(
-		Long blockId,
+		Long blockNum,
 		String blockCode,
 		Map<Integer, RowAccumulator> rowsByRowNo
 	) {
-		private BlockAccumulator(Long blockId, String blockCode) {
-			this(blockId, blockCode, new LinkedHashMap<>());
+		private BlockAccumulator(Long blockNum, String blockCode) {
+			this(blockNum, blockCode, new LinkedHashMap<>());
 		}
 
 		private SectionBlocksResponse.BlockInfo toResponse() {
 			return SectionBlocksResponse.BlockInfo.of(
-				blockId,
+				blockNum,
 				blockCode,
 				rowsByRowNo.values().stream()
 					.map(RowAccumulator::toResponse)

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SeatDataInitializer.java
@@ -84,113 +84,113 @@ public class SeatDataInitializer implements CommandLineRunner {
 		// ── 3. Blocks ──
 
 		// ─── 중앙 프리미엄석 ───
-		saveBlock(center, premium, "CP", Viewpoint.CENTER, 50, 50);
+		saveBlock(center, premium, "CP", 1L, Viewpoint.CENTER, 50, 50);
 
 		// ─── 익사이팅존 ───
-		saveBlock(home, homeExciting, "EX-1", Viewpoint.INFIELD_1B, 30, 40);
-		saveBlock(away, awayExciting, "EX-3", Viewpoint.INFIELD_3B, 40, 30);
+		saveBlock(home, homeExciting, "EX-1", 2L, Viewpoint.INFIELD_1B, 30, 40);
+		saveBlock(away, awayExciting, "EX-3", 3L, Viewpoint.INFIELD_3B, 40, 30);
 
 		// ─── 1루(홈) 오렌지석 (응원석) 205~208 ───
 		int rank = 1;
 		for (int i = 205; i <= 208; i++) {
-			saveBlock(home, homeOrange, String.valueOf(i),
+			saveBlock(home, homeOrange, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, rank++, 80 + (i - 205));
 		}
 
 		// ─── 3루(어웨이) 오렌지석 (응원석) 219~222 ───
 		rank = 1;
 		for (int i = 219; i <= 222; i++) {
-			saveBlock(away, awayOrange, String.valueOf(i),
+			saveBlock(away, awayOrange, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 80 + (i - 219), rank++);
 		}
 
 		// ─── 1루(홈) 퍼플석 (테이블석) 110~113 ───
 		for (int i = 110; i <= 113; i++) {
-			saveBlock(home, homePurple, String.valueOf(i),
+			saveBlock(home, homePurple, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 10 + (i - 110), 60 + (i - 110));
 		}
 
 		// ─── 3루(어웨이) 퍼플석 (테이블석) 212~215 ───
 		for (int i = 212; i <= 215; i++) {
-			saveBlock(away, awayPurple, String.valueOf(i),
+			saveBlock(away, awayPurple, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 60 + (i - 212), 10 + (i - 212));
 		}
 
 		// ─── 1루(홈) 블루석 114~116 ───
 		for (int i = 114; i <= 116; i++) {
-			saveBlock(home, homeBlue, String.valueOf(i),
+			saveBlock(home, homeBlue, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 14 + (i - 114), 55 + (i - 114));
 		}
 
 		// ─── 1루(홈) 블루석 216~218 (2층) ───
 		for (int i = 216; i <= 218; i++) {
-			saveBlock(home, homeBlue, String.valueOf(i),
+			saveBlock(home, homeBlue, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 5 + (i - 216), 70 + (i - 216));
 		}
 
 		// ─── 3루(어웨이) 블루석 107~109 ───
 		for (int i = 107; i <= 109; i++) {
-			saveBlock(away, awayBlue, String.valueOf(i),
+			saveBlock(away, awayBlue, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 55 + (i - 107), 14 + (i - 107));
 		}
 
 		// ─── 3루(어웨이) 블루석 209~211 (2층) ───
 		for (int i = 209; i <= 211; i++) {
-			saveBlock(away, awayBlue, String.valueOf(i),
+			saveBlock(away, awayBlue, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 70 + (i - 209), 5 + (i - 209));
 		}
 
 		// ─── 1루(홈) 레드석 117~122 ───
 		for (int i = 117; i <= 122; i++) {
-			saveBlock(home, homeRed, String.valueOf(i),
+			saveBlock(home, homeRed, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 17 + (i - 117), 45 + (i - 117));
 		}
 
 		// ─── 1루(홈) 레드석 223~226 (2층) ───
 		for (int i = 223; i <= 226; i++) {
-			saveBlock(home, homeRed, String.valueOf(i),
+			saveBlock(home, homeRed, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 8 + (i - 223), 65 + (i - 223));
 		}
 
 		// ─── 3루(어웨이) 레드석 101~106 ───
 		for (int i = 101; i <= 106; i++) {
-			saveBlock(away, awayRed, String.valueOf(i),
+			saveBlock(away, awayRed, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 45 + (i - 101), 17 + (i - 101));
 		}
 
 		// ─── 3루(어웨이) 레드석 201~204 (2층) ───
 		for (int i = 201; i <= 204; i++) {
-			saveBlock(away, awayRed, String.valueOf(i),
+			saveBlock(away, awayRed, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 65 + (i - 201), 8 + (i - 201));
 		}
 
 		// ─── 1루(홈) 네이비석 301~317 ───
 		for (int i = 301; i <= 317; i++) {
-			saveBlock(home, homeNavy, String.valueOf(i),
+			saveBlock(home, homeNavy, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_1B, 23 + (i - 301), 35 + (i - 301));
 		}
 
 		// ─── 3루(어웨이) 네이비석 318~334 ───
 		for (int i = 318; i <= 334; i++) {
-			saveBlock(away, awayNavy, String.valueOf(i),
+			saveBlock(away, awayNavy, String.valueOf(i), (long) i,
 				Viewpoint.INFIELD_3B, 35 + (i - 318), 23 + (i - 318));
 		}
 
 		// ─── 외야 그린석 401~407 (1루 방향 → OUTFIELD_R) ───
 		for (int i = 401; i <= 407; i++) {
-			saveBlock(outfield, green, String.valueOf(i),
+			saveBlock(outfield, green, String.valueOf(i), (long) i,
 				Viewpoint.OUTFIELD_R, 60 + (i - 401), 90 + (i - 401));
 		}
 
 		// ─── 외야 그린석 408~415 (중앙 → OUTFIELD_C) ───
 		for (int i = 408; i <= 415; i++) {
-			saveBlock(outfield, green, String.valueOf(i),
+			saveBlock(outfield, green, String.valueOf(i), (long) i,
 				Viewpoint.OUTFIELD_C, 70 + (i - 408), 70 + (i - 408));
 		}
 
 		// ─── 외야 그린석 416~422 (3루 방향 → OUTFIELD_L) ───
 		for (int i = 416; i <= 422; i++) {
-			saveBlock(outfield, green, String.valueOf(i),
+			saveBlock(outfield, green, String.valueOf(i), (long) i,
 				Viewpoint.OUTFIELD_L, 90 + (i - 416), 60 + (i - 416));
 		}
 
@@ -213,11 +213,12 @@ public class SeatDataInitializer implements CommandLineRunner {
 	}
 
 	private void saveBlock(Area area, Section section,
-		String blockCode, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
+		String blockCode, Long blockNum, Viewpoint viewpoint, Integer homeCheerRank, Integer awayCheerRank) {
 		Block block = blockRepository.save(Block.builder()
 			.area(area)
 			.section(section)
 			.blockCode(blockCode)
+			.blockNum(blockNum)
 			.viewpoint(viewpoint)
 			.homeCheerRank(homeCheerRank)
 			.awayCheerRank(awayCheerRank)

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -36,7 +36,7 @@ public record BlockRecommendationResponse(
 		public static RecommendedBlock from(BlockRecommendation recommendation, int rank) {
 			var block = recommendation.block();
 			return new RecommendedBlock(
-				block.getId(),
+				block.getBlockNum(),
 				block.getBlockCode(),
 				block.getSection().getName(),
 				block.getArea().getName(),

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentService.java
@@ -34,7 +34,7 @@ public class SeatAssignmentService {
 	private final SeatBlockLock seatBlockLock;
 	private final SeatAssignmentTransactionalService seatAssignmentTransactionalService;
 
-	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockId) {
+	public SeatAssignmentResponse assignAndHoldSeats(Long userId, Long matchId, Long blockNum) {
 
 		BookingOptions bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 
@@ -44,7 +44,8 @@ public class SeatAssignmentService {
 		Integer requiredSeats = bookingOptions.ticketCount();
 		boolean nearAdjacentToggle = bookingOptions.nearAdjacentToggle();
 
-		Block block = blockRepository.findByIdWithSectionOrThrow(blockId);
+		Block block = blockRepository.findByBlockNumWithSectionOrThrow(blockNum);
+		Long blockId = block.getId();
 
 		Preconditions.validate(seatBlockLock.tryLock(matchId, blockId), ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
 

--- a/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/block/service/BlockServiceTest.java
@@ -34,6 +34,7 @@ class BlockServiceTest {
 
 		// then
 		assertThat(result.blocks()).hasSize(3);
+		assertThat(result.blocks().get(0).blockId()).isEqualTo(1L); // blockNum = 1 (CP)
 		assertThat(result.blocks().get(0).blockCode()).isEqualTo("CP");
 		assertThat(result.blocks().get(0).sectionName()).isEqualTo("테라존(중앙 프리미엄석)");
 		assertThat(result.blocks().get(0).areaName()).isEqualTo("중앙");

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
@@ -60,10 +60,12 @@ class SeatCommonServiceTest {
 	}
 
 	private Block createBlock(Long blockId, String blockCode, Section section) {
+		Long blockNum = blockCode.matches("\\d+") ? Long.parseLong(blockCode) : blockId;
 		Block block = Block.builder()
 			.area(section.getArea())
 			.section(section)
 			.blockCode(blockCode)
+			.blockNum(blockNum)
 			.viewpoint(com.goormgb.be.domain.onboarding.enums.Viewpoint.INFIELD_1B)
 			.homeCheerRank(1)
 			.awayCheerRank(1)

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
@@ -21,6 +21,7 @@ import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.seat.enums.SeatZone;
 import com.goormgb.be.seat.seatHold.entity.SeatHold;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
@@ -32,6 +33,8 @@ class SeatHoldTransactionalServiceTest {
 	private static final Long MATCH_ID = 10L;
 	private static final Instant NOW = Instant.parse("2026-04-15T10:00:00Z");
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private MatchSeatRepository matchSeatRepository;
 	@Mock

--- a/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/fixture/BlockFixture.java
@@ -70,6 +70,7 @@ public final class BlockFixture {
 			.area(area)
 			.section(section)
 			.blockCode("CP")
+			.blockNum(1L)
 			.viewpoint(Viewpoint.CENTER)
 			.homeCheerRank(50)
 			.awayCheerRank(50)
@@ -83,6 +84,7 @@ public final class BlockFixture {
 			.area(area)
 			.section(section)
 			.blockCode("205")
+			.blockNum(205L)
 			.viewpoint(Viewpoint.INFIELD_1B)
 			.homeCheerRank(1)
 			.awayCheerRank(81)
@@ -96,6 +98,7 @@ public final class BlockFixture {
 			.area(area)
 			.section(section)
 			.blockCode("408")
+			.blockNum(408L)
 			.viewpoint(Viewpoint.OUTFIELD_C)
 			.homeCheerRank(70)
 			.awayCheerRank(70)
@@ -115,15 +118,16 @@ public final class BlockFixture {
 	}
 
 	public static BlockItemDto cpBlockItemDto() {
-		return new BlockItemDto(null, "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
+		return new BlockItemDto(1L, "CP", "테라존(중앙 프리미엄석)", "중앙", Viewpoint.CENTER);
 	}
 
 	public static Block block(Long id, String blockCode, AreaCode areaCode, Viewpoint viewpoint,
 		Integer homeCheerRank, Integer awayCheerRank) {
 		Area area = Area.builder().code(areaCode).name(areaCode.getDescription()).build();
 		Section section = Section.builder().area(area).code(SectionCode.ORANGE).name("오렌지석").build();
+		Long blockNum = blockCode.matches("\\d+") ? Long.parseLong(blockCode) : id;
 		Block block = Block.builder()
-			.area(area).section(section).blockCode(blockCode)
+			.area(area).section(section).blockCode(blockCode).blockNum(blockNum)
 			.viewpoint(viewpoint).homeCheerRank(homeCheerRank).awayCheerRank(awayCheerRank).build();
 		ReflectionTestUtils.setField(block, "id", id);
 		return block;

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
@@ -37,44 +38,54 @@ class SeatAssignmentServiceTest {
 	@InjectMocks
 	private SeatAssignmentService seatAssignmentService;
 
+	private static final Long MATCH_ID = 1L;
+	private static final Long USER_ID = 1L;
+	private static final Long BLOCK_NUM = 1L; // CP block
+
+	private Block cpBlock;
+
 	private void setupCommon() {
-		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
-			.willReturn(new BookingOptions(1L, 1L, true, 3, false, Instant.now()));
-		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L, 1L)).willReturn(true);
+		cpBlock = BlockFixture.cpBlock();
+		ReflectionTestUtils.setField(cpBlock, "id", 99L); // PK와 blockNum이 다름을 검증
+		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
+			.willReturn(new BookingOptions(USER_ID, MATCH_ID, true, 3, false, Instant.now()));
+		given(blockRepository.findByBlockNumWithSectionOrThrow(BLOCK_NUM)).willReturn(cpBlock);
+		given(seatBlockLock.tryLock(MATCH_ID, 99L)).willReturn(true);
 	}
 
 	@Test
-	@DisplayName("정상 요청 시 락 획득 후 트랜잭션 서비스를 호출하고 락을 해제한다")
+	@DisplayName("정상 요청 시 blockNum으로 Block을 조회하고 PK로 락을 획득한다")
 	void 정상_요청_락_트랜잭션_순서() {
 		// given
 		setupCommon();
-		Block block = BlockFixture.cpBlock();
 		SeatAssignmentResponse expectedResponse = SeatAssignmentResponse.of(
-			1L, block, List.of(), Instant.parse("2026-04-15T10:05:00Z"), false);
-		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false)))
+			MATCH_ID, cpBlock, List.of(), Instant.parse("2026-04-15T10:05:00Z"), false);
+		given(seatAssignmentTransactionalService.assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(99L), any(Block.class), eq(3), eq(false)))
 			.willReturn(expectedResponse);
 
 		// when
-		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L);
+		SeatAssignmentResponse response = seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_NUM);
 
 		// then
 		assertThat(response).isNotNull();
-		then(seatAssignmentTransactionalService).should().assignAndHold(eq(1L), eq(1L), eq(1L), any(Block.class), eq(3), eq(false));
-		then(seatBlockLock).should().unlock(1L, 1L);
+		then(blockRepository).should().findByBlockNumWithSectionOrThrow(BLOCK_NUM);
+		then(seatAssignmentTransactionalService).should().assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(99L), any(Block.class), eq(3), eq(false));
+		then(seatBlockLock).should().unlock(MATCH_ID, 99L);
 	}
 
 	@Test
 	@DisplayName("락 획득 실패 시 예외가 발생한다")
 	void 락_획득_실패_예외() {
 		// given
-		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(1L, 1L))
-			.willReturn(new BookingOptions(1L, 1L, true, 3, false, Instant.now()));
-		given(blockRepository.findByIdWithSectionOrThrow(1L)).willReturn(BlockFixture.cpBlock());
-		given(seatBlockLock.tryLock(1L, 1L)).willReturn(false);
+		cpBlock = BlockFixture.cpBlock();
+		ReflectionTestUtils.setField(cpBlock, "id", 99L);
+		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
+			.willReturn(new BookingOptions(USER_ID, MATCH_ID, true, 3, false, Instant.now()));
+		given(blockRepository.findByBlockNumWithSectionOrThrow(BLOCK_NUM)).willReturn(cpBlock);
+		given(seatBlockLock.tryLock(MATCH_ID, 99L)).willReturn(false);
 
 		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L))
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_NUM))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.SEAT_LOCK_ACQUISITION_FAILED);
@@ -85,15 +96,15 @@ class SeatAssignmentServiceTest {
 	void 트랜잭션_예외시_락_해제() {
 		// given
 		setupCommon();
-		given(seatAssignmentTransactionalService.assignAndHold(eq(1L), eq(1L), eq(1L), any(), eq(3), eq(false)))
+		given(seatAssignmentTransactionalService.assignAndHold(eq(USER_ID), eq(MATCH_ID), eq(99L), any(), eq(3), eq(false)))
 			.willThrow(new CustomException(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE));
 
 		// when & then
-		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(1L, 1L, 1L))
+		assertThatThrownBy(() -> seatAssignmentService.assignAndHoldSeats(USER_ID, MATCH_ID, BLOCK_NUM))
 			.isInstanceOf(CustomException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NO_CONSECUTIVE_SEAT_AVAILABLE);
 
-		then(seatBlockLock).should().unlock(1L, 1L);
+		then(seatBlockLock).should().unlock(MATCH_ID, 99L);
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatAssignmentTransactionalServiceTest.java
@@ -23,6 +23,7 @@ import com.goormgb.be.seat.fixture.BlockFixture;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.recommendation.dto.internal.SeatGroup;
 import com.goormgb.be.seat.recommendation.dto.internal.SemiGroup;
 import com.goormgb.be.seat.recommendation.dto.response.SeatAssignmentResponse;
@@ -32,6 +33,8 @@ import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 @ExtendWith(MockitoExtension.class)
 class SeatAssignmentTransactionalServiceTest {
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private MatchSeatRepository matchSeatRepository;
 	@Mock

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -32,6 +32,7 @@ import com.goormgb.be.seat.fixture.OnboardingFixture;
 import com.goormgb.be.seat.booking.model.BookingOptions;
 import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.recommendation.dto.response.BlockRecommendationResponse;
 import com.goormgb.be.user.entity.User;
 
@@ -56,6 +57,9 @@ class SeatRecommendationServiceTest {
 	private ConsecutiveSeatCounter consecutiveSeatCounter;
 	@Mock
 	private PreferenceScoreCalculator preferenceScoreCalculator;
+
+	@Mock
+	private SeatMetricsService seatMetricsService;
 
 	@InjectMocks
 	private SeatRecommendationService seatRecommendationService;

--- a/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/seatHold/scheduler/SeatHoldCleanupSchedulerTest.java
@@ -14,11 +14,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.metrics.SeatMetricsService;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldCleanupSchedulerTest {
 
+	@Mock
+	private SeatMetricsService seatMetricsService;
 	@Mock
 	private SeatHoldRepository seatHoldRepository;
 	@Mock


### PR DESCRIPTION
## 🔧 작업 내용
- `blocks` 테이블에 `block_num` (Long, UNIQUE) 컬럼 추가하여 블럭 고유 번호 도입
- API 응답의 `blockId`가 DB PK(auto-increment) 대신 `blockNum`(블럭 번호)을 반환하도록 수정
- 좌석 배정 API 내부에서 `blockNum`으로 Block을 조회하도록 변경
- 퍼플·블루·레드석 36개 블럭의 1루/3루 area 배정 오류 교정


  ## 🧩 구현 상세 (선택)
- `blockNum` 매핑 규칙: 숫자 코드는 그대로 (205→205), 특수 코드는 별도 번호 (CP→1, EX-1→2, EX-3→3)
- `blockId` 필드 타입 Long 유지 → 프론트 타입 변경 없음,  값만 PK에서 blockNum으로 변경
- API 경로 `POST /blocks/{blockId}/assign` 변경 없음, 내부에서 `findByBlockNumWithSectionOrThrow()`로 조회
- 퍼플석 112,113/212,213, 블루석 107~109/114~116/209~211/216~218, 레드석 101~106/117~122/201~204/223~226 area_id/section_id/viewpoint 교정(Seat Data Initializer 는 제가 건드리면 휴먼에러 날까봐 ai 로 돌렸습니다..!)
- `SeatMetricsService` 의존성 추가 후 테스트 Mock 누락수정 포함

### 📌 관련 Jira Issue
- GRGB-288

## 🧪 테스트 방법 (선택)
- `./gradlew :Seat:test` → 86개 테스트 전체 통과 확인
- `GET /matches/{matchId}/seat-groups` 호출 → `SectionInfo.blockIds` 값이 blockNum(205, 206...)인지 확인
- `GET /matches/{matchId}/sections/{sectionId}/blocks` 호출 → `BlockInfo.blockId` 값이 PK가 아닌 blockNum인지 확인
- `GET /matches/{matchId}/recommendations/blocks` 호출 → `RecommendedBlock.blockId` 값 확인
- `POST /matches/{matchId}/recommendations/blocks/{blockNum}/assign` 호출 → blockNum으로 정상 배정 확인

## ❗ 참고 사항
- 프론트 입장에서 `blockId` 타입/필드명 변경 없음, 값만 달라짐 (PK → blockNum)
