### PR TITLE
fix(metric): 매트릭 버킷으로 내보내는 설정 추가 [GRGB-304]

### DIFF
--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -66,7 +66,7 @@ management:
         enabled: true
       group:
         readiness:
-          include: readinessState, db
+          include: readinessState
   metrics:
     distribution:
       percentiles-histogram:

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -66,7 +66,11 @@ management:
         enabled: true
       group:
         readiness:
-          include: readinessState
+          include: readinessState, db
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 logging:
   config: classpath:logback-spring.xml

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -64,6 +64,10 @@ management:
       group:
         readiness:
           include: readinessState, db
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 logging:
   config: classpath:logback-spring.xml

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -42,6 +42,10 @@ management:
       group:
         readiness:
           include: readinessState, db
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 logging:
   config: classpath:logback-spring.xml

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -68,6 +68,10 @@ management:
       group:
         readiness:
           include: readinessState, db
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 logging:
   config: classpath:logback-spring.xml

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -51,6 +51,10 @@ management:
       group:
         readiness:
           include: readinessState, db
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 logging:
   config: classpath:logback-spring.xml


### PR DESCRIPTION
## 🔧 작업 내용

- http.server.requests 히스토그램 활성화로 응답 시간 분포 수집 가능하도록 개선

## 🧩 구현 상세 (선택)

- 핵심 로직 설명
- 설계 / 구조 / 알고리즘 / 모델 선택 이유
- 트레이드오프 또는 고민했던 지점

### 📌 관련 Jira Issue

- GRGB-304

## 🧪 테스트 방법(선택)

- 테스트 대상
- Endpoint / 함수 / 스크립트
- 파라미터 및 체크 포인트

## ❗ 참고 사항

- 리뷰 시 유의할 점
- 후속 작업 예정
- 배포 시 주의 사항
