### PR TITLE
feat(mypage): 티켓 취소 요청 API 구현 [GRGB-302]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/TimeConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package com.goormgb.be.ordercore.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+	@Bean
+	public Clock clock() {
+		return Clock.systemUTC();
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -4,12 +4,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
@@ -114,5 +116,26 @@ public class MyPageController {
 		@PathVariable Long ticketId
 	) {
 		return ApiResult.ok("QR 발급 성공", myPageService.getTicketEntryQr(userId, ticketId));
+	}
+
+	@Operation(
+		summary = "티켓 취소 요청",
+		description = "사용자의 특정 예매(ticketId=orders.id)에 대한 취소 요청을 처리합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "취소 요청 완료"),
+		@ApiResponse(responseCode = "400", description = "취소 불가 상태", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
+		@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+	})
+	@PostMapping("/tickets/{ticketId}/cancel")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<MyPageTicketCancelResponse> requestTicketCancel(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long ticketId
+	) {
+		return ApiResult.ok("취소 요청이 완료되었습니다.", myPageService.requestTicketCancel(userId, ticketId));
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketCancelResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketCancelResponse.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.ordercore.mypage.dto.response;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+
+public record MyPageTicketCancelResponse(
+	Long ticketId,
+	OrderStatus status,
+	int totalAmount,
+	int cancellationFee,
+	int refundedAmount
+) {
+	public static MyPageTicketCancelResponse of(Order order) {
+		return new MyPageTicketCancelResponse(
+			order.getId(),
+			order.getStatus(),
+			order.getTotalAmount(),
+			order.getCancellationFee(),
+			order.getRefundedAmount()
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.ordercore.mypage.service;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -79,6 +80,7 @@ public class MyPageService {
 	private final QrTokenRepository qrTokenRepository;
 	private final MyPageQueryService myPageQueryService;
 	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
+	private final Clock clock;
 
 	/**
 	 * 마이페이지 프로필 요약 조회
@@ -87,7 +89,7 @@ public class MyPageService {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
 
-		Instant now = Instant.now();
+		Instant now = Instant.now(clock);
 		long upcomingCount = orderRepository.countUpcomingOrders(userId, UPCOMING_STATUSES, now);
 		long cancelRefundCount = orderRepository.countByUserIdAndStatusIn(userId, CANCEL_REFUND_STATUSES);
 		long completedCount = orderRepository.countCompletedOrders(userId, now);
@@ -107,7 +109,7 @@ public class MyPageService {
 		TicketTab ticketTab = TicketTab.fromString(tab);
 		List<String> statusNames = ticketTab.getStatusNames();
 
-		Instant now = Instant.now();
+		Instant now = Instant.now(clock);
 		int totalCount = (int)orderRepository.countByUserId(userId);
 		int upcomingCount = (int)orderRepository.countUpcomingOrders(userId, UPCOMING_STATUSES, now);
 		int cancelProcessingCount = (int)orderRepository.countByUserIdAndStatusIn(userId, CANCEL_PROCESSING_STATUSES);
@@ -179,7 +181,7 @@ public class MyPageService {
 		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
-		Instant now = Instant.now();
+		Instant now = Instant.now(clock);
 		validateQrIssuableTime(order.getMatch().getMatchAt(), now);
 
 		QrToken qrToken = qrTokenRepository.findByOrderIdAndExpiresAtAfter(ticketId, now)
@@ -191,15 +193,16 @@ public class MyPageService {
 
 	@Transactional
 	public MyPageTicketCancelResponse requestTicketCancel(Long userId, Long ticketId) {
+		Instant now = Instant.now(clock);
 		Order order = orderRepository.findByIdForUpdate(ticketId)
 			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
-		CancellationFeePolicy policy = findCancellationPolicy(order.getMatch().getMatchAt());
+		CancellationFeePolicy policy = findCancellationPolicy(order.getMatch().getMatchAt(), now);
 		Preconditions.validate(Boolean.TRUE.equals(policy.getCancellable()), ErrorCode.TICKET_CANCEL_NOT_ALLOWED);
 
-		int cancellationFee = calculateCancellationFee(order, policy);
+		int cancellationFee = calculateCancellationFee(order, policy, now);
 		int refundedAmount = order.getTotalAmount() - cancellationFee;
 		order.cancel(cancellationFee, refundedAmount);
 
@@ -284,7 +287,7 @@ public class MyPageService {
 			.toInstant();
 
 		int daysLeft = Math.max(0, (int)ChronoUnit.DAYS.between(
-			LocalDate.now(KST),
+			Instant.now(clock).atZone(KST).toLocalDate(),
 			matchAt.atZone(KST).toLocalDate()
 		));
 
@@ -333,25 +336,34 @@ public class MyPageService {
 		return Instant.ofEpochSecond(expiresEpochSec);
 	}
 
-	private CancellationFeePolicy findCancellationPolicy(Instant matchAt) {
+	private CancellationFeePolicy findCancellationPolicy(Instant matchAt, Instant now) {
 		int daysLeft = Math.max(0, (int)ChronoUnit.DAYS.between(
-			LocalDate.now(KST),
+			now.atZone(KST).toLocalDate(),
 			matchAt.atZone(KST).toLocalDate()
 		));
 		return cancellationFeePolicyRepository.findByDaysLeft(daysLeft)
 			.orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
 	}
 
-	private int calculateCancellationFee(Order order, CancellationFeePolicy policy) {
+	private int calculateCancellationFee(Order order, CancellationFeePolicy policy, Instant now) {
 		int ticketAmount = Math.max(0, order.getTotalAmount() - order.getBookingFee());
 		int ticketFee = policy.getTicketFeeRate()
 			.multiply(BigDecimal.valueOf(ticketAmount))
 			.setScale(0, RoundingMode.DOWN)
 			.intValue();
 
-		if (Boolean.TRUE.equals(policy.getBookingFeeRefundable())) {
+		if (Boolean.TRUE.equals(policy.getBookingFeeRefundable()) && isSameBookingDate(order, now)) {
 			return ticketFee;
 		}
 		return ticketFee + order.getBookingFee();
+	}
+
+	private boolean isSameBookingDate(Order order, Instant now) {
+		if (order.getCreatedAt() == null) {
+			return false;
+		}
+		LocalDate bookingDate = order.getCreatedAt().atZone(KST).toLocalDate();
+		LocalDate cancelDate = now.atZone(KST).toLocalDate();
+		return bookingDate.equals(cancelDate);
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -23,6 +23,7 @@ import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRep
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
@@ -188,6 +189,23 @@ public class MyPageService {
 		return MyPageTicketQrResponse.of(order, seatRows, qrToken.getQrToken(), qrToken.getExpiresAt());
 	}
 
+	@Transactional
+	public MyPageTicketCancelResponse requestTicketCancel(Long userId, Long ticketId) {
+		Order order = orderRepository.findByIdForUpdate(ticketId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
+
+		CancellationFeePolicy policy = findCancellationPolicy(order.getMatch().getMatchAt());
+		Preconditions.validate(Boolean.TRUE.equals(policy.getCancellable()), ErrorCode.TICKET_CANCEL_NOT_ALLOWED);
+
+		int cancellationFee = calculateCancellationFee(order, policy);
+		int refundedAmount = order.getTotalAmount() - cancellationFee;
+		order.cancel(cancellationFee, refundedAmount);
+
+		return MyPageTicketCancelResponse.of(order);
+	}
+
 	private Map<Long, List<MyPageTicketListResponse.SeatInfo>> buildSeatMap(List<Long> orderIds) {
 		List<OrderSeatRow> seatRows = myPageQueryService.findOrderSeatRowsByOrderIds(orderIds);
 		return seatRows.stream()
@@ -313,5 +331,27 @@ public class MyPageService {
 		long nowEpochSec = now.getEpochSecond();
 		long expiresEpochSec = ((nowEpochSec / QR_REFRESH_INTERVAL_SECONDS) + 1) * QR_REFRESH_INTERVAL_SECONDS;
 		return Instant.ofEpochSecond(expiresEpochSec);
+	}
+
+	private CancellationFeePolicy findCancellationPolicy(Instant matchAt) {
+		int daysLeft = Math.max(0, (int)ChronoUnit.DAYS.between(
+			LocalDate.now(KST),
+			matchAt.atZone(KST).toLocalDate()
+		));
+		return cancellationFeePolicyRepository.findByDaysLeft(daysLeft)
+			.orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+	}
+
+	private int calculateCancellationFee(Order order, CancellationFeePolicy policy) {
+		int ticketAmount = Math.max(0, order.getTotalAmount() - order.getBookingFee());
+		int ticketFee = policy.getTicketFeeRate()
+			.multiply(BigDecimal.valueOf(ticketAmount))
+			.setScale(0, RoundingMode.DOWN)
+			.intValue();
+
+		if (Boolean.TRUE.equals(policy.getBookingFeeRefundable())) {
+			return ticketFee;
+		}
+		return ticketFee + order.getBookingFee();
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -8,6 +8,7 @@ import com.goormgb.be.domain.ticket.enums.TicketType;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
@@ -176,6 +177,16 @@ public final class MyPageFixture {
 				new MyPageTicketQrResponse.SeatInfo("오렌지석", "206", 3, 13),
 				new MyPageTicketQrResponse.SeatInfo("오렌지석", "206", 3, 14)
 			)
+		);
+	}
+
+	public static MyPageTicketCancelResponse createTicketCancelResponse() {
+		return new MyPageTicketCancelResponse(
+			101L,
+			OrderStatus.CANCEL_REQUESTED,
+			42000,
+			6000,
+			36000
 		);
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -22,6 +22,7 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.mypage.MyPageFixture;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
@@ -290,6 +291,55 @@ class MyPageControllerTest extends WebMvcTestSupport {
 			mockMvc.perform(get("/mypage/tickets/101/qr"))
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.message").value("경기 시작 이후에는 QR을 발급할 수 없습니다."));
+		}
+	}
+
+	@Nested
+	@DisplayName("POST /mypage/tickets/{ticketId}/cancel — 티켓 취소 요청")
+	class RequestTicketCancel {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 취소 결과를 반환한다")
+		void requestTicketCancel_성공() throws Exception {
+			MyPageTicketCancelResponse response = MyPageFixture.createTicketCancelResponse();
+			given(myPageService.requestTicketCancel(1L, 101L)).willReturn(response);
+
+			mockMvc.perform(post("/mypage/tickets/101/cancel"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.message").value("취소 요청이 완료되었습니다."))
+				.andExpect(jsonPath("$.data.ticketId").value(101))
+				.andExpect(jsonPath("$.data.status").value("CANCEL_REQUESTED"))
+				.andExpect(jsonPath("$.data.totalAmount").value(42000))
+				.andExpect(jsonPath("$.data.cancellationFee").value(6000))
+				.andExpect(jsonPath("$.data.refundedAmount").value(36000));
+		}
+
+		@Test
+		@DisplayName("본인 소유가 아니면 403을 반환한다")
+		void requestTicketCancel_권한없음_403() throws Exception {
+			given(myPageService.requestTicketCancel(1L, 101L))
+				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+
+			mockMvc.perform(post("/mypage/tickets/101/cancel"))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+		}
+
+		@Test
+		@DisplayName("취소 가능한 기간이 아니면 400을 반환한다")
+		void requestTicketCancel_취소불가기간_400() throws Exception {
+			given(myPageService.requestTicketCancel(1L, 101L))
+				.willThrow(new CustomException(ErrorCode.TICKET_CANCEL_NOT_ALLOWED));
+
+			mockMvc.perform(post("/mypage/tickets/101/cancel"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("취소 가능한 기간이 아닙니다."));
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -31,6 +31,7 @@ import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
@@ -535,6 +536,127 @@ class MyPageServiceTest {
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
 				.isInstanceOf(CustomException.class)
 				.hasMessage(ErrorCode.ENTRY_QR_MATCH_STARTED.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("requestTicketCancel — 티켓 취소 요청")
+	class RequestTicketCancel {
+
+		private Order createOrder(Long ticketId, Long userId, OrderStatus status, Instant matchAt) {
+			var stadium = OrderFixture.createStadium();
+			var homeClub = OrderFixture.createHomeClub(stadium);
+			var awayClub = OrderFixture.createAwayClub(stadium);
+			Match match = Match.builder()
+				.matchAt(matchAt)
+				.homeClub(homeClub)
+				.awayClub(awayClub)
+				.stadium(stadium)
+				.saleStatus(SaleStatus.ON_SALE)
+				.build();
+			ReflectionTestUtils.setField(match, "id", 55L);
+
+			User user = OrderFixture.createUserWithId(userId);
+			Order order = OrderFixture.createOrderWithId(ticketId, user, match, 42000);
+			order.updateStatus(status);
+			return order;
+		}
+
+		@Test
+		@DisplayName("D-1~D-6 정책이면 취소수수료는 bookingFee + 티켓금액 10% 이다")
+		void requestTicketCancel_d1to6_성공() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(2, ChronoUnit.DAYS));
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(1)
+				.daysBeforeMatchMax(6)
+				.cancellable(true)
+				.ticketFeeRate(new BigDecimal("0.100"))
+				.bookingFeeRefundable(false)
+				.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(response.ticketId()).isEqualTo(ticketId);
+			assertThat(response.status()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+			assertThat(response.totalAmount()).isEqualTo(42000);
+			assertThat(response.cancellationFee()).isEqualTo(6000);
+			assertThat(response.refundedAmount()).isEqualTo(36000);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+			assertThat(order.getCancellationFee()).isEqualTo(6000);
+			assertThat(order.getRefundedAmount()).isEqualTo(36000);
+		}
+
+		@Test
+		@DisplayName("D-7 이상 정책이면 전액 환불한다")
+		void requestTicketCancel_d7plus_전액환불() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(10, ChronoUnit.DAYS));
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(7)
+				.daysBeforeMatchMax(null)
+				.cancellable(true)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(true)
+				.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(response.cancellationFee()).isEqualTo(0);
+			assertThat(response.refundedAmount()).isEqualTo(42000);
+		}
+
+		@Test
+		@DisplayName("취소 불가 정책이면 TICKET_CANCEL_NOT_ALLOWED 예외가 발생한다")
+		void requestTicketCancel_notCancellable_예외() {
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now().plus(1, ChronoUnit.HOURS));
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(0)
+				.daysBeforeMatchMax(0)
+				.cancellable(false)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(false)
+				.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.TICKET_CANCEL_NOT_ALLOWED.getMessage());
+		}
+
+		@Test
+		@DisplayName("PAID 상태가 아니면 INVALID_ORDER_STATUS 예외가 발생한다")
+		void requestTicketCancel_notPaid_예외() {
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, 1L, OrderStatus.CANCELLED, Instant.now().plus(2, ChronoUnit.DAYS));
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+		}
+
+		@Test
+		@DisplayName("본인 소유가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		void requestTicketCancel_권한없음_예외() {
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, 2L, OrderStatus.PAID, Instant.now().plus(2, ChronoUnit.DAYS));
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+
+			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -5,7 +5,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -67,16 +69,19 @@ class MyPageServiceTest {
 	private QrTokenRepository qrTokenRepository;
 
 	private MyPageService myPageService;
+	private Clock clock;
 
 	@BeforeEach
 	void setUp() {
+		clock = Clock.fixed(Instant.parse("2026-03-26T00:00:00Z"), ZoneOffset.UTC);
 		myPageService = new MyPageService(
 			userRepository,
 			userSnsRepository,
 			orderRepository,
 			qrTokenRepository,
 			myPageQueryService,
-			cancellationFeePolicyRepository
+			cancellationFeePolicyRepository,
+			clock
 		);
 	}
 
@@ -463,11 +468,11 @@ class MyPageServiceTest {
 		void getTicketEntryQr_existingToken_성공() {
 			Long userId = 1L;
 			Long ticketId = 101L;
-			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(10, ChronoUnit.MINUTES));
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 			QrToken existing = QrToken.builder()
 				.qrToken("existing-qr-token")
-				.expiresAt(Instant.now().plus(2, ChronoUnit.MINUTES))
+				.expiresAt(Instant.now(clock).plus(2, ChronoUnit.MINUTES))
 				.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
@@ -486,7 +491,7 @@ class MyPageServiceTest {
 		void getTicketEntryQr_issueNewToken_성공() {
 			Long userId = 1L;
 			Long ticketId = 101L;
-			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(10, ChronoUnit.MINUTES));
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
@@ -498,7 +503,7 @@ class MyPageServiceTest {
 
 			assertThat(response.ticketId()).isEqualTo(ticketId);
 			assertThat(response.qrToken()).isNotBlank();
-			assertThat(response.expiresAt()).isAfter(Instant.now());
+			assertThat(response.expiresAt()).isAfter(Instant.now(clock));
 			then(qrTokenRepository).should().save(any(QrToken.class));
 		}
 
@@ -506,7 +511,7 @@ class MyPageServiceTest {
 		@DisplayName("PAID 상태가 아니면 INVALID_ORDER_STATUS 예외가 발생한다")
 		void getTicketEntryQr_notPaid_예외() {
 			Long ticketId = 101L;
-			Order order = createOrder(ticketId, 1L, OrderStatus.PAYMENT_PENDING, Instant.now().plus(10, ChronoUnit.MINUTES));
+			Order order = createOrder(ticketId, 1L, OrderStatus.PAYMENT_PENDING, Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
@@ -518,7 +523,7 @@ class MyPageServiceTest {
 		@DisplayName("입장 가능 시간 이전이면 ENTRY_QR_NOT_AVAILABLE_YET 예외가 발생한다")
 		void getTicketEntryQr_beforeEntryWindow_예외() {
 			Long ticketId = 101L;
-			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now().plus(5, ChronoUnit.HOURS));
+			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now(clock).plus(5, ChronoUnit.HOURS));
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
@@ -530,7 +535,7 @@ class MyPageServiceTest {
 		@DisplayName("경기 시작 이후면 ENTRY_QR_MATCH_STARTED 예외가 발생한다")
 		void getTicketEntryQr_matchStarted_예외() {
 			Long ticketId = 101L;
-			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now().minus(1, ChronoUnit.HOURS));
+			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now(clock).minus(1, ChronoUnit.HOURS));
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
@@ -612,6 +617,31 @@ class MyPageServiceTest {
 
 			assertThat(response.cancellationFee()).isEqualTo(0);
 			assertThat(response.refundedAmount()).isEqualTo(42000);
+		}
+
+		@Test
+		@DisplayName("D-7 이상이어도 예매 당일이 아니면 bookingFee는 환불하지 않는다")
+		void requestTicketCancel_d7plus_notBookingDay_bookingFee미환불() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(10, ChronoUnit.DAYS));
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now().minus(1, ChronoUnit.DAYS));
+
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+				.daysBeforeMatchMin(7)
+				.daysBeforeMatchMax(null)
+				.cancellable(true)
+				.ticketFeeRate(BigDecimal.ZERO)
+				.bookingFeeRefundable(true)
+				.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+
+			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(response.cancellationFee()).isEqualTo(2000);
+			assertThat(response.refundedAmount()).isEqualTo(40000);
 		}
 
 		@Test

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -110,6 +110,7 @@ public enum ErrorCode {
 	// Mypage
 	INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "size는 최대 10까지 허용됩니다."),
 	INVALID_TICKET_TAB(HttpStatus.BAD_REQUEST, "유효하지 않은 탭 값입니다."),
+	TICKET_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "취소 가능한 기간이 아닙니다."),
 	ENTRY_QR_NOT_AVAILABLE_YET(HttpStatus.BAD_REQUEST, "아직 입장 가능 시간이 아닙니다."),
 	ENTRY_QR_MATCH_STARTED(HttpStatus.BAD_REQUEST, "경기 시작 이후에는 QR을 발급할 수 없습니다."),
 


### PR DESCRIPTION
## 🔧 작업 내용

- POST /mypage/tickets/{ticketId}/cancel API를 추가했습니다.
- 취소 가능 기간/상태 검증 후 취소 수수료와 환불 금액을 계산하도록 구현했습니다.
- 주문 상태를 취소 요청 상태로 변경하고 정산 필드를 함께 갱신했습니다.

## 🧩 구현 상세 (선택)

- 서비스 계층에서 취소 가능성 판단(소유권, 상태, 기간)을 일괄 처리했습니다.
- 정책 구간별 수수료 계산 로직을 분리해 테스트 가능하도록 구성했습니다.

### 📌 관련 Jira Issue

- GRGB-302

## 🧪 테스트 방법(선택)

<img width="1031" height="509" alt="image" src="https://github.com/user-attachments/assets/db516b6d-853d-4e6a-b156-8f87e1892ca2" />

## ❗ 참고 사항

<img width="517" height="241" alt="image" src="https://github.com/user-attachments/assets/73c5dec4-6be5-4c8f-a366-e462fdf31d37" />

