### PR TITLE
feat(mypage): 예매 상세 조회 API [GRGB-291]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ Temporary Items
 
 ### AI Agent ###
 .claude/
+.codex/

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.goormgb.be.ordercore.mypage.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.service.MyPageService;
 
@@ -70,5 +72,25 @@ public class MyPageController {
 		@RequestParam(defaultValue = "10") int size
 	) {
 		return ApiResult.ok("조회 성공", myPageService.getTickets(userId, tab, page, size));
+	}
+
+	@Operation(
+		summary = "예매 상세 조회",
+		description = "사용자의 특정 예매(ticketId=orders.id) 상세 정보를 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
+		@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+	})
+	@GetMapping("/tickets/{ticketId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<MyPageTicketDetailResponse> getTicketDetail(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long ticketId
+	) {
+		return ApiResult.ok("조회 성공", myPageService.getTicketDetail(userId, ticketId));
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketDetailBaseRow.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketDetailBaseRow.java
@@ -6,6 +6,7 @@ import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 
 public record TicketDetailBaseRow(
 	Long orderId,
+	Long userId,
 	OrderStatus status,
 	int totalAmount,
 	int bookingFee,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketDetailBaseRow.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketDetailBaseRow.java
@@ -1,0 +1,33 @@
+package com.goormgb.be.ordercore.mypage.dto.query;
+
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+
+public record TicketDetailBaseRow(
+	Long orderId,
+	OrderStatus status,
+	int totalAmount,
+	int bookingFee,
+	java.time.Instant cancelledAt,
+	int cancellationFee,
+	Integer refundedAmount,
+	Long matchId,
+	java.time.Instant matchAt,
+	Long homeClubId,
+	String homeClubName,
+	Long awayClubId,
+	String awayClubName,
+	Long stadiumId,
+	String stadiumName,
+	String stadiumAddress,
+	PaymentMethod paymentMethod,
+	java.time.Instant paidAt,
+	String accountBank,
+	String accountNumber,
+	String accountHolder,
+	java.time.Instant depositDeadline,
+	CashReceiptPurpose cashReceiptPurpose,
+	String cashReceiptNumber
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketSeatDetailRow.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/query/TicketSeatDetailRow.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.ordercore.mypage.dto.query;
+
+import com.goormgb.be.domain.ticket.enums.TicketType;
+
+public record TicketSeatDetailRow(
+	String sectionName,
+	String blockCode,
+	int rowNo,
+	int seatNo,
+	int price,
+	TicketType ticketType
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketDetailResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketDetailResponse.java
@@ -1,0 +1,155 @@
+package com.goormgb.be.ordercore.mypage.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+
+public record MyPageTicketDetailResponse(
+	Long ticketId,
+	OrderStatus status,
+	MatchInfo match,
+	List<SeatInfo> seats,
+	PaymentInfo payment,
+	CancellationPolicy cancellationPolicy,
+	VirtualAccount virtualAccount,
+	CancellationInfo cancellation,
+	TicketActions actions
+) {
+
+	public static MyPageTicketDetailResponse of(
+		TicketDetailBaseRow base,
+		List<TicketSeatDetailRow> seatRows,
+		PaymentInfo payment,
+		CancellationPolicy cancellationPolicy,
+		VirtualAccount virtualAccount,
+		CancellationInfo cancellation
+	) {
+		return new MyPageTicketDetailResponse(
+			base.orderId(),
+			base.status(),
+			MatchInfo.from(base),
+			seatRows.stream()
+				.map(SeatInfo::from)
+				.toList(),
+			payment,
+			cancellationPolicy,
+			virtualAccount,
+			cancellation,
+			TicketActions.of(base.status())
+		);
+	}
+
+	public record MatchInfo(
+		Long matchId,
+		Instant matchAt,
+		ClubInfo homeClub,
+		ClubInfo awayClub,
+		StadiumInfo stadium
+	) {
+		public static MatchInfo from(TicketDetailBaseRow base) {
+			return new MatchInfo(
+				base.matchId(),
+				base.matchAt(),
+				ClubInfo.home(base),
+				ClubInfo.away(base),
+				StadiumInfo.from(base)
+			);
+		}
+	}
+
+	public record ClubInfo(
+		Long clubId,
+		String koName
+	) {
+		public static ClubInfo home(TicketDetailBaseRow base) {
+			return new ClubInfo(base.homeClubId(), base.homeClubName());
+		}
+
+		public static ClubInfo away(TicketDetailBaseRow base) {
+			return new ClubInfo(base.awayClubId(), base.awayClubName());
+		}
+	}
+
+	public record StadiumInfo(
+		Long stadiumId,
+		String koName,
+		String address
+	) {
+		public static StadiumInfo from(TicketDetailBaseRow base) {
+			return new StadiumInfo(
+				base.stadiumId(),
+				base.stadiumName(),
+				base.stadiumAddress()
+			);
+		}
+	}
+
+	public record SeatInfo(
+		String sectionName,
+		String blockCode,
+		int rowNo,
+		int seatNo,
+		int price,
+		TicketType ticketType
+	) {
+		public static SeatInfo from(TicketSeatDetailRow row) {
+			return new SeatInfo(
+				row.sectionName(),
+				row.blockCode(),
+				row.rowNo(),
+				row.seatNo(),
+				row.price(),
+				row.ticketType()
+			);
+		}
+	}
+
+	public record PaymentInfo(
+		int totalAmount,
+		int serviceFee,
+		String paymentMethod,
+		Instant paidAt,
+		CashReceiptInfo cashReceipt
+	) {
+	}
+
+	public record CashReceiptInfo(
+		String type,
+		String number,
+		int totalAmount
+	) {
+	}
+
+	public record CancellationPolicy(
+		Instant deadline,
+		String feeRate
+	) {
+	}
+
+	public record VirtualAccount(
+		String bank,
+		String accountNumber,
+		String holder,
+		Instant depositDeadline
+	) {
+	}
+
+	public record CancellationInfo(
+		Instant cancelledAt,
+		int cancellationFee,
+		Integer refundedAmount
+	) {
+	}
+
+	public record TicketActions(
+		boolean canPrint
+	) {
+		public static TicketActions of(OrderStatus status) {
+			return new TicketActions(status == OrderStatus.PAID);
+		}
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -3,12 +3,18 @@ package com.goormgb.be.ordercore.mypage.query;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,15 +29,15 @@ public class MyPageQueryService {
 	 */
 	public long countTickets(Long userId, List<String> statuses) {
 		String sql = """
-				SELECT COUNT(*)
-				FROM orders
-				WHERE user_id = :userId
-				  AND status IN (:statuses)
-				""";
+			SELECT COUNT(*)
+			FROM orders
+			WHERE user_id = :userId
+			  AND status IN (:statuses)
+			""";
 
 		var params = new MapSqlParameterSource()
-				.addValue("userId", userId)
-				.addValue("statuses", statuses);
+			.addValue("userId", userId)
+			.addValue("statuses", statuses);
 
 		Long count = namedJdbc.queryForObject(sql, params, Long.class);
 		return count != null ? count : 0L;
@@ -42,43 +48,43 @@ public class MyPageQueryService {
 	 */
 	public List<TicketRow> findTickets(Long userId, List<String> statuses, int page, int size) {
 		String sql = """
-				SELECT
-				    o.id           AS order_id,
-				    o.status,
-				    m.match_at,
-				    hc.id          AS home_club_id,
-				    hc.ko_name     AS home_club_name,
-				    ac.id          AS away_club_id,
-				    ac.ko_name     AS away_club_name,
-				    st.ko_name     AS stadium_name,
-				    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
-				FROM orders o
-				JOIN matches m  ON o.match_id    = m.id
-				JOIN clubs hc   ON m.home_club_id = hc.id
-				JOIN clubs ac   ON m.away_club_id = ac.id
-				JOIN stadiums st ON m.stadium_id  = st.id
-				WHERE o.user_id = :userId
-				  AND o.status IN (:statuses)
-				ORDER BY o.created_at DESC
-				LIMIT :size OFFSET :offset
-				""";
+			SELECT
+			    o.id           AS order_id,
+			    o.status,
+			    m.match_at,
+			    hc.id          AS home_club_id,
+			    hc.ko_name     AS home_club_name,
+			    ac.id          AS away_club_id,
+			    ac.ko_name     AS away_club_name,
+			    st.ko_name     AS stadium_name,
+			    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
+			FROM orders o
+			JOIN matches m  ON o.match_id    = m.id
+			JOIN clubs hc   ON m.home_club_id = hc.id
+			JOIN clubs ac   ON m.away_club_id = ac.id
+			JOIN stadiums st ON m.stadium_id  = st.id
+			WHERE o.user_id = :userId
+			  AND o.status IN (:statuses)
+			ORDER BY o.created_at DESC
+			LIMIT :size OFFSET :offset
+			""";
 
 		var params = new MapSqlParameterSource()
-				.addValue("userId", userId)
-				.addValue("statuses", statuses)
-				.addValue("size", size)
-				.addValue("offset", (long)page * size);
+			.addValue("userId", userId)
+			.addValue("statuses", statuses)
+			.addValue("size", size)
+			.addValue("offset", (long)page * size);
 
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new TicketRow(
-				rs.getLong("order_id"),
-				OrderStatus.valueOf(rs.getString("status")),
-				rs.getObject("match_at", Timestamp.class).toInstant(),
-				rs.getLong("home_club_id"),
-				rs.getString("home_club_name"),
-				rs.getLong("away_club_id"),
-				rs.getString("away_club_name"),
-				rs.getString("stadium_name"),
-				rs.getInt("seat_count")
+			rs.getLong("order_id"),
+			OrderStatus.valueOf(rs.getString("status")),
+			rs.getObject("match_at", Timestamp.class).toInstant(),
+			rs.getLong("home_club_id"),
+			rs.getString("home_club_name"),
+			rs.getLong("away_club_id"),
+			rs.getString("away_club_name"),
+			rs.getString("stadium_name"),
+			rs.getInt("seat_count")
 		));
 	}
 
@@ -91,28 +97,141 @@ public class MyPageQueryService {
 		}
 
 		String sql = """
-				SELECT
-				    os.order_id,
-				    sec.name    AS section_name,
-				    b.block_code,
-				    os.row_no,
-				    os.seat_no
-				FROM order_seats os
-				JOIN sections sec ON os.section_id = sec.id
-				JOIN blocks b     ON os.block_id   = b.id
-				WHERE os.order_id IN (:orderIds)
-				ORDER BY os.order_id, os.id
-				""";
+			SELECT
+			    os.order_id,
+			    sec.name    AS section_name,
+			    b.block_code,
+			    os.row_no,
+			    os.seat_no
+			FROM order_seats os
+			JOIN sections sec ON os.section_id = sec.id
+			JOIN blocks b     ON os.block_id   = b.id
+			WHERE os.order_id IN (:orderIds)
+			ORDER BY os.order_id, os.id
+			""";
 
 		var params = new MapSqlParameterSource()
-				.addValue("orderIds", orderIds);
+			.addValue("orderIds", orderIds);
 
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new OrderSeatRow(
+			rs.getLong("order_id"),
+			rs.getString("section_name"),
+			rs.getString("block_code"),
+			rs.getInt("row_no"),
+			rs.getInt("seat_no")
+		));
+	}
+
+	/**
+	 * ticketId(orderId)에 해당하는 상세 기본 정보를 반환한다.
+	 */
+	public Optional<TicketDetailBaseRow> findTicketDetailBaseByOrderId(Long orderId) {
+		String sql = """
+			SELECT
+			    o.id             AS order_id,
+			    o.status         AS order_status,
+			    o.total_amount,
+			    o.booking_fee,
+			    o.cancelled_at,
+			    o.cancellation_fee,
+			    o.refunded_amount,
+			    m.id             AS match_id,
+			    m.match_at,
+			    hc.id            AS home_club_id,
+			    hc.ko_name       AS home_club_name,
+			    ac.id            AS away_club_id,
+			    ac.ko_name       AS away_club_name,
+			    st.id            AS stadium_id,
+			    st.ko_name       AS stadium_name,
+			    st.address       AS stadium_address,
+			    p.payment_method,
+			    p.paid_at,
+			    p.account_bank,
+			    p.account_number,
+			    p.account_holder,
+			    p.deposit_deadline,
+			    cr.purpose       AS cash_receipt_purpose,
+			    cr.number        AS cash_receipt_number
+			FROM orders o
+			JOIN matches m      ON o.match_id = m.id
+			JOIN clubs hc       ON m.home_club_id = hc.id
+			JOIN clubs ac       ON m.away_club_id = ac.id
+			JOIN stadiums st    ON m.stadium_id = st.id
+			LEFT JOIN payments p ON p.order_id = o.id
+			LEFT JOIN cash_receipts cr ON cr.payment_id = p.id
+			WHERE o.id = :orderId
+			""";
+
+		var params = new MapSqlParameterSource()
+			.addValue("orderId", orderId);
+
+		List<TicketDetailBaseRow> rows = namedJdbc.query(sql, params, (rs, rowNum) -> {
+			String paymentMethod = rs.getString("payment_method");
+			String cashReceiptPurpose = rs.getString("cash_receipt_purpose");
+
+			return new TicketDetailBaseRow(
 				rs.getLong("order_id"),
-				rs.getString("section_name"),
-				rs.getString("block_code"),
-				rs.getInt("row_no"),
-				rs.getInt("seat_no")
+				OrderStatus.valueOf(rs.getString("order_status")),
+				rs.getInt("total_amount"),
+				rs.getInt("booking_fee"),
+				rs.getObject("cancelled_at", Timestamp.class) == null ? null
+					: rs.getObject("cancelled_at", Timestamp.class).toInstant(),
+				rs.getInt("cancellation_fee"),
+				rs.getObject("refunded_amount", Integer.class),
+				rs.getLong("match_id"),
+				rs.getObject("match_at", Timestamp.class).toInstant(),
+				rs.getLong("home_club_id"),
+				rs.getString("home_club_name"),
+				rs.getLong("away_club_id"),
+				rs.getString("away_club_name"),
+				rs.getLong("stadium_id"),
+				rs.getString("stadium_name"),
+				rs.getString("stadium_address"),
+				paymentMethod == null ? null : PaymentMethod.valueOf(paymentMethod),
+				rs.getObject("paid_at", Timestamp.class) == null ? null
+					: rs.getObject("paid_at", Timestamp.class).toInstant(),
+				rs.getString("account_bank"),
+				rs.getString("account_number"),
+				rs.getString("account_holder"),
+				rs.getObject("deposit_deadline", Timestamp.class) == null ? null
+					: rs.getObject("deposit_deadline", Timestamp.class).toInstant(),
+				cashReceiptPurpose == null ? null : CashReceiptPurpose.valueOf(cashReceiptPurpose),
+				rs.getString("cash_receipt_number")
+			);
+		});
+
+		return rows.stream().findFirst();
+	}
+
+	/**
+	 * ticketId(orderId)에 해당하는 좌석 상세 정보를 반환한다.
+	 */
+	public List<TicketSeatDetailRow> findTicketSeatRowsByOrderId(Long orderId) {
+		String sql = """
+			SELECT
+			    sec.name      AS section_name,
+			    b.block_code,
+			    os.row_no,
+			    os.seat_no,
+			    os.price,
+			    os.ticket_type
+			FROM order_seats os
+			JOIN sections sec ON os.section_id = sec.id
+			JOIN blocks b     ON os.block_id = b.id
+			WHERE os.order_id = :orderId
+			ORDER BY os.id
+			""";
+
+		var params = new MapSqlParameterSource()
+			.addValue("orderId", orderId);
+
+		return namedJdbc.query(sql, params, (rs, rowNum) -> new TicketSeatDetailRow(
+			rs.getString("section_name"),
+			rs.getString("block_code"),
+			rs.getInt("row_no"),
+			rs.getInt("seat_no"),
+			rs.getInt("price"),
+			TicketType.valueOf(rs.getString("ticket_type"))
 		));
 	}
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -129,6 +129,7 @@ public class MyPageQueryService {
 		String sql = """
 			SELECT
 			    o.id             AS order_id,
+			    o.user_id        AS user_id,
 			    o.status         AS order_status,
 			    o.total_amount,
 			    o.booking_fee,
@@ -171,6 +172,7 @@ public class MyPageQueryService {
 
 			return new TicketDetailBaseRow(
 				rs.getLong("order_id"),
+				rs.getLong("user_id"),
 				OrderStatus.valueOf(rs.getString("order_status")),
 				rs.getInt("total_amount"),
 				rs.getInt("booking_fee"),

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -27,7 +27,6 @@ import com.goormgb.be.ordercore.mypage.enums.TicketTab;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
-import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
@@ -134,13 +133,9 @@ public class MyPageService {
 	 * 마이페이지 예매 상세 조회
 	 */
 	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {
-		Order order = orderRepository.findById(ticketId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
-
 		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderId(ticketId)
 			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		Preconditions.validate(base.userId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
 
 		MyPageTicketDetailResponse.PaymentInfo payment = new MyPageTicketDetailResponse.PaymentInfo(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -1,6 +1,11 @@
 package com.goormgb.be.ordercore.mypage.service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -8,16 +13,24 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
+import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRepository;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.enums.TicketTab;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
+import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.repository.UserRepository;
@@ -33,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MyPageService {
 
 	private static final int MAX_PAGE_SIZE = 10;
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	private static final List<OrderStatus> UPCOMING_STATUSES = List.of(
 		OrderStatus.PAYMENT_PENDING,
@@ -55,6 +69,7 @@ public class MyPageService {
 	private final UserSnsRepository userSnsRepository;
 	private final OrderRepository orderRepository;
 	private final MyPageQueryService myPageQueryService;
+	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
 
 	/**
 	 * 마이페이지 프로필 요약 조회
@@ -69,7 +84,7 @@ public class MyPageService {
 		long completedCount = orderRepository.countCompletedOrders(userId, now);
 
 		log.info("[MyPageService] 프로필 조회 - userId={}, upcomingCount={}, cancelRefundCount={}, completedCount={}",
-				userId, upcomingCount, cancelRefundCount, completedCount);
+			userId, upcomingCount, cancelRefundCount, completedCount);
 
 		return MyPageProfileResponse.of(user, userSns, upcomingCount, cancelRefundCount, completedCount);
 	}
@@ -99,34 +114,71 @@ public class MyPageService {
 			List<Long> orderIds = ticketRows.stream().map(TicketRow::orderId).toList();
 			Map<Long, List<MyPageTicketListResponse.SeatInfo>> seatMap = buildSeatMap(orderIds);
 			tickets = ticketRows.stream()
-					.map(row -> toTicketItem(row, seatMap.getOrDefault(row.orderId(), List.of())))
-					.toList();
+				.map(row -> toTicketItem(row, seatMap.getOrDefault(row.orderId(), List.of())))
+				.toList();
 		}
 
 		int totalPages = totalElements == 0 ? 0 : (int)Math.ceil((double)totalElements / size);
 		boolean hasNext = (long)(page + 1) * size < totalElements;
 
 		log.info("[MyPageService] 예매 내역 조회 - userId={}, tab={}, page={}, size={}, totalElements={}",
-				userId, tab, page, size, totalElements);
+			userId, tab, page, size, totalElements);
 
 		return MyPageTicketListResponse.of(
-				totalCount, upcomingCount, cancelProcessingCount, completedCount,
-				ticketTab.name(), page, size, totalElements, totalPages, hasNext, tickets
+			totalCount, upcomingCount, cancelProcessingCount, completedCount,
+			ticketTab.name(), page, size, totalElements, totalPages, hasNext, tickets
+		);
+	}
+
+	/**
+	 * 마이페이지 예매 상세 조회
+	 */
+	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {
+		Order order = orderRepository.findById(ticketId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+
+		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderId(ticketId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
+
+		MyPageTicketDetailResponse.PaymentInfo payment = new MyPageTicketDetailResponse.PaymentInfo(
+			base.totalAmount(),
+			base.bookingFee(),
+			toPaymentMethodValue(base.paymentMethod()),
+			base.paidAt(),
+			toCashReceipt(base)
+		);
+
+		MyPageTicketDetailResponse.CancellationPolicy cancellationPolicy =
+			buildCancellationPolicy(base.matchAt());
+
+		MyPageTicketDetailResponse.VirtualAccount virtualAccount = toVirtualAccount(base);
+		MyPageTicketDetailResponse.CancellationInfo cancellation = toCancellation(base);
+
+		return MyPageTicketDetailResponse.of(
+			base,
+			seatRows,
+			payment,
+			cancellationPolicy,
+			virtualAccount,
+			cancellation
 		);
 	}
 
 	private Map<Long, List<MyPageTicketListResponse.SeatInfo>> buildSeatMap(List<Long> orderIds) {
 		List<OrderSeatRow> seatRows = myPageQueryService.findOrderSeatRowsByOrderIds(orderIds);
 		return seatRows.stream()
-				.collect(Collectors.groupingBy(
-						OrderSeatRow::orderId,
-						Collectors.mapping(
-								row -> new MyPageTicketListResponse.SeatInfo(
-										row.sectionName(), row.blockCode(), row.rowNo(), row.seatNo()
-								),
-								Collectors.toList()
-						)
-				));
+			.collect(Collectors.groupingBy(
+				OrderSeatRow::orderId,
+				Collectors.mapping(
+					row -> new MyPageTicketListResponse.SeatInfo(
+						row.sectionName(), row.blockCode(), row.rowNo(), row.seatNo()
+					),
+					Collectors.toList()
+				)
+			));
 	}
 
 	private MyPageTicketListResponse.TicketItem toTicketItem(
@@ -134,15 +186,90 @@ public class MyPageService {
 		List<MyPageTicketListResponse.SeatInfo> seats
 	) {
 		return new MyPageTicketListResponse.TicketItem(
-				row.orderId(),
-				row.matchAt(),
-				new MyPageTicketListResponse.ClubInfo(row.homeClubId(), row.homeClubName()),
-				new MyPageTicketListResponse.ClubInfo(row.awayClubId(), row.awayClubName()),
-				row.stadiumName(),
-				row.seatCount(),
-				seats,
-				row.status(),
-				MyPageTicketListResponse.TicketActions.of(row.status(), row.matchAt())
+			row.orderId(),
+			row.matchAt(),
+			new MyPageTicketListResponse.ClubInfo(row.homeClubId(), row.homeClubName()),
+			new MyPageTicketListResponse.ClubInfo(row.awayClubId(), row.awayClubName()),
+			row.stadiumName(),
+			row.seatCount(),
+			seats,
+			row.status(),
+			MyPageTicketListResponse.TicketActions.of(row.status(), row.matchAt())
 		);
+	}
+
+	private MyPageTicketDetailResponse.VirtualAccount toVirtualAccount(TicketDetailBaseRow row) {
+		if (row.paymentMethod() != PaymentMethod.BANK_TRANSFER || row.status() != OrderStatus.PAYMENT_PENDING) {
+			return null;
+		}
+
+		return new MyPageTicketDetailResponse.VirtualAccount(
+			row.accountBank(),
+			row.accountNumber(),
+			row.accountHolder(),
+			row.depositDeadline()
+		);
+	}
+
+	private MyPageTicketDetailResponse.CancellationInfo toCancellation(TicketDetailBaseRow row) {
+		if (row.cancelledAt() == null) {
+			return null;
+		}
+
+		return new MyPageTicketDetailResponse.CancellationInfo(
+			row.cancelledAt(),
+			row.cancellationFee(),
+			row.refundedAmount()
+		);
+	}
+
+	private MyPageTicketDetailResponse.CashReceiptInfo toCashReceipt(TicketDetailBaseRow row) {
+		if (row.cashReceiptPurpose() == null || row.cashReceiptNumber() == null) {
+			return null;
+		}
+
+		return new MyPageTicketDetailResponse.CashReceiptInfo(
+			row.cashReceiptPurpose().name(),
+			row.cashReceiptNumber(),
+			row.totalAmount()
+		);
+	}
+
+	private MyPageTicketDetailResponse.CancellationPolicy buildCancellationPolicy(Instant matchAt) {
+		Instant deadline = matchAt.atZone(KST)
+			.minusDays(1)
+			.withHour(23)
+			.withMinute(59)
+			.withSecond(0)
+			.withNano(0)
+			.toInstant();
+
+		int daysLeft = Math.max(0, (int)ChronoUnit.DAYS.between(
+			LocalDate.now(KST),
+			matchAt.atZone(KST).toLocalDate()
+		));
+
+		CancellationFeePolicy policy = cancellationFeePolicyRepository.findByDaysLeft(daysLeft)
+			.orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+		return new MyPageTicketDetailResponse.CancellationPolicy(
+			deadline,
+			toPercentString(policy.getTicketFeeRate())
+		);
+	}
+
+	private String toPercentString(BigDecimal feeRate) {
+		BigDecimal percent = feeRate.multiply(BigDecimal.valueOf(100));
+		return percent.setScale(3, RoundingMode.DOWN).stripTrailingZeros().toPlainString() + "%";
+	}
+
+	private String toPaymentMethodValue(PaymentMethod method) {
+		if (method == null) {
+			return null;
+		}
+		if (method == PaymentMethod.BANK_TRANSFER) {
+			return "VIRTUAL_ACCOUNT";
+		}
+		return method.name();
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -4,11 +4,17 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 
 public final class MyPageFixture {
 
@@ -75,6 +81,76 @@ public final class MyPageFixture {
 			8, 2, 1, 5,
 			"BOOKED", 0, 10, 1L, 1, false,
 			List.of(ticket)
+		);
+	}
+
+	public static TicketDetailBaseRow createTicketDetailBaseRow(Long orderId, OrderStatus status) {
+		Instant futureMatchAt = Instant.now().plus(15, ChronoUnit.DAYS);
+		return new TicketDetailBaseRow(
+			orderId,
+			status,
+			42000,
+			2000,
+			status == OrderStatus.CANCELLED ? Instant.now().minus(1, ChronoUnit.DAYS) : null,
+			status == OrderStatus.CANCELLED ? 4200 : 0,
+			status == OrderStatus.CANCELLED ? 37800 : null,
+			55L,
+			futureMatchAt,
+			1L,
+			"LG 트윈스",
+			2L,
+			"두산 베어스",
+			3L,
+			"잠실야구장",
+			"서울특별시 송파구 올림픽로 19-2",
+			status == OrderStatus.PAYMENT_PENDING ? PaymentMethod.BANK_TRANSFER : PaymentMethod.TOSS_PAY,
+			status == OrderStatus.PAID ? Instant.now().minus(2, ChronoUnit.DAYS) : null,
+			status == OrderStatus.PAYMENT_PENDING ? "신한은행" : null,
+			status == OrderStatus.PAYMENT_PENDING ? "110-123-456789" : null,
+			status == OrderStatus.PAYMENT_PENDING ? "주식회사 구름공방" : null,
+			status == OrderStatus.PAYMENT_PENDING ? Instant.now().plus(1, ChronoUnit.DAYS) : null,
+			status == OrderStatus.PAID ? CashReceiptPurpose.PERSONAL_DEDUCTION : null,
+			status == OrderStatus.PAID ? "010-1234-5678" : null
+		);
+	}
+
+	public static List<TicketSeatDetailRow> createTicketSeatDetailRows() {
+		return List.of(
+			new TicketSeatDetailRow("오렌지석", "206", 3, 13, 20000, TicketType.ADULT),
+			new TicketSeatDetailRow("오렌지석", "206", 3, 14, 20000, TicketType.ADULT)
+		);
+	}
+
+	public static MyPageTicketDetailResponse createTicketDetailResponse() {
+		Instant futureMatchAt = Instant.now().plus(15, ChronoUnit.DAYS);
+		return new MyPageTicketDetailResponse(
+			101L,
+			OrderStatus.PAID,
+			new MyPageTicketDetailResponse.MatchInfo(
+				55L,
+				futureMatchAt,
+				new MyPageTicketDetailResponse.ClubInfo(1L, "LG 트윈스"),
+				new MyPageTicketDetailResponse.ClubInfo(2L, "KT 위즈"),
+				new MyPageTicketDetailResponse.StadiumInfo(3L, "잠실야구장", "서울특별시 송파구 올림픽로 19-2")
+			),
+			List.of(
+				new MyPageTicketDetailResponse.SeatInfo("오렌지석", "206", 3, 13, 20000, TicketType.ADULT),
+				new MyPageTicketDetailResponse.SeatInfo("오렌지석", "206", 3, 14, 20000, TicketType.ADULT)
+			),
+			new MyPageTicketDetailResponse.PaymentInfo(
+				42000,
+				2000,
+				"TOSS_PAY",
+				Instant.now().minus(2, ChronoUnit.DAYS),
+				new MyPageTicketDetailResponse.CashReceiptInfo("PERSONAL_DEDUCTION", "010-1234-5678", 42000)
+			),
+			new MyPageTicketDetailResponse.CancellationPolicy(
+				futureMatchAt.minus(1, ChronoUnit.DAYS),
+				"10%"
+			),
+			null,
+			null,
+			new MyPageTicketDetailResponse.TicketActions(true)
 		);
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -85,9 +85,14 @@ public final class MyPageFixture {
 	}
 
 	public static TicketDetailBaseRow createTicketDetailBaseRow(Long orderId, OrderStatus status) {
+		return createTicketDetailBaseRow(1L, orderId, status);
+	}
+
+	public static TicketDetailBaseRow createTicketDetailBaseRow(Long userId, Long orderId, OrderStatus status) {
 		Instant futureMatchAt = Instant.now().plus(15, ChronoUnit.DAYS);
 		return new TicketDetailBaseRow(
 			orderId,
+			userId,
 			status,
 			42000,
 			2000,

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.mypage.MyPageFixture;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.service.MyPageService;
@@ -180,6 +181,55 @@ class MyPageControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.data.tickets[0].actions.canDeposit").value(false))
 				.andExpect(jsonPath("$.data.tickets[0].actions.canCancel").value(true))
 				.andExpect(jsonPath("$.data.tickets[0].actions.canViewDetail").value(true));
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /mypage/tickets/{ticketId} — 예매 상세 조회")
+	class GetTicketDetail {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 상세 정보를 반환한다")
+		void getTicketDetail_성공() throws Exception {
+			MyPageTicketDetailResponse response = MyPageFixture.createTicketDetailResponse();
+			given(myPageService.getTicketDetail(1L, 101L)).willReturn(response);
+
+			mockMvc.perform(get("/mypage/tickets/101"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.message").value("조회 성공"))
+				.andExpect(jsonPath("$.data.ticketId").value(101))
+				.andExpect(jsonPath("$.data.status").value("PAID"))
+				.andExpect(jsonPath("$.data.actions.canPrint").value(true))
+				.andExpect(jsonPath("$.data.match.matchId").value(55))
+				.andExpect(jsonPath("$.data.seats.length()").value(2));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 ticketId면 404를 반환한다")
+		void getTicketDetail_주문없음_404() throws Exception {
+			given(myPageService.getTicketDetail(1L, 999L))
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+			mockMvc.perform(get("/mypage/tickets/999"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
+		}
+
+		@Test
+		@DisplayName("본인 소유가 아니면 403을 반환한다")
+		void getTicketDetail_권한없음_403() throws Exception {
+			given(myPageService.getTicketDetail(1L, 101L))
+				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+
+			mockMvc.perform(get("/mypage/tickets/101"))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -19,14 +20,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
+import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRepository;
 import com.goormgb.be.ordercore.fixture.mypage.MyPageFixture;
 import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
+import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
-import com.goormgb.be.ordercore.mypage.enums.TicketTab;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
+import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.user.entity.User;
@@ -47,13 +53,15 @@ class MyPageServiceTest {
 	private OrderRepository orderRepository;
 	@Mock
 	private MyPageQueryService myPageQueryService;
+	@Mock
+	private CancellationFeePolicyRepository cancellationFeePolicyRepository;
 
 	private MyPageService myPageService;
 
 	@BeforeEach
 	void setUp() {
 		myPageService = new MyPageService(
-			userRepository, userSnsRepository, orderRepository, myPageQueryService
+			userRepository, userSnsRepository, orderRepository, myPageQueryService, cancellationFeePolicyRepository
 		);
 	}
 
@@ -295,6 +303,131 @@ class MyPageServiceTest {
 			assertThat(response.summary().upcomingCount()).isEqualTo(3);
 			assertThat(response.summary().cancelProcessingCount()).isEqualTo(2);
 			assertThat(response.summary().completedCount()).isEqualTo(5);
+		}
+	}
+
+	@Nested
+	@DisplayName("getTicketDetail — 예매 상세 조회")
+	class GetTicketDetail {
+
+		@Test
+		@DisplayName("PAID 상태 상세 정보를 반환한다")
+		void getTicketDetail_PAID_성공() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			User user = OrderFixture.createUserWithId(userId);
+			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
+			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.PAID);
+			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(1)
+				.daysBeforeMatchMax(6)
+				.cancellable(true)
+				.ticketFeeRate(new BigDecimal("0.100"))
+				.bookingFeeRefundable(false)
+				.build();
+
+			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
+			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketDetailResponse response = myPageService.getTicketDetail(userId, ticketId);
+
+			assertThat(response.ticketId()).isEqualTo(ticketId);
+			assertThat(response.status()).isEqualTo(OrderStatus.PAID);
+			assertThat(response.payment().paymentMethod()).isEqualTo("TOSS_PAY");
+			assertThat(response.virtualAccount()).isNull();
+			assertThat(response.cancellation()).isNull();
+			assertThat(response.actions().canPrint()).isTrue();
+			assertThat(response.seats()).hasSize(2);
+			assertThat(response.payment().cashReceipt()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("PAYMENT_PENDING 무통장 상세 조회 시 virtualAccount를 반환한다")
+		void getTicketDetail_PAYMENT_PENDING_가상계좌_성공() {
+			Long userId = 1L;
+			Long ticketId = 102L;
+			User user = OrderFixture.createUserWithId(userId);
+			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
+			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId,
+				OrderStatus.PAYMENT_PENDING);
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(7)
+				.daysBeforeMatchMax(null)
+				.cancellable(true)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(true)
+				.build();
+
+			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
+			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
+				.willReturn(MyPageFixture.createTicketSeatDetailRows());
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketDetailResponse response = myPageService.getTicketDetail(userId, ticketId);
+
+			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+			assertThat(response.payment().paymentMethod()).isEqualTo("VIRTUAL_ACCOUNT");
+			assertThat(response.payment().paidAt()).isNull();
+			assertThat(response.virtualAccount()).isNotNull();
+			assertThat(response.actions().canPrint()).isFalse();
+		}
+
+		@Test
+		@DisplayName("취소된 티켓은 cancellation 정보를 반환한다")
+		void getTicketDetail_CANCELLED_성공() {
+			Long userId = 1L;
+			Long ticketId = 103L;
+			User user = OrderFixture.createUserWithId(userId);
+			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
+			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.CANCELLED);
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(1)
+				.daysBeforeMatchMax(6)
+				.cancellable(true)
+				.ticketFeeRate(new BigDecimal("0.100"))
+				.bookingFeeRefundable(false)
+				.build();
+
+			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
+			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
+				.willReturn(MyPageFixture.createTicketSeatDetailRows());
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketDetailResponse response = myPageService.getTicketDetail(userId, ticketId);
+
+			assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
+			assertThat(response.cancellation()).isNotNull();
+			assertThat(response.actions().canPrint()).isFalse();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 티켓이면 ORDER_NOT_FOUND 예외가 발생한다")
+		void getTicketDetail_주문없음_예외() {
+			Long ticketId = 999L;
+			given(orderRepository.findById(ticketId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("본인 소유가 아닌 티켓이면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		void getTicketDetail_권한없음_예외() {
+			Long ticketId = 104L;
+			User owner = OrderFixture.createUserWithId(2L);
+			Order order = OrderFixture.createOrderWithId(ticketId, owner, OrderFixture.createWeekdayMatch(), 42000);
+
+			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -32,7 +32,6 @@ import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
-import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.user.entity.User;
@@ -315,8 +314,6 @@ class MyPageServiceTest {
 		void getTicketDetail_PAID_성공() {
 			Long userId = 1L;
 			Long ticketId = 101L;
-			User user = OrderFixture.createUserWithId(userId);
-			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.PAID);
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
@@ -327,7 +324,6 @@ class MyPageServiceTest {
 				.bookingFeeRefundable(false)
 				.build();
 
-			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -349,8 +345,6 @@ class MyPageServiceTest {
 		void getTicketDetail_PAYMENT_PENDING_가상계좌_성공() {
 			Long userId = 1L;
 			Long ticketId = 102L;
-			User user = OrderFixture.createUserWithId(userId);
-			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId,
 				OrderStatus.PAYMENT_PENDING);
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
@@ -361,7 +355,6 @@ class MyPageServiceTest {
 				.bookingFeeRefundable(true)
 				.build();
 
-			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
 				.willReturn(MyPageFixture.createTicketSeatDetailRows());
@@ -381,8 +374,6 @@ class MyPageServiceTest {
 		void getTicketDetail_CANCELLED_성공() {
 			Long userId = 1L;
 			Long ticketId = 103L;
-			User user = OrderFixture.createUserWithId(userId);
-			Order order = OrderFixture.createOrderWithId(ticketId, user, OrderFixture.createWeekdayMatch(), 42000);
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.CANCELLED);
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 				.daysBeforeMatchMin(1)
@@ -392,7 +383,6 @@ class MyPageServiceTest {
 				.bookingFeeRefundable(false)
 				.build();
 
-			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
 				.willReturn(MyPageFixture.createTicketSeatDetailRows());
@@ -409,7 +399,7 @@ class MyPageServiceTest {
 		@DisplayName("존재하지 않는 티켓이면 ORDER_NOT_FOUND 예외가 발생한다")
 		void getTicketDetail_주문없음_예외() {
 			Long ticketId = 999L;
-			given(orderRepository.findById(ticketId)).willReturn(Optional.empty());
+			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
 				.isInstanceOf(CustomException.class)
@@ -420,10 +410,8 @@ class MyPageServiceTest {
 		@DisplayName("본인 소유가 아닌 티켓이면 ORDER_ACCESS_DENIED 예외가 발생한다")
 		void getTicketDetail_권한없음_예외() {
 			Long ticketId = 104L;
-			User owner = OrderFixture.createUserWithId(2L);
-			Order order = OrderFixture.createOrderWithId(ticketId, owner, OrderFixture.createWeekdayMatch(), 42000);
-
-			given(orderRepository.findById(ticketId)).willReturn(Optional.of(order));
+			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(2L, ticketId, OrderStatus.PAID);
+			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 
 			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
 				.isInstanceOf(CustomException.class)

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -19,6 +19,7 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.fixture.payment.PaymentFixture;
+import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
@@ -45,12 +46,15 @@ class PaymentServiceTest {
 	private PaymentRepository paymentRepository;
 	@Mock
 	private CashReceiptRepository cashReceiptRepository;
+	@Mock
+	private OrderMetricsService orderMetricsService;
 
 	private PaymentService paymentService;
 
 	@BeforeEach
 	void setUp() {
-		paymentService = new PaymentService(orderRepository, paymentRepository, cashReceiptRepository);
+		paymentService = new PaymentService(orderMetricsService, orderRepository, paymentRepository,
+			cashReceiptRepository);
 	}
 
 	private Order createOrderWithUser(Long orderId, Long userId) {
@@ -135,10 +139,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-					() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
+				() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -151,10 +155,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-					() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
+				() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -167,10 +171,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-					() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
+				() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 
 		@Test
@@ -185,10 +189,10 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(existingPayment));
 
 			assertThatThrownBy(
-					() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
+				() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 	}
 
@@ -248,11 +252,11 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-					() -> paymentService.createCashReceipt(userId, orderId,
-							PaymentFixture.createPersonalDeductionRequest())
+				() -> paymentService.createCashReceipt(userId, orderId,
+					PaymentFixture.createPersonalDeductionRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -269,11 +273,11 @@ class PaymentServiceTest {
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.of(existing));
 
 			assertThatThrownBy(
-					() -> paymentService.createCashReceipt(userId, orderId,
-							PaymentFixture.createPersonalDeductionRequest())
+				() -> paymentService.createCashReceipt(userId, orderId,
+					PaymentFixture.createPersonalDeductionRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
 		}
 
 		@Test
@@ -286,11 +290,11 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-					() -> paymentService.createCashReceipt(attackerId, 1L,
-							PaymentFixture.createPersonalDeductionRequest())
+				() -> paymentService.createCashReceipt(attackerId, 1L,
+					PaymentFixture.createPersonalDeductionRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -299,10 +303,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-					() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
+				() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
 			)
-					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용

- `GET /mypage/tickets/{ticketId}` 예매 상세 조회 API를 추가했습니다.
- 주문 상태(PAID, PAYMENT_PENDING, CANCELLED)에 따라 응답 필드를 분기해 필요한 결제/가상계좌/취소 정보를 반환하도록 구현했습니다.
- 좌석, 경기, 결제, 취소 정보를 한 번에 조회할 수 있도록 Query Service와 Service/Controller 계층을 정리했습니다.

## 🧩 구현 상세 (선택)

**예매 상세 조회 API**
- `GET /mypage/tickets/{ticketId}`
- `MyPageQueryService`에서 티켓 기본 정보와 좌석 상세를 조합해 응답 DTO로 매핑합니다.
- `MyPageService`에서 인증 사용자 기준 권한 검증(본인 티켓 여부)과 상태별 응답 조립을 담당합니다.
- `MyPageController`에 상세 조회 엔드포인트를 추가하고 테스트 픽스처/서비스/컨트롤러 테스트를 보강했습니다.

### 📌 관련 Jira Issue

- GRGB-291

## 🧪 테스트 방법(선택)

<img width="1090" height="480" alt="스크린샷 2026-03-24 오후 1 59 45" src="https://github.com/user-attachments/assets/bae342cf-bc2e-4f85-a9cb-3e759cbfdbf3" />

<img width="969" height="438" alt="스크린샷 2026-03-24 오후 1 59 23" src="https://github.com/user-attachments/assets/17e12442-a9f9-49e1-9851-92fbb58491a8" />


## ❗ 참고 사항

- 슬기님 강의 해주신 느낌으로 codex cli로 처음 써봤는데 굉장히 좋은듯함니다
