### PR TITLE
fix(seat): 추천 블록 조회 시 Block PK 대신 blockNum으로 조회하도록 수정 [GRGB-303]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/block/repository/BlockRepository.java
@@ -23,6 +23,9 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
 	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id IN :blockIds")
 	List<Block> findAllByIdInWithSectionAndArea(@Param("blockIds") List<Long> blockIds);
 
+	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.blockNum IN :blockNums")
+	List<Block> findAllByBlockNumInWithSectionAndArea(@Param("blockNums") List<Long> blockNums);
+
 	@Query("SELECT b FROM Block b JOIN FETCH b.section s JOIN FETCH b.area a WHERE b.id = :blockId")
 	Optional<Block> findByIdWithSectionAndArea(@Param("blockId") Long blockId);
 

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -71,10 +71,10 @@ public class SeatRecommendationService {
 
 			SeatSession seatSession = SeatSession.from(bookingOptions);
 			int ticketCount = seatSession.getTicketCount();
-			List<Long> preferredBlockIds = onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);
+			List<Long> preferredBlockNums = onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);
 
 			Match match = matchRepository.findDetailByIdOrThrow(matchId);
-			List<Block> preferredBlocks = blockRepository.findAllByBlockNumInWithSectionAndArea(preferredBlockIds);
+			List<Block> preferredBlocks = blockRepository.findAllByBlockNumInWithSectionAndArea(preferredBlockNums);
 			OnboardingPreference pref = onboardingPreferenceRepository.findByUserIdOrThrow(
 				userId, ErrorCode.PREFERENCE_NOT_FOUND);
 			List<OnboardingViewpointPriority> viewpoints =

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -74,7 +74,7 @@ public class SeatRecommendationService {
 			List<Long> preferredBlockIds = onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);
 
 			Match match = matchRepository.findDetailByIdOrThrow(matchId);
-			List<Block> preferredBlocks = blockRepository.findAllByIdInWithSectionAndArea(preferredBlockIds);
+			List<Block> preferredBlocks = blockRepository.findAllByBlockNumInWithSectionAndArea(preferredBlockIds);
 			OnboardingPreference pref = onboardingPreferenceRepository.findByUserIdOrThrow(
 				userId, ErrorCode.PREFERENCE_NOT_FOUND);
 			List<OnboardingViewpointPriority> viewpoints =

--- a/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/controller/SeatCommonControllerTest.java
@@ -126,7 +126,7 @@ class SeatCommonControllerTest extends WebMvcTestSupport {
 			.andExpect(jsonPath("$.code").value("OK"))
 			.andExpect(jsonPath("$.data.matchId").value(10))
 			.andExpect(jsonPath("$.data.seatCount").value(2))
-			.andExpect(jsonPath("$.data.seatIds[0]").value(206313))
+			.andExpect(jsonPath("$.data.matchSeatIds[0]").value(206313))
 			.andExpect(jsonPath("$.data.holdExpiresAt").value("2026-04-15T10:05:00Z"));
 
 		then(seatHoldService).should().createOrRefreshHold(userId, matchId, List.of(206313L, 206314L));

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
@@ -46,7 +48,7 @@ class SeatHoldTransactionalServiceTest {
 	private SeatHoldTransactionalService seatHoldTransactionalService;
 
 	private MatchSeat matchSeat(Long seatId, MatchSeatSaleStatus status) {
-		return MatchSeat.builder()
+		MatchSeat ms = MatchSeat.builder()
 			.matchId(MATCH_ID)
 			.seatId(seatId)
 			.areaId(1L)
@@ -58,6 +60,8 @@ class SeatHoldTransactionalServiceTest {
 			.seatZone(SeatZone.LOW)
 			.saleStatus(status)
 			.build();
+		ReflectionTestUtils.setField(ms, "id", seatId);
+		return ms;
 	}
 
 	private SeatHold seatHold(Long matchSeatId, Long seatId, Long userId, Instant expiresAt) {
@@ -131,7 +135,7 @@ class SeatHoldTransactionalServiceTest {
 			List.of(206313L, 206314L));
 
 		// then
-		assertThat(response.seatIds()).containsExactly(206313L, 206314L);
+		assertThat(response.matchSeatIds()).containsExactly(206313L, 206314L);
 		verify(seatHoldRepository).deleteAllByMatchSeatIdIn(List.of(11L, 12L));
 		verify(seatHoldRepository).flush();
 		verify(seatHoldRepository).saveAll(anyList());

--- a/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationServiceTest.java
@@ -84,7 +84,7 @@ class SeatRecommendationServiceTest {
 		given(onboardingPreferredBlockRepository.findBlockIdsByUserId(userId))
 			.willReturn(List.of(205L, 206L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
-		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 206L)))
+		given(blockRepository.findAllByBlockNumInWithSectionAndArea(List.of(205L, 206L)))
 			.willReturn(List.of(block205, block206));
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
 			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.ANY));
@@ -128,7 +128,7 @@ class SeatRecommendationServiceTest {
 		given(onboardingPreferredBlockRepository.findBlockIdsByUserId(userId))
 			.willReturn(List.of(205L, 408L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
-		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L, 408L)))
+		given(blockRepository.findAllByBlockNumInWithSectionAndArea(List.of(205L, 408L)))
 			.willReturn(List.of(block205, block408));
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
 			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.NEAR));
@@ -173,7 +173,7 @@ class SeatRecommendationServiceTest {
 		given(onboardingPreferredBlockRepository.findBlockIdsByUserId(userId))
 			.willReturn(List.of(205L));
 		given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
-		given(blockRepository.findAllByIdInWithSectionAndArea(List.of(205L))).willReturn(List.of(block205));
+		given(blockRepository.findAllByBlockNumInWithSectionAndArea(List.of(205L))).willReturn(List.of(block205));
 		given(onboardingPreferenceRepository.findByUserIdOrThrow(eq(userId), any()))
 			.willReturn(OnboardingFixture.preference(user, lgClub, CheerProximityPref.ANY));
 		given(onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId)).willReturn(List.of());


### PR DESCRIPTION
## 🔧 작업 내용
- 선호 블록 추천 시 유저가 선택한 10개 블록 중 일부만 반환되는 버그 수정

- 원인: `onboarding_preferred_blocks`에 blockNum(구역번호: 101~422)이 저장되는데, 추천 서비스에서 이 값을 BlockId PK로 조회하고 있었음ㅠㅠ
- Block PK 범위(1~100)와 blockNum 범위(101~422)가 달라서 대부분 매칭 실패, 우연히 PK가 일치하는 일부만 엉뚱한 블록으로 추천됨........
                                                         
## 🧩 구현 상세
- `BlockRepository`에 `findAllByBlockNumInWithSectionAndArea` 메서드 추가    
- `SeatRecommendationService`에서 `findAllByIdIn` → `findAllByBlockNumIn` 호출로 변경
- 프론트엔드/온보딩 저장 로직은 정상이므로 변경 없음 
                                                         
```java                                                
  // Before: Block PK로 조회 (잘못됨)                    
  blockRepository.findAllByIdInWithSectionAndArea(preferr
  edBlockIds);                                           
   
  // After: blockNum으로 조회 (정상)                     
  blockRepository.findAllByBlockNumInWithSectionAndArea(p
  referredBlockIds);                                     
```   

### 📌 관련 Jira Issue
  - GRGB-303

##  ❗ 참고 사항
- 기존 유저의 onboarding_preferred_blocks 데이터는 이미 blockNum으로 정상 저장되어 있으므로 DB 마이그레이션 불필요