### PR TITLE
fix(docker): buildplatform, tagetplatform 빈값으로 인한 빌드 실패 수정 [GRGB-292]

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,6 +52,9 @@ services:
     build:
       context: ..
       dockerfile: API-Gateway/Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
     container_name: api-gateway
     environment:
       AUTH_GUARD_URL: http://auth-guard:8080
@@ -76,6 +79,9 @@ services:
     build:
       context: ..
       dockerfile: Auth-Guard/Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
     container_name: auth-guard
     environment:
       DB_URL: jdbc:postgresql://local-postgres:5432/goormgb
@@ -105,6 +111,9 @@ services:
     build:
       context: ..
       dockerfile: Queue/Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
     container_name: queue
     environment:
       DB_URL: jdbc:postgresql://local-postgres:5432/goormgb
@@ -126,6 +135,9 @@ services:
     build:
       context: ..
       dockerfile: Seat/Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
     container_name: seat
     environment:
       DB_URL: jdbc:postgresql://local-postgres:5432/goormgb
@@ -146,6 +158,9 @@ services:
     build:
       context: ..
       dockerfile: Order-Core/Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
     container_name: order-core
     environment:
       DB_URL: jdbc:postgresql://local-postgres:5432/goormgb


### PR DESCRIPTION
## 🔧 작업 내용

- 로컬에서 도커 빌드 시 변수 값 찾지 못해서 실패하는 이슈 수정

## 🧩 구현 상세 (선택)

agrs 값 추가로 빌드 실패 해결
```
      args:
        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
        TARGETPLATFORM: ${TARGETPLATFORM:-linux/arm64}
```

### 📌 관련 Jira Issue

- GRGB-292

## 🧪 테스트 방법(선택)

<img width="343" height="246" alt="image" src="https://github.com/user-attachments/assets/e8342827-c067-447f-9588-a5e4929149be" />

<img width="355" height="159" alt="image" src="https://github.com/user-attachments/assets/db42d276-dafd-4ffd-b924-e5ab1c566226" />


## ❗ 참고 사항

- 리뷰 시 유의할 점
- 후속 작업 예정
- 배포 시 주의 사항
