### PR TITLE
feat(auth-guard): JWT Access/Refresh Token에 sid(세션 ID) claim 추가 [GRGB-293]

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -29,6 +29,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private static final String BEARER_PREFIX = "Bearer ";
 	private static final String HEADER_USER_ID = "X-User-Id";
 	private static final String HEADER_USER_ROLE = "X-User-Role";
+	private static final String HEADER_SESSION_ID = "X-Session-Id";
+	private static final String HEADER_TOKEN_JTI = "X-Token-Jti";
 
 	// 인증 없이 통과시킬 경로 prefix 목록
 	private static final List<String> WHITELIST = List.of(
@@ -76,6 +78,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 			String jti = jwtTokenProvider.getJti(claims);
 			Long userId = jwtTokenProvider.getUserId(claims);
 			String authority = jwtTokenProvider.getAuthority(claims);
+			String sid = jwtTokenProvider.getSid(claims);
 
 			return blacklistRepository.isBlacklisted(jti)
 					.flatMap(isBlacklisted -> {
@@ -84,12 +87,18 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 							return unauthorizedResponse(exchange);
 						}
 
-						ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+						ServerHttpRequest.Builder requestBuilder = exchange.getRequest().mutate()
 								.header(HEADER_USER_ID, String.valueOf(userId))
 								.header(HEADER_USER_ROLE, authority)
-								.build();
+								.header(HEADER_TOKEN_JTI, jti);
 
-						log.debug("JWT authenticated - userId: {}, role: {}", userId, authority);
+						if (sid != null) {
+							requestBuilder.header(HEADER_SESSION_ID, sid);
+						}
+
+						ServerHttpRequest mutatedRequest = requestBuilder.build();
+
+						log.debug("JWT authenticated - userId: {}, role: {}, sid: {}", userId, authority, sid);
 						return chain.filter(exchange.mutate().request(mutatedRequest).build());
 					});
 

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
@@ -22,6 +22,7 @@ public class JwtTokenProvider {
 
 	private static final String CLAIM_TOKEN_TYPE = "tokenType";
 	private static final String CLAIM_AUTH = "auth";
+	private static final String CLAIM_SID = "sid";
 
 	private final JwtProperties jwtProperties;
 	private RSAPublicKey publicKey;
@@ -62,5 +63,9 @@ public class JwtTokenProvider {
 
 	public String getJti(Claims claims) {
 		return claims.getId();
+	}
+
+	public String getSid(Claims claims) {
+		return claims.get(CLAIM_SID, String.class);
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
@@ -2,6 +2,8 @@ package com.goormgb.be.authguard.auth.dto;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,8 +34,9 @@ public class RefreshTokenInfo {
 	/** JWT ID - 토큰 고유 식별자 (UUID), Redis Key로 사용 */
 	private String jti;
 
-	/** 토큰 패밀리 ID - RTR(Refresh Token Rotation) 추적용 */
-	private String tokenFamily;
+	/** 세션 ID - 로그인 세션 식별 및 RTR 추적용 */
+	@JsonAlias("tokenFamily")
+	private String sid;
 
 	/** 토큰 발급 시각 (UTC 기준 절대시간) */
 	private Instant issuedAt;

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -73,15 +73,23 @@ public class AuthService {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Preconditions.validate(user.getStatus() != UserStatus.DEACTIVATE, ErrorCode.USER_DEACTIVATED);
 
-		// 6. 새 토큰 발급
-		String newAccessToken = jwtTokenProvider.createAccessToken(userId, DEFAULT_AUTHORITY);
-		String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+		// 6. 기존 sid 추출 (하위 호환: sid 없는 기존 토큰은 새로 생성)
+		String sid = jwtTokenProvider.getSidFromToken(refreshToken);
+		if (sid == null) {
+			sid = storedTokenInfo.getSid();
+		}
+		if (sid == null) {
+			sid = java.util.UUID.randomUUID().toString();
+		}
+
+		// 7. 새 토큰 발급 (동일 sid 유지)
+		String newAccessToken = jwtTokenProvider.createAccessToken(userId, DEFAULT_AUTHORITY, sid);
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(userId, sid);
 		String newJti = jwtTokenProvider.getJtiFromToken(newRefreshToken);
 
-		// 7. Redis 갱신 (기존 토큰 삭제 + 새 토큰 저장)
+		// 8. Redis 갱신 (기존 토큰 삭제 + 새 토큰 저장)
 		refreshTokenRepository.deleteByJti(jti);
 
-		// LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 		Instant now = Instant.now();
 		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
 
@@ -89,9 +97,8 @@ public class AuthService {
 				.userId(userId)
 				.token(newRefreshToken)
 				.jti(newJti)
-				.tokenFamily(storedTokenInfo.getTokenFamily()) // 기존 토큰 패밀리 유지
+				.sid(sid)
 				.issuedAt(now)
-				// .expiresAt(now.plusDays(expirationDays))
 				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.goormgb.be.authguard.auth.service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -55,32 +57,28 @@ public class AuthService {
 		// 1. Refresh Token 검증
 		jwtTokenProvider.validateToken(refreshToken);
 
-		// 2. 토큰 타입 확인
-		TokenType tokenType = jwtTokenProvider.getTokenTypeFromToken(refreshToken);
+		// 2. Claims 한 번만 파싱하여 필요한 정보 추출
+		Claims claims = jwtTokenProvider.parseClaims(refreshToken);
+		TokenType tokenType = jwtTokenProvider.getTokenType(claims);
 		Preconditions.validate(tokenType == TokenType.REFRESH, ErrorCode.INVALID_TOKEN_TYPE);
 
-		// 3. jti, userId 추출
-		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
-		Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+		String jti = jwtTokenProvider.getJti(claims);
+		Long userId = jwtTokenProvider.getUserId(claims);
 
-		// 4. Redis에서 저장된 토큰 조회 & 일치 확인
+		// 3. Redis에서 저장된 토큰 조회 & 일치 확인
 		RefreshTokenInfo storedTokenInfo = refreshTokenRepository.findByJtiOrThrow(jti,
 				ErrorCode.REFRESH_TOKEN_NOT_FOUND);
 
 		Preconditions.validate(refreshToken.equals(storedTokenInfo.getToken()), ErrorCode.REFRESH_TOKEN_MISMATCH);
 
-		// 5. 사용자 상태 확인
+		// 4. 사용자 상태 확인
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Preconditions.validate(user.getStatus() != UserStatus.DEACTIVATE, ErrorCode.USER_DEACTIVATED);
 
-		// 6. 기존 sid 추출 (하위 호환: sid 없는 기존 토큰은 새로 생성)
-		String sid = jwtTokenProvider.getSidFromToken(refreshToken);
-		if (sid == null) {
-			sid = storedTokenInfo.getSid();
-		}
-		if (sid == null) {
-			sid = java.util.UUID.randomUUID().toString();
-		}
+		// 5. 기존 sid 추출 (하위 호환: sid 없는 기존 토큰은 새로 생성)
+		String sid = Optional.ofNullable(jwtTokenProvider.getSid(claims))
+				.or(() -> Optional.ofNullable(storedTokenInfo.getSid()))
+				.orElseGet(() -> UUID.randomUUID().toString());
 
 		// 7. 새 토큰 발급 (동일 sid 유지)
 		String newAccessToken = jwtTokenProvider.createAccessToken(userId, DEFAULT_AUTHORITY, sid);

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
@@ -79,8 +79,9 @@ public class DevAuthService {
 
 		user.updateLastLoginAt();
 
-		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY);
-		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+		String sid = UUID.randomUUID().toString();
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY, sid);
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), sid);
 		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
 
 		Instant now = Instant.now();
@@ -90,7 +91,7 @@ public class DevAuthService {
 				.userId(user.getId())
 				.token(refreshToken)
 				.jti(jti)
-				.tokenFamily(UUID.randomUUID().toString())
+				.sid(sid)
 				.issuedAt(now)
 				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
 				.userAgent(request.getHeader("User-Agent"))

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -33,6 +33,7 @@ public class AuthGuardSecurityConfig {
 								"/kakao/**",
 								"/token/refresh",
 								"/dev/auth/**",
+								"/loadtest/**",
 								"/swagger-ui/**",
 								"/swagger-ui.html",
 								"/swagger-resources/**",

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -30,6 +30,7 @@ public class JwtTokenProvider {
 
 	private static final String CLAIM_TOKEN_TYPE = "tokenType";
 	private static final String CLAIM_AUTH = "auth";
+	private static final String CLAIM_SID = "sid";
 
 	private final JwtProperties jwtProperties;
 	private RSAPrivateKey privateKey;
@@ -41,7 +42,7 @@ public class JwtTokenProvider {
 		this.publicKey = RsaKeyUtils.parsePublicKey(jwtProperties.getPublicKey());
 	}
 
-	public String createAccessToken(Long userId, String authority) {
+	public String createAccessToken(Long userId, String authority, String sid) {
 		Instant now = Instant.now();
 		Instant expiration = now.plus(jwtProperties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
 
@@ -59,11 +60,12 @@ public class JwtTokenProvider {
 				.id(UUID.randomUUID().toString())
 				.claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
 				.claim(CLAIM_AUTH, authority)
+				.claim(CLAIM_SID, sid)
 				.signWith(privateKey, Jwts.SIG.RS256)
 				.compact();
 	}
 
-	public String createRefreshToken(Long userId) {
+	public String createRefreshToken(Long userId, String sid) {
 		Instant now = Instant.now();
 		Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationDays(), ChronoUnit.DAYS);
 
@@ -80,6 +82,7 @@ public class JwtTokenProvider {
 				.expiration(Date.from(expiration))
 				.id(UUID.randomUUID().toString())
 				.claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
+				.claim(CLAIM_SID, sid)
 				.signWith(privateKey, Jwts.SIG.RS256)
 				.compact();
 	}
@@ -116,6 +119,11 @@ public class JwtTokenProvider {
 	public String getJtiFromToken(String token) {
 		Claims claims = parseClaimsFromToken(token);
 		return claims.getId();
+	}
+
+	public String getSidFromToken(String token) {
+		Claims claims = parseClaimsFromToken(token);
+		return claims.get(CLAIM_SID, String.class);
 	}
 
 	public Date getExpirationFromToken(String token) {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -100,35 +100,57 @@ public class JwtTokenProvider {
 		}
 	}
 
-	public Long getUserIdFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public Claims parseClaims(String token) {
+		return parseClaimsFromToken(token);
+	}
+
+	public Long getUserId(Claims claims) {
 		return Long.parseLong(claims.getSubject());
 	}
 
-	public String getAuthorityFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public String getAuthority(Claims claims) {
 		return claims.get(CLAIM_AUTH, String.class);
 	}
 
-	public TokenType getTokenTypeFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public TokenType getTokenType(Claims claims) {
 		String tokenTypeValue = claims.get(CLAIM_TOKEN_TYPE, String.class);
 		return TokenType.valueOf(tokenTypeValue);
 	}
 
-	public String getJtiFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public String getJti(Claims claims) {
 		return claims.getId();
 	}
 
-	public String getSidFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public String getSid(Claims claims) {
 		return claims.get(CLAIM_SID, String.class);
 	}
 
-	public Date getExpirationFromToken(String token) {
-		Claims claims = parseClaimsFromToken(token);
+	public Date getExpiration(Claims claims) {
 		return claims.getExpiration();
+	}
+
+	public Long getUserIdFromToken(String token) {
+		return getUserId(parseClaimsFromToken(token));
+	}
+
+	public String getAuthorityFromToken(String token) {
+		return getAuthority(parseClaimsFromToken(token));
+	}
+
+	public TokenType getTokenTypeFromToken(String token) {
+		return getTokenType(parseClaimsFromToken(token));
+	}
+
+	public String getJtiFromToken(String token) {
+		return getJti(parseClaimsFromToken(token));
+	}
+
+	public String getSidFromToken(String token) {
+		return getSid(parseClaimsFromToken(token));
+	}
+
+	public Date getExpirationFromToken(String token) {
+		return getExpiration(parseClaimsFromToken(token));
 	}
 
 	private Claims parseClaimsFromToken(String token) {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -78,16 +78,16 @@ public class KakaoAuthService {
 		user.updateLastLoginAt();
 
 		// 6. JWT 발급
+		String sid = UUID.randomUUID().toString();
 		String accessToken =
-				jwtTokenProvider.createAccessToken(user.getId(), "ROLE_USER");
+				jwtTokenProvider.createAccessToken(user.getId(), "ROLE_USER", sid);
 
 		String refreshToken =
-				jwtTokenProvider.createRefreshToken(user.getId());
+				jwtTokenProvider.createRefreshToken(user.getId(), sid);
 
 		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
 
 		// 7. refreshToken redis 에 저장
-		//LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 		Instant now = Instant.now();
 
 		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
@@ -96,9 +96,8 @@ public class KakaoAuthService {
 				.userId(user.getId())
 				.token(refreshToken)
 				.jti(jti)
-				.tokenFamily(UUID.randomUUID().toString()) // 신규 로그인이므로 새로운 토큰 패밀리 생성
+				.sid(sid)
 				.issuedAt(now)
-				//.expiresAt(now.plusDays(expirationDays))
 				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))

--- a/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/security/filter/XUserIdAuthenticationFilter.java
@@ -21,6 +21,7 @@ public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 
 	private static final String HEADER_USER_ID = "X-User-Id";
 	private static final String HEADER_USER_ROLE = "X-User-Role";
+	private static final String HEADER_SESSION_ID = "X-Session-Id";
 
 	@Override
 	protected void doFilterInternal(
@@ -31,6 +32,7 @@ public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 
 		String userId = request.getHeader(HEADER_USER_ID);
 		String userRole = request.getHeader(HEADER_USER_ROLE);
+		String sessionId = request.getHeader(HEADER_SESSION_ID);
 
 		if (userId != null && !userId.isBlank()) {
 			try {
@@ -46,6 +48,10 @@ public class XUserIdAuthenticationFilter extends OncePerRequestFilter {
 								null,
 								List.of(authority)
 						);
+
+				if (sessionId != null && !sessionId.isBlank()) {
+					authentication.setDetails(sessionId);
+				}
 
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			} catch (NumberFormatException e) {


### PR DESCRIPTION
## 🔧 작업 내용
- JWT Access/Refresh Token에 sid(세션 ID) claim 추가
- API-Gateway에서 sid, jti를 다운스트림 서비스로 헤더 전달
- 토큰 패밀리는 jwt에 안넣고 레디스 저장용이었는데, ai 방어 에이전트를 위해  API-Gateway에서 다운스트림에 X-Session-Id 헤더로 전달함.

## 🧩 구현 상세
- **Auth-Guard**: `createAccessToken(userId, authority, sid)`, `createRefreshToken(userId,sid)`로 시그니처 변경
- **로그인 시** sid = UUID 신규 생성, **토큰 재발급(RTR) 시** 기존 sid 유지 (같은 세션)
- **RefreshTokenInfo**: `tokenFamily` → `sid`로 리네이밍, `@JsonAlias("tokenFamily")`로 Redis 하위 호환 보장
- **API-Gateway**: JWT에서 sid/jti 추출 후 `X-Session-Id`, `X-Token-Jti` 헤더로 다운스트림 전달
- **common-core**: `XUserIdAuthenticationFilter`에서 `X-Session-Id` 읽어 `SecurityContext.details`에 저장
- sid가 없는 기존 토큰은 null 허용으로 하위 호환 처리

  ### 📌 관련 Jira Issue
  - GRGB-293

## 🧪 테스트 방법
- 로그인 → Access Token JWT 디코딩하여 `sid` claim 존재 확인
- 토큰 재발급 → 새 토큰의 `sid`가 이전과 동일한지 확인
- 다른 기기 로그인 → 다른 `sid` 생성 확인
- API-Gateway 로그에 `sid` 포함 확인
<img width="1351" height="1081" alt="스크린샷 2026-03-25 오전 9 02 48" src="https://github.com/user-attachments/assets/23beea40-e59d-439d-b543-bb235ed08fca" />

## ❗ 참고 사항
- 기존 발급된 JWT(sid 없음)도 정상 동작 (하위 호환)