### PR TITLE
feat(monitoring): 외부에서 확인할 수 있도록 endpoints web 활성화 [GRGB-297]

### DIFF
--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -56,6 +56,10 @@ springdoc:
         url: /order/v3/api-docs
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       probes:

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -59,7 +59,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, prometheus
   endpoint:
     health:
       probes:

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, prometheus
   endpoint:
     health:
       probes:

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -53,6 +53,10 @@ kakao:
   user-info-url: https://kapi.kakao.com/v2/user/me
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       probes:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -31,6 +31,10 @@ spring:
       port: ${REDIS_PORT}
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       probes:

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, prometheus
   endpoint:
     health:
       probes:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -57,6 +57,10 @@ queue:
       issuer: queue-service
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       probes:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -60,7 +60,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, prometheus
   endpoint:
     health:
       probes:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -40,6 +40,10 @@ admission:
     issuer: ${ADMISSION_JWT_ISSUER:queue-service}
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
   endpoint:
     health:
       probes:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, metrics, prometheus
+        include: health, prometheus
   endpoint:
     health:
       probes:


### PR DESCRIPTION
## 🔧 작업 내용

- prometheus 추가

## 🧩 구현 상세 (선택)

 **외부에서 확인할 수 있는 endpoints 활성화**
```
  endpoints:
    web:
      exposure:
        include: health, info, metrics, prometheus
```


### 📌 관련 Jira Issue

- GRGB-297


## ❗ 참고 사항

