### PR TITLE
feat(order-core): 주문 생성 요청에서 좌석별 price 제거 및 totalPrice 위임

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -38,7 +38,12 @@ public class OrderController {
 
 	@Operation(
 		summary = "주문서 조회",
-		description = "선점된 좌석의 경기·좌석 상세 정보와 예상 금액을 조회합니다.",
+		description = """
+			선점된 좌석의 경기·좌석 상세 정보와 성인 기본가(adultPrice)를 조회합니다.
+			- 경기장은 잠실야구장으로 고정 반환됩니다.
+			- adultPrice는 주중/주말에 따라 자동 계산된 성인 기본가입니다.
+			- 할인 가격(장애인, 청소년, 군경 등)은 adultPrice를 기준으로 프론트에서 계산합니다.
+			""",
 		security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
@@ -62,7 +67,13 @@ public class OrderController {
 
 	@Operation(
 		summary = "주문 생성",
-		description = "예매자 정보 및 좌석·티켓 타입을 입력받아 주문을 생성합니다. 결제는 별도로 진행합니다.",
+		description = """
+			예매자 정보, 좌석별 티켓 타입·가격, 총 결제 금액을 받아 주문을 생성합니다.
+			- seats[].price: 프론트에서 할인 적용한 좌석별 최종 가격
+			- totalPrice: 좌석 가격 합계 + 수수료(2,000원) = 총 결제 금액 (프론트 계산)
+			- 결제는 목업(무조건 성공)으로 처리됩니다.
+			- ticketType: ADULT, YOUTH, MILITARY, CHILD, SENIOR, VETERAN, DISABLED
+			""",
 		security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -68,11 +68,10 @@ public class OrderController {
 	@Operation(
 		summary = "주문 생성",
 		description = """
-			예매자 정보, 좌석별 티켓 타입, 총 결제 금액을 받아 주문을 생성합니다.
-			- seats[]: matchSeatId + ticketType만 전송
+			예매자 정보, 좌석 ID 목록, 총 결제 금액을 받아 주문을 생성합니다.
+			- matchSeatIds: 주문서 조회에서 받은 매치 좌석 ID 목록
 			- totalPrice: 프론트에서 할인 적용 후 계산한 총 결제 금액 (수수료 2,000원 포함)
 			- 결제는 목업(무조건 성공)으로 처리됩니다.
-			- ticketType: ADULT, YOUTH, MILITARY, CHILD, SENIOR, VETERAN, DISABLED
 			""",
 		security = @SecurityRequirement(name = "BearerAuth")
 	)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -68,9 +68,9 @@ public class OrderController {
 	@Operation(
 		summary = "주문 생성",
 		description = """
-			예매자 정보, 좌석별 티켓 타입·가격, 총 결제 금액을 받아 주문을 생성합니다.
-			- seats[].price: 프론트에서 할인 적용한 좌석별 최종 가격
-			- totalPrice: 좌석 가격 합계 + 수수료(2,000원) = 총 결제 금액 (프론트 계산)
+			예매자 정보, 좌석별 티켓 타입, 총 결제 금액을 받아 주문을 생성합니다.
+			- seats[]: matchSeatId + ticketType만 전송
+			- totalPrice: 프론트에서 할인 적용 후 계산한 총 결제 금액 (수수료 2,000원 포함)
 			- 결제는 목업(무조건 성공)으로 처리됩니다.
 			- ticketType: ADULT, YOUTH, MILITARY, CHILD, SENIOR, VETERAN, DISABLED
 			""",

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
@@ -3,7 +3,6 @@ package com.goormgb.be.ordercore.order.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -19,12 +18,11 @@ public record OrderCreateRequest(
 	@NotNull(message = "matchId는 필수입니다.")
 	Long matchId,
 
-	@Schema(description = "좌석별 주문 정보 (matchSeatId + ticketType)", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "매치 좌석 ID 목록 (주문서 조회에서 받은 matchSeatId)", example = "[149801, 149802]", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotEmpty(message = "좌석 정보는 최소 1개 이상이어야 합니다.")
-	@Valid
-	List<SeatOrderItem> seats,
+	List<Long> matchSeatIds,
 
-	@Schema(description = "총 결제 금액 (좌석 가격 합계 + 수수료 2,000원, 프론트에서 계산)", example = "42000", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "총 결제 금액 (프론트에서 할인 적용 후 계산, 수수료 2,000원 포함, 원 단위)", example = "42000", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "총 결제 금액은 필수입니다.")
 	@Min(value = 0, message = "총 결제 금액은 0 이상이어야 합니다.")
 	Integer totalPrice,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
@@ -19,7 +19,7 @@ public record OrderCreateRequest(
 	@NotNull(message = "matchId는 필수입니다.")
 	Long matchId,
 
-	@Schema(description = "좌석별 주문 정보 (할인 적용된 개별 가격 포함)", requiredMode = Schema.RequiredMode.REQUIRED)
+	@Schema(description = "좌석별 주문 정보 (matchSeatId + ticketType)", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotEmpty(message = "좌석 정보는 최소 1개 이상이어야 합니다.")
 	@Valid
 	List<SeatOrderItem> seats,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/OrderCreateRequest.java
@@ -2,36 +2,50 @@ package com.goormgb.be.ordercore.order.dto.request;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "주문 생성 요청")
 public record OrderCreateRequest(
 
+	@Schema(description = "경기 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "matchId는 필수입니다.")
 	Long matchId,
 
+	@Schema(description = "좌석별 주문 정보 (할인 적용된 개별 가격 포함)", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotEmpty(message = "좌석 정보는 최소 1개 이상이어야 합니다.")
 	@Valid
 	List<SeatOrderItem> seats,
 
+	@Schema(description = "총 결제 금액 (좌석 가격 합계 + 수수료 2,000원, 프론트에서 계산)", example = "42000", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "총 결제 금액은 필수입니다.")
+	@Min(value = 0, message = "총 결제 금액은 0 이상이어야 합니다.")
+	Integer totalPrice,
+
+	@Schema(description = "예매자 이름", example = "윤정빈", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "예매자 이름은 필수입니다.")
 	@Size(max = 50)
 	String ordererName,
 
+	@Schema(description = "예매자 이메일", example = "test@email.com", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "예매자 이메일은 필수입니다.")
 	@Email(message = "이메일 형식이 올바르지 않습니다.")
 	@Size(max = 255)
 	String ordererEmail,
 
+	@Schema(description = "예매자 휴대폰 번호", example = "01012345678", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "예매자 휴대폰 번호는 필수입니다.")
 	@Size(max = 20)
 	String ordererPhone,
 
+	@Schema(description = "예매자 생년월일 (YYMMDD)", example = "990831", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotBlank(message = "예매자 생년월일은 필수입니다.")
 	@Pattern(regexp = "^\\d{6}$", message = "생년월일은 6자리 숫자여야 합니다. (예: 990831)")
 	String ordererBirthDate

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
@@ -3,7 +3,6 @@ package com.goormgb.be.ordercore.order.dto.request;
 import com.goormgb.be.domain.ticket.enums.TicketType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "좌석별 주문 항목")
@@ -15,11 +14,6 @@ public record SeatOrderItem(
 
 	@Schema(description = "티켓 타입 (ADULT, YOUTH, MILITARY, CHILD, SENIOR, VETERAN, DISABLED)", example = "ADULT", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "ticketType은 필수입니다.")
-	TicketType ticketType,
-
-	@Schema(description = "해당 좌석의 최종 가격 (할인 적용 후, 프론트에서 계산, 원 단위)", example = "20000", requiredMode = Schema.RequiredMode.REQUIRED)
-	@NotNull(message = "price는 필수입니다.")
-	@Min(value = 0, message = "가격은 0 이상이어야 합니다.")
-	Integer price
+	TicketType ticketType
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/request/SeatOrderItem.java
@@ -2,14 +2,24 @@ package com.goormgb.be.ordercore.order.dto.request;
 
 import com.goormgb.be.domain.ticket.enums.TicketType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "좌석별 주문 항목")
 public record SeatOrderItem(
 
+	@Schema(description = "매치 좌석 ID (주문서 조회에서 받은 matchSeatId)", example = "149801", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "matchSeatId는 필수입니다.")
 	Long matchSeatId,
 
+	@Schema(description = "티켓 타입 (ADULT, YOUTH, MILITARY, CHILD, SENIOR, VETERAN, DISABLED)", example = "ADULT", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "ticketType은 필수입니다.")
-	TicketType ticketType
+	TicketType ticketType,
+
+	@Schema(description = "해당 좌석의 최종 가격 (할인 적용 후, 프론트에서 계산, 원 단위)", example = "20000", requiredMode = Schema.RequiredMode.REQUIRED)
+	@NotNull(message = "price는 필수입니다.")
+	@Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+	Integer price
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
@@ -5,14 +5,17 @@ import java.time.Instant;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문 생성 응답")
 public record OrderCreateResponse(
-	Long orderId,
-	OrderStatus status,
-	Long matchId,
-	int seatCount,
-	int totalAmount,
-	int bookingFee,
-	Instant createdAt
+	@Schema(description = "주문 ID", example = "1") Long orderId,
+	@Schema(description = "주문 상태", example = "PAYMENT_PENDING") OrderStatus status,
+	@Schema(description = "경기 ID", example = "1") Long matchId,
+	@Schema(description = "주문 좌석 수", example = "2") int seatCount,
+	@Schema(description = "총 결제 금액 (원)", example = "42000") int totalAmount,
+	@Schema(description = "예매 수수료 (원)", example = "2000") int bookingFee,
+	@Schema(description = "주문 생성 일시 (UTC)", example = "2026-03-22T05:39:00Z") Instant createdAt
 ) {
 
 	public static OrderCreateResponse of(Order order, int seatCount) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
@@ -6,19 +6,26 @@ import java.util.List;
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주문서 조회 응답")
 public record OrderSheetGetResponse(
-		MatchInfo match,
-		List<SeatInfo> seats,
-		Summary summary
+		@Schema(description = "경기 정보") MatchInfo match,
+		@Schema(description = "선점된 좌석 목록") List<SeatInfo> seats,
+		@Schema(description = "요약 정보") Summary summary
 ) {
 
+	@Schema(description = "경기 정보")
 	public record MatchInfo(
-			Long matchId,
-			Instant matchAt,
-			ClubInfo homeClub,
-			ClubInfo awayClub,
-			StadiumInfo stadium
+			@Schema(description = "경기 ID", example = "1") Long matchId,
+			@Schema(description = "경기 일시 (UTC)", example = "2026-03-29T05:00:00Z") Instant matchAt,
+			@Schema(description = "홈 구단 정보") ClubInfo homeClub,
+			@Schema(description = "원정 구단 정보") ClubInfo awayClub,
+			@Schema(description = "경기장 정보 (잠실야구장 고정)") StadiumInfo stadium
 	) {
+		private static final String JAMSIL_STADIUM_NAME = "잠실종합운동장 잠실야구장";
+		private static final String JAMSIL_STADIUM_ADDRESS = "서울 송파구 올림픽로 19-2 서울종합운동장";
+
 		public static MatchInfo from(Match match) {
 			return new MatchInfo(
 					match.getId(),
@@ -27,28 +34,38 @@ public record OrderSheetGetResponse(
 					new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
 					new StadiumInfo(
 							match.getStadium().getId(),
-							match.getStadium().getKoName(),
-							match.getStadium().getAddress()
+							JAMSIL_STADIUM_NAME,
+							JAMSIL_STADIUM_ADDRESS
 					)
 			);
 		}
 	}
 
-	public record ClubInfo(Long clubId, String koName) {
+	@Schema(description = "구단 정보")
+	public record ClubInfo(
+			@Schema(description = "구단 ID", example = "1") Long clubId,
+			@Schema(description = "구단 한글명", example = "LG 트윈스") String koName
+	) {
 	}
 
-	public record StadiumInfo(Long stadiumId, String koName, String address) {
+	@Schema(description = "경기장 정보")
+	public record StadiumInfo(
+			@Schema(description = "경기장 ID", example = "1") Long stadiumId,
+			@Schema(description = "경기장명", example = "잠실종합운동장 잠실야구장") String koName,
+			@Schema(description = "경기장 주소", example = "서울 송파구 올림픽로 19-2 서울종합운동장") String address
+	) {
 	}
 
+	@Schema(description = "좌석 정보")
 	public record SeatInfo(
-			Long matchSeatId,
-			Long sectionId,
-			String sectionName,
-			Long blockId,
-			String blockCode,
-			Integer rowNo,
-			Integer seatNo,
-			Integer adultPrice
+			@Schema(description = "매치 좌석 ID", example = "149801") Long matchSeatId,
+			@Schema(description = "섹션 ID", example = "5") Long sectionId,
+			@Schema(description = "섹션명", example = "오렌지석") String sectionName,
+			@Schema(description = "블럭 ID", example = "1") Long blockId,
+			@Schema(description = "블럭 코드", example = "206") String blockCode,
+			@Schema(description = "열 번호", example = "3") Integer rowNo,
+			@Schema(description = "좌석 번호", example = "13") Integer seatNo,
+			@Schema(description = "성인 기본가 (주중/주말 자동 반영, 원 단위)", example = "20000") Integer adultPrice
 	) {
 		public static SeatInfo of(SeatHoldInfo holdInfo, Integer adultPrice) {
 			return new SeatInfo(
@@ -64,7 +81,11 @@ public record OrderSheetGetResponse(
 		}
 	}
 
-	public record Summary(int seatCount, int bookingFee) {
+	@Schema(description = "요약 정보")
+	public record Summary(
+			@Schema(description = "선점 좌석 수", example = "2") int seatCount,
+			@Schema(description = "예매 수수료 (원)", example = "2000") int bookingFee
+	) {
 	}
 
 	private static final int BOOKING_FEE = 2_000;

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
@@ -23,6 +23,7 @@ public record OrderSheetGetResponse(
 			@Schema(description = "원정 구단 정보") ClubInfo awayClub,
 			@Schema(description = "경기장 정보 (잠실야구장 고정)") StadiumInfo stadium
 	) {
+		private static final Long JAMSIL_STADIUM_ID = 1L;
 		private static final String JAMSIL_STADIUM_NAME = "잠실종합운동장 잠실야구장";
 		private static final String JAMSIL_STADIUM_ADDRESS = "서울 송파구 올림픽로 19-2 서울종합운동장";
 
@@ -33,7 +34,7 @@ public record OrderSheetGetResponse(
 					new ClubInfo(match.getHomeClub().getId(), match.getHomeClub().getKoName()),
 					new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
 					new StadiumInfo(
-							match.getStadium().getId(),
+							JAMSIL_STADIUM_ID,
 							JAMSIL_STADIUM_NAME,
 							JAMSIL_STADIUM_ADDRESS
 					)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
@@ -78,4 +78,8 @@ public class OrderSeat extends BaseEntity {
 		this.price = price;
 		this.ticketType = ticketType;
 	}
+
+	public void assignOrder(Order order) {
+		this.order = order;
+	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -38,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderService {
 
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-	private static final int BOOKING_FEE = 2_000;
 
 	private final MatchRepository matchRepository;
 	private final UserRepository userRepository;
@@ -90,32 +89,27 @@ public class OrderService {
 		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
-		String dayType = determineDayType(match.getMatchAt());
 		Map<Long, SeatOrderItem> seatItemMap = request.seats().stream()
 				.collect(Collectors.toMap(SeatOrderItem::matchSeatId, item -> item));
 
-		// 유효성 검증 + 가격 계산
+		// 유효성 검증 + 프론트에서 전달받은 가격 사용
 		record SeatPriceItem(SeatHoldInfo hold, SeatOrderItem item, int price) {
 		}
 		List<SeatPriceItem> priceItems = new ArrayList<>();
-		int ticketTotal = 0;
 		for (SeatHoldInfo hold : holdInfos) {
 			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
 			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
 					ErrorCode.INVALID_ORDER_STATUS);
 
 			SeatOrderItem item = seatItemMap.get(hold.matchSeatId());
-			Integer price = seatInfoQueryService.findPrice(hold.sectionId(), dayType, item.ticketType().name());
-			Preconditions.validate(price != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
-			priceItems.add(new SeatPriceItem(hold, item, price));
-			ticketTotal += price;
+			Preconditions.validate(item != null, ErrorCode.ORDER_SEAT_EMPTY);
+			priceItems.add(new SeatPriceItem(hold, item, item.price()));
 		}
-		int totalAmount = ticketTotal + BOOKING_FEE;
 
 		Order order = Order.builder()
 				.user(user)
 				.match(match)
-				.totalAmount(totalAmount)
+				.totalAmount(request.totalPrice())
 				.ordererName(request.ordererName())
 				.ordererEmail(request.ordererEmail())
 				.ordererPhone(request.ordererPhone())
@@ -140,7 +134,7 @@ public class OrderService {
 		orderSeatRepository.saveAll(orderSeats);
 
 		log.info("[OrderService] 주문 생성 완료 - orderId={}, userId={}, seatCount={}, totalAmount={}",
-				order.getId(), userId, orderSeats.size(), totalAmount);
+				order.getId(), userId, orderSeats.size(), request.totalPrice());
 
 		return OrderCreateResponse.of(order, orderSeats.size());
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -89,10 +89,11 @@ public class OrderService {
 		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
+		String dayType = determineDayType(match.getMatchAt());
 		Map<Long, SeatOrderItem> seatItemMap = request.seats().stream()
 				.collect(Collectors.toMap(SeatOrderItem::matchSeatId, item -> item));
 
-		// 유효성 검증 + 프론트에서 전달받은 가격 사용
+		// 유효성 검증 + 좌석별 가격 조회 (order_seats 저장용)
 		record SeatPriceItem(SeatHoldInfo hold, SeatOrderItem item, int price) {
 		}
 		List<SeatPriceItem> priceItems = new ArrayList<>();
@@ -103,7 +104,9 @@ public class OrderService {
 
 			SeatOrderItem item = seatItemMap.get(hold.matchSeatId());
 			Preconditions.validate(item != null, ErrorCode.ORDER_SEAT_EMPTY);
-			priceItems.add(new SeatPriceItem(hold, item, item.price()));
+			Integer price = seatInfoQueryService.findPrice(hold.sectionId(), dayType, item.ticketType().name());
+			Preconditions.validate(price != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
+			priceItems.add(new SeatPriceItem(hold, item, price));
 		}
 
 		Order order = Order.builder()

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -5,18 +5,16 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.domain.ticket.enums.TicketType;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
-import com.goormgb.be.ordercore.order.dto.request.SeatOrderItem;
 import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
 import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
 import com.goormgb.be.ordercore.order.entity.Order;
@@ -76,37 +74,36 @@ public class OrderService {
 	 * 주문 생성: 좌석 선점 검증 후 Order + OrderSeat 엔티티를 생성한다.
 	 */
 	public OrderCreateResponse createOrder(Long userId, OrderCreateRequest request) {
-		Preconditions.validate(!request.seats().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
+		Preconditions.validate(!request.matchSeatIds().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Match match = matchRepository.findDetailByIdOrThrow(request.matchId());
 
-		List<Long> matchSeatIds = request.seats().stream()
-				.map(SeatOrderItem::matchSeatId)
-				.toList();
-
-		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, matchSeatIds);
-		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
+		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, request.matchSeatIds());
+		Preconditions.validate(holdInfos.size() == request.matchSeatIds().size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
 		String dayType = determineDayType(match.getMatchAt());
-		Map<Long, SeatOrderItem> seatItemMap = request.seats().stream()
-				.collect(Collectors.toMap(SeatOrderItem::matchSeatId, item -> item));
 
-		// 유효성 검증 + 좌석별 가격 조회 (order_seats 저장용)
-		record SeatPriceItem(SeatHoldInfo hold, SeatOrderItem item, int price) {
-		}
-		List<SeatPriceItem> priceItems = new ArrayList<>();
+		// 유효성 검증 + 좌석별 성인 기본가 조회 (order_seats 저장용)
+		List<OrderSeat> orderSeats = new ArrayList<>();
 		for (SeatHoldInfo hold : holdInfos) {
 			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
 			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
 					ErrorCode.INVALID_ORDER_STATUS);
 
-			SeatOrderItem item = seatItemMap.get(hold.matchSeatId());
-			Preconditions.validate(item != null, ErrorCode.ORDER_SEAT_EMPTY);
-			Integer price = seatInfoQueryService.findPrice(hold.sectionId(), dayType, item.ticketType().name());
-			Preconditions.validate(price != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
-			priceItems.add(new SeatPriceItem(hold, item, price));
+			Integer adultPrice = seatInfoQueryService.findPrice(hold.sectionId(), dayType, "ADULT");
+			Preconditions.validate(adultPrice != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
+
+			orderSeats.add(OrderSeat.builder()
+					.matchSeatId(hold.matchSeatId())
+					.blockId(hold.blockId())
+					.sectionId(hold.sectionId())
+					.rowNo(hold.rowNo())
+					.seatNo(hold.seatNo())
+					.price(adultPrice)
+					.ticketType(TicketType.ADULT)
+					.build());
 		}
 
 		Order order = Order.builder()
@@ -120,20 +117,7 @@ public class OrderService {
 				.build();
 
 		orderRepository.save(order);
-
-		List<OrderSeat> orderSeats = priceItems.stream()
-				.map(pi -> OrderSeat.builder()
-						.order(order)
-						.matchSeatId(pi.hold().matchSeatId())
-						.blockId(pi.hold().blockId())
-						.sectionId(pi.hold().sectionId())
-						.rowNo(pi.hold().rowNo())
-						.seatNo(pi.hold().seatNo())
-						.price(pi.price())
-						.ticketType(pi.item().ticketType())
-						.build())
-				.toList();
-
+		orderSeats.forEach(seat -> seat.assignOrder(order));
 		orderSeatRepository.saveAll(orderSeats);
 
 		log.info("[OrderService] 주문 생성 완료 - orderId={}, userId={}, seatCount={}, totalAmount={}",


### PR DESCRIPTION
## 🔧 작업 내용
- 주문서 조회 시 경기장 정보를 잠실야구장으로 하드코딩 (기존: DB의 stadium 정보 그대로 반환 → KT, KIA 등 타 구장 노출 이슈)
- 주문 생성 시 가격 계산 책임을 프론트엔드로 위임 (기존: 백엔드 price_policies 테이블 조회 →  프론트에서 할인 적용 후 최종 가격 전송)
- 주문 생성 요청에 `totalPrice` (총 결제 금액) 및 좌석별 `price` (할인 적용 후 개별 가격) 필드 추가                                                                                    
                                                                                               
## 🧩 구현 상세                                           
- **경기장 하드코딩**: `OrderSheetGetResponse.MatchInfo.from()`에서 `match.getStadium()` 대신
   잠실야구장 상수 반환                                                                        
- **가격 위임**: `OrderService.createOrder()`에서 `price_policies` 조회 로직 제거, 프론트가  보낸 `request.totalPrice()`를 `orders.total_amount`에 저장
- **좌석별 가격 저장**: `SeatOrderItem.price`를 `order_seats.price`에 저장하여 이메일 발송 시 좌석별 금액 참조 가능
- 결제는 목업(무조건 성공)이므로 서버 사이드 가격 검증 생략


## ❗ 참고 사항
- **프론트 변경 필요**: 주문 생성 API에 `totalPrice` (Integer, 필수), 필드 추가됨
- 후속 작업: 결제 완료 이메일 발송 기능 (좌석별 price 데이터 활용 예정)