### PR TITLE
fix(seat): 종료된 경기 좌석 데이터 삭제 스케줄러 구현 [GRGB-287]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.seat.matchSeat.repository;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -95,4 +96,23 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 		@Param("matchId") Long matchId,
 		@Param("blockIds") List<Long> blockIds
 	);
+
+	@Query(
+		value = """
+			SELECT ms.id
+			FROM match_seats ms
+			JOIN matches m ON m.id = ms.match_id
+			WHERE m.sale_status = :saleStatus
+			  AND m.match_at < :cutoff
+			""",
+		nativeQuery = true
+	)
+	List<Long> findCleanupTargetMatchSeatIds(
+		@Param("saleStatus") String saleStatus,
+		@Param("cutoff") Instant cutoff
+	);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM MatchSeat ms WHERE ms.id IN :matchSeatIds")
+	int deleteByIdIn(@Param("matchSeatIds") List<Long> matchSeatIds);
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/scheduler/MatchSeatScheduler.java
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.goormgb.be.seat.matchSeat.service.MatchSeatCleanupService;
 import com.goormgb.be.seat.matchSeat.service.MatchSeatPreparationService;
 
 import lombok.RequiredArgsConstructor;
@@ -17,13 +18,23 @@ import lombok.extern.slf4j.Slf4j;
 public class MatchSeatScheduler {
 
 	private final MatchSeatPreparationService matchSeatPreparationService;
+	private final MatchSeatCleanupService matchSeatCleanupService;
 
 	/**
 	 * 매일 자정 00:00: 경기 7일 전이 된 UPCOMING 경기에 대해 match_seats 데이터를 미리 생성한다.
 	 */
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void prepareMatchSeats() {
-		log.info("[MatchSeatScheduler] 스케줄러 실행 시각(KST): {}", ZonedDateTime.now(ZoneId.of("Asia/Seoul")));
+		log.info("[MatchSeatScheduler] 좌석 생성 스케줄러 실행 시각(KST): {}", ZonedDateTime.now(ZoneId.of("Asia/Seoul")));
 		matchSeatPreparationService.prepareMatchSeats();
+	}
+
+	/**
+	 * 매일 오전 01:00: 종료 후 7일이 지난 경기의 match_seat 데이터를 정리한다.
+	 */
+	@Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+	public void cleanupEndedMatchSeats() {
+		log.info("[MatchSeatCleanupScheduler] 좌석 삭제 스케줄러 실행 시각(KST): {}", ZonedDateTime.now(ZoneId.of("Asia/Seoul")));
+		matchSeatCleanupService.cleanupEndedMatchSeats();
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupService.java
@@ -22,6 +22,8 @@ public class MatchSeatCleanupService {
 
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private static final long RETENTION_DAYS = 7L;
+	// IN 절 파라미터 수를 과도하게 키우지 않기 위한 안전한 기본 배치 크기
+	private static final int DELETE_BATCH_SIZE = 1_000;
 
 	private final MatchSeatRepository matchSeatRepository;
 	private final Clock clock;
@@ -39,7 +41,7 @@ public class MatchSeatCleanupService {
 			return;
 		}
 
-		int deletedCount = matchSeatRepository.deleteByIdIn(cleanupTargetMatchSeatIds);
+		int deletedCount = deleteInBatches(cleanupTargetMatchSeatIds);
 		log.info(
 			"[MatchSeatCleanupService] 종료 경기 match_seat 정리 완료. cutoff={}, deletedCount={}",
 			cutoff,
@@ -50,5 +52,19 @@ public class MatchSeatCleanupService {
 	Instant calculateCutoff() {
 		LocalDate todayKst = clock.instant().atZone(KST).toLocalDate();
 		return todayKst.minusDays(RETENTION_DAYS).atStartOfDay(KST).toInstant();
+	}
+
+	private int deleteInBatches(List<Long> cleanupTargetMatchSeatIds) {
+		int totalDeletedCount = 0;
+
+		for (int i = 0; i < cleanupTargetMatchSeatIds.size(); i += DELETE_BATCH_SIZE) {
+			List<Long> batch = cleanupTargetMatchSeatIds.subList(
+				i,
+				Math.min(i + DELETE_BATCH_SIZE, cleanupTargetMatchSeatIds.size())
+			);
+			totalDeletedCount += matchSeatRepository.deleteByIdIn(batch);
+		}
+
+		return totalDeletedCount;
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupService.java
@@ -1,0 +1,54 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchSeatCleanupService {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final long RETENTION_DAYS = 7L;
+
+	private final MatchSeatRepository matchSeatRepository;
+	private final Clock clock;
+
+	@Transactional
+	public void cleanupEndedMatchSeats() {
+		Instant cutoff = calculateCutoff();
+		List<Long> cleanupTargetMatchSeatIds = matchSeatRepository.findCleanupTargetMatchSeatIds(
+			SaleStatus.ENDED.name(),
+			cutoff
+		);
+
+		if (cleanupTargetMatchSeatIds.isEmpty()) {
+			log.info("[MatchSeatCleanupService] 삭제 대상 match_seat 없음. cutoff={}", cutoff);
+			return;
+		}
+
+		int deletedCount = matchSeatRepository.deleteByIdIn(cleanupTargetMatchSeatIds);
+		log.info(
+			"[MatchSeatCleanupService] 종료 경기 match_seat 정리 완료. cutoff={}, deletedCount={}",
+			cutoff,
+			deletedCount
+		);
+	}
+
+	Instant calculateCutoff() {
+		LocalDate todayKst = clock.instant().atZone(KST).toLocalDate();
+		return todayKst.minusDays(RETENTION_DAYS).atStartOfDay(KST).toInstant();
+	}
+}

--- a/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/matchSeat/service/MatchSeatCleanupServiceTest.java
@@ -1,0 +1,67 @@
+package com.goormgb.be.seat.matchSeat.service;
+
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.Mockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MatchSeatCleanupServiceTest {
+
+	private static final Instant NOW = Instant.parse("2026-03-23T16:00:00Z");
+	private static final Instant EXPECTED_CUTOFF = Instant.parse("2026-03-16T15:00:00Z");
+
+	@Mock
+	private MatchSeatRepository matchSeatRepository;
+	@Mock
+	private Clock clock;
+
+	@InjectMocks
+	private MatchSeatCleanupService matchSeatCleanupService;
+
+	@Test
+	@DisplayName("삭제 가능한 match_seat이 없으면 삭제를 수행하지 않는다")
+	void cleanupEndedMatchSeats_noTargets() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+		given(matchSeatRepository.findCleanupTargetMatchSeatIds("ENDED", EXPECTED_CUTOFF))
+			.willReturn(List.of());
+
+		// when
+		matchSeatCleanupService.cleanupEndedMatchSeats();
+
+		// then
+		then(matchSeatRepository).should().findCleanupTargetMatchSeatIds("ENDED", EXPECTED_CUTOFF);
+		then(matchSeatRepository).should(never()).deleteByIdIn(anyList());
+	}
+
+	@Test
+	@DisplayName("7일이 지난 종료 경기의 match_seat을 삭제한다")
+	void cleanupEndedMatchSeats_deletesTargets() {
+		// given
+		given(clock.instant()).willReturn(NOW);
+		List<Long> cleanupTargetMatchSeatIds = List.of(11L, 12L, 13L);
+		given(matchSeatRepository.findCleanupTargetMatchSeatIds("ENDED", EXPECTED_CUTOFF))
+			.willReturn(cleanupTargetMatchSeatIds);
+		given(matchSeatRepository.deleteByIdIn(cleanupTargetMatchSeatIds)).willReturn(3);
+
+		// when
+		matchSeatCleanupService.cleanupEndedMatchSeats();
+
+		// then
+		then(matchSeatRepository).should().findCleanupTargetMatchSeatIds("ENDED", EXPECTED_CUTOFF);
+		then(matchSeatRepository).should().deleteByIdIn(cleanupTargetMatchSeatIds);
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용

- 좌석 삭제 스케줄러 구현

## 🧩 구현 상세 (선택)

**좌석 삭제 스케줄러 구현**
- 01:00 시에 종료된 경기의 좌석 데이터 삭제 스케줄러 실행
> 이때 삭제하는 좌석의 데이터는 당일 7일전 경기 이전 데이터 남아있을 경우 삭제

### 📌 관련 Jira Issue

- GRGB-287

## 🧪 테스트 방법(선택)

<img width="1098" height="376" alt="image" src="https://github.com/user-attachments/assets/50bcb3f1-1f7c-4c35-b33d-a7aa470acd46" />


## ❗ 참고 사항
