### PR TITLE
 feat(common-core): DB 개인정보 AES-256-GCM 양방향 암호화 [GRGB-305]

### DIFF
--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -43,6 +43,9 @@ jwt:
   cookie:
     secure: false
 
+encryption:
+  db-key: ${DB_ENCRYPTION_KEY}
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
@@ -1,11 +1,13 @@
 package com.goormgb.be.ordercore.inquiry.entity;
 
+import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryCategory;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryStatus;
 import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -52,7 +54,8 @@ public class Inquiry extends BaseEntity {
 	@Column(name = "status", nullable = false, length = 20)
 	private InquiryStatus status;
 
-	@Column(name = "phone_number", length = 20)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "phone_number", length = 512)
 	private String phoneNumber;
 
 	@Builder

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.global.encryption.EncryptionProvider;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MyPageQueryService {
 
 	private final NamedParameterJdbcTemplate namedJdbc;
+	private final EncryptionProvider encryptionProvider;
 
 	/**
 	 * 탭 조건에 해당하는 티켓 수를 반환한다.
@@ -193,12 +195,12 @@ public class MyPageQueryService {
 				rs.getObject("paid_at", Timestamp.class) == null ? null
 					: rs.getObject("paid_at", Timestamp.class).toInstant(),
 				rs.getString("account_bank"),
-				rs.getString("account_number"),
-				rs.getString("account_holder"),
+				decrypt(rs.getString("account_number")),
+				decrypt(rs.getString("account_holder")),
 				rs.getObject("deposit_deadline", Timestamp.class) == null ? null
 					: rs.getObject("deposit_deadline", Timestamp.class).toInstant(),
 				cashReceiptPurpose == null ? null : CashReceiptPurpose.valueOf(cashReceiptPurpose),
-				rs.getString("cash_receipt_number")
+				decrypt(rs.getString("cash_receipt_number"))
 			);
 		});
 
@@ -248,6 +250,13 @@ public class MyPageQueryService {
 		String stadiumName,
 		int seatCount
 	) {
+	}
+
+	private String decrypt(String value) {
+		if (value == null) {
+			return null;
+		}
+		return encryptionProvider.decrypt(value);
 	}
 
 	public record OrderSeatRow(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -3,11 +3,13 @@ package com.goormgb.be.ordercore.order.entity;
 import java.time.Instant;
 
 import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -65,16 +67,20 @@ public class Order extends BaseEntity {
 	@Column(name = "cancelled_at")
 	private Instant cancelledAt;
 
-	@Column(name = "orderer_name", nullable = false, length = 50)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "orderer_name", nullable = false, length = 512)
 	private String ordererName;
 
-	@Column(name = "orderer_email", nullable = false, length = 255)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "orderer_email", nullable = false, length = 512)
 	private String ordererEmail;
 
-	@Column(name = "orderer_phone", nullable = false, length = 20)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "orderer_phone", nullable = false, length = 512)
 	private String ordererPhone;
 
-	@Column(name = "orderer_birth_date", nullable = false, length = 6)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "orderer_birth_date", nullable = false, length = 512)
 	private String ordererBirthDate;
 
 	@Builder

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
@@ -1,9 +1,11 @@
 package com.goormgb.be.ordercore.payment.entity;
 
+import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,7 +42,8 @@ public class CashReceipt extends BaseEntity {
 	 * PERSONAL_DEDUCTION: 현금영수증용 전화번호
 	 * BUSINESS_EXPENSE: 사업자번호
 	 */
-	@Column(name = "number", nullable = false, length = 50)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "number", nullable = false, length = 512)
 	private String number;
 
 	@Builder

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/Payment.java
@@ -2,12 +2,14 @@ package com.goormgb.be.ordercore.payment.entity;
 
 import java.time.Instant;
 
+import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -55,10 +57,12 @@ public class Payment extends BaseEntity {
 	@Column(name = "account_bank", length = 50)
 	private String accountBank;
 
-	@Column(name = "account_number", length = 50)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "account_number", length = 512)
 	private String accountNumber;
 
-	@Column(name = "account_holder", length = 50)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "account_holder", length = 512)
 	private String accountHolder;
 
 	@Column(name = "deposit_deadline")

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -30,6 +30,9 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 
+encryption:
+  db-key: ${DB_ENCRYPTION_KEY}
+
 management:
   endpoints:
     web:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -56,6 +56,9 @@ queue:
       public-key: ${ADMISSION_PUBLIC_KEY}
       issuer: queue-service
 
+encryption:
+  db-key: ${DB_ENCRYPTION_KEY}
+
 management:
   endpoints:
     web:

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -39,6 +39,9 @@ admission:
     public-key: ${ADMISSION_PUBLIC_KEY}
     issuer: ${ADMISSION_JWT_ISSUER:queue-service}
 
+encryption:
+  db-key: ${DB_ENCRYPTION_KEY}
+
 management:
   endpoints:
     web:

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/AesEncryptionProvider.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/AesEncryptionProvider.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.global.encryption;
 
 import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -58,7 +59,7 @@ public class AesEncryptionProvider implements EncryptionProvider {
 			byteBuffer.put(cipherText);
 
 			return Base64.getEncoder().encodeToString(byteBuffer.array());
-		} catch (Exception e) {
+		} catch (GeneralSecurityException e) {
 			throw new IllegalStateException("DB 암호화 실패", e);
 		}
 	}
@@ -80,7 +81,7 @@ public class AesEncryptionProvider implements EncryptionProvider {
 
 			byte[] plainText = cipher.doFinal(encrypted);
 			return new String(plainText, java.nio.charset.StandardCharsets.UTF_8);
-		} catch (Exception e) {
+		} catch (GeneralSecurityException | RuntimeException e) {
 			throw new IllegalStateException("DB 복호화 실패", e);
 		}
 	}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/AesEncryptionProvider.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/AesEncryptionProvider.java
@@ -1,0 +1,87 @@
+package com.goormgb.be.global.encryption;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Profile({"staging", "prod"})
+public class AesEncryptionProvider implements EncryptionProvider {
+
+	private static final String ALGORITHM = "AES/GCM/NoPadding";
+	private static final int GCM_IV_LENGTH = 12;
+	private static final int GCM_TAG_LENGTH = 128;
+
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	@Value("${encryption.db-key}")
+	private String base64Key;
+
+	private SecretKey secretKey;
+
+	@PostConstruct
+	public void init() {
+		byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+		if (keyBytes.length != 32) {
+			throw new IllegalArgumentException("DB_ENCRYPTION_KEY must be 256 bits (32 bytes)");
+		}
+		this.secretKey = new SecretKeySpec(keyBytes, "AES");
+		log.info("[AesEncryptionProvider] DB 암호화 활성화됨 (AES-256-GCM)");
+	}
+
+	@Override
+	public String encrypt(String plainText) {
+		try {
+			byte[] iv = new byte[GCM_IV_LENGTH];
+			secureRandom.nextBytes(iv);
+
+			Cipher cipher = Cipher.getInstance(ALGORITHM);
+			cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+			byte[] cipherText = cipher.doFinal(plainText.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+			ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + cipherText.length);
+			byteBuffer.put(iv);
+			byteBuffer.put(cipherText);
+
+			return Base64.getEncoder().encodeToString(byteBuffer.array());
+		} catch (Exception e) {
+			throw new IllegalStateException("DB 암호화 실패", e);
+		}
+	}
+
+	@Override
+	public String decrypt(String cipherText) {
+		try {
+			byte[] decoded = Base64.getDecoder().decode(cipherText);
+
+			ByteBuffer byteBuffer = ByteBuffer.wrap(decoded);
+			byte[] iv = new byte[GCM_IV_LENGTH];
+			byteBuffer.get(iv);
+
+			byte[] encrypted = new byte[byteBuffer.remaining()];
+			byteBuffer.get(encrypted);
+
+			Cipher cipher = Cipher.getInstance(ALGORITHM);
+			cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+			byte[] plainText = cipher.doFinal(encrypted);
+			return new String(plainText, java.nio.charset.StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			throw new IllegalStateException("DB 복호화 실패", e);
+		}
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
@@ -1,22 +1,30 @@
 package com.goormgb.be.global.encryption;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import lombok.extern.slf4j.Slf4j;
 
 @Converter
 public class EncryptionConverter implements AttributeConverter<String, String> {
 
 	private static EncryptionProvider encryptionProvider;
 
+	@Slf4j
 	@Component
 	static class EncryptionProviderInjector implements ApplicationContextAware {
 		@Override
 		public void setApplicationContext(ApplicationContext applicationContext) {
-			EncryptionConverter.encryptionProvider = applicationContext.getBean(EncryptionProvider.class);
+			try {
+				EncryptionConverter.encryptionProvider = applicationContext.getBean(EncryptionProvider.class);
+			} catch (NoSuchBeanDefinitionException e) {
+				log.warn("[EncryptionConverter] EncryptionProvider 빈 없음 - NoOp 모드로 동작");
+				EncryptionConverter.encryptionProvider = new NoOpEncryptionProvider();
+			}
 		}
 	}
 
@@ -25,6 +33,9 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
 		if (attribute == null) {
 			return null;
 		}
+		if (encryptionProvider == null) {
+			throw new IllegalStateException("EncryptionProvider가 초기화되지 않았습니다.");
+		}
 		return encryptionProvider.encrypt(attribute);
 	}
 
@@ -32,6 +43,9 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
 	public String convertToEntityAttribute(String dbData) {
 		if (dbData == null) {
 			return null;
+		}
+		if (encryptionProvider == null) {
+			throw new IllegalStateException("EncryptionProvider가 초기화되지 않았습니다.");
 		}
 		return encryptionProvider.decrypt(dbData);
 	}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
@@ -1,0 +1,38 @@
+package com.goormgb.be.global.encryption;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class EncryptionConverter implements AttributeConverter<String, String> {
+
+	private static EncryptionProvider encryptionProvider;
+
+	@Component
+	static class EncryptionProviderInjector implements ApplicationContextAware {
+		@Override
+		public void setApplicationContext(ApplicationContext applicationContext) {
+			EncryptionConverter.encryptionProvider = applicationContext.getBean(EncryptionProvider.class);
+		}
+	}
+
+	@Override
+	public String convertToDatabaseColumn(String attribute) {
+		if (attribute == null) {
+			return null;
+		}
+		return encryptionProvider.encrypt(attribute);
+	}
+
+	@Override
+	public String convertToEntityAttribute(String dbData) {
+		if (dbData == null) {
+			return null;
+		}
+		return encryptionProvider.decrypt(dbData);
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionProvider.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionProvider.java
@@ -1,0 +1,7 @@
+package com.goormgb.be.global.encryption;
+
+public interface EncryptionProvider {
+	String encrypt(String plainText);
+
+	String decrypt(String cipherText);
+}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/NoOpEncryptionProvider.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/NoOpEncryptionProvider.java
@@ -1,0 +1,19 @@
+package com.goormgb.be.global.encryption;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"local", "dev", "test"})
+public class NoOpEncryptionProvider implements EncryptionProvider {
+
+	@Override
+	public String encrypt(String plainText) {
+		return plainText;
+	}
+
+	@Override
+	public String decrypt(String cipherText) {
+		return cipherText;
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
 	PREFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "온보딩 선호도 정보를 찾을 수 없습니다."),
 
 	// Auth
+
+	// TODO: 묶을 수 있는 공통 에러사항에 대해서는 한가지 키워드로 묶기. 백엔드 보안처리.
+
+	// HTTP UNAUTHORIZED 401
+	// AUTHORIZED_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
 	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다."),

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleCustomException(CustomException e) {
-		return ErrorResponse.error(e.getErrorCode().getStatus(), e.getErrorCode().getMessage());
+		return ErrorResponse.error(e.getErrorCode());
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
+++ b/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
@@ -19,7 +19,8 @@ public class ErrorResponse {
 	}
 
 	public static ResponseEntity<ErrorData> error(ErrorCode errorCode) {
-		return error(errorCode.getStatus(), errorCode.getMessage());
+		return ResponseEntity.status(errorCode.getStatus())
+				.body(ErrorData.of(errorCode.name(), errorCode.getMessage()));
 	}
 
 	@Getter

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -5,7 +5,10 @@ import java.time.Instant;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.user.enums.UserStatus;
 
+import com.goormgb.be.global.encryption.EncryptionConverter;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -25,10 +28,12 @@ public class User extends BaseEntity {
 	@Column(name = "status", nullable = false, length = 20)
 	private UserStatus status = UserStatus.ACTIVATE;
 
-	@Column(name = "email", length = 255)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "email", length = 512)
 	private String email;
 
-	@Column(name = "nickname", length = 100)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "nickname", length = 512)
 	private String nickname;
 
 	@Column(name = "profile_image_url")

--- a/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -3,10 +3,7 @@ package com.goormgb.be.user.entity;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.user.enums.SocialProvider;
 
-import com.goormgb.be.global.encryption.EncryptionConverter;
-
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -39,8 +36,7 @@ public class UserSns extends BaseEntity {
 	@Column(name = "provider", nullable = false, length = 20)
 	private SocialProvider provider;
 
-	@Convert(converter = EncryptionConverter.class)
-	@Column(name = "provider_user_id", nullable = false, length = 512)
+	@Column(name = "provider_user_id", nullable = false, length = 128)
 	private String providerUserId;
 
 	@Builder

--- a/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -3,7 +3,10 @@ package com.goormgb.be.user.entity;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.user.enums.SocialProvider;
 
+import com.goormgb.be.global.encryption.EncryptionConverter;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -36,7 +39,8 @@ public class UserSns extends BaseEntity {
 	@Column(name = "provider", nullable = false, length = 20)
 	private SocialProvider provider;
 
-	@Column(name = "provider_user_id", nullable = false, length = 128)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "provider_user_id", nullable = false, length = 512)
 	private String providerUserId;
 
 	@Builder


### PR DESCRIPTION
## 🔧 작업 내용
- staging/prod 환경에서 DB에 저장되는 개인정보를 AES-256-GCM으로 양방향 암호화
- local/dev/test 환경에서는 암호화 비활성화 (평문 저장)
- JPA AttributeConverter를 활용하여 기존 비즈니스 로직 변경 없이 투명하게 적용
- 보안팀 DB 개인정보 암호화 정책 가이드 반영

## 🧩 구현 상세
- **EncryptionProvider 인터페이스**: 암호화/복호화 추상화
- **AesEncryptionProvider** (`@Profile staging, prod`): AES-256-GCM 암호화/복호화, IV 12바이트 랜덤 생성, Base64 인코딩 저장
- **NoOpEncryptionProvider** (`@Profile local, dev, test`): 평문 그대로 통과
- **EncryptionConverter**: JPA AttributeConverter, `ApplicationContextAware`로 static 빈 주입 (JPA가 기본 생성자로 Converter를 생성하는 문제 해결)
- **@Convert 적용 엔티티**: User(email, nickname), Order(ordererName, ordererEmail, ordererPhone, ordererBirthDate), Payment(accountNumber, accountHolder), CashReceipt(number), Inquiry(phoneNumber)

- 암호화 대상 컬럼 길이 VARCHAR(512)로 확장
- 환경변수 `DB_ENCRYPTION_KEY` 하나로 staging/prod 통용

### 📌 관련 Jira Issue
- GRGB-305

## 🧪 테스트 방법
- staging 프로필로 Auth-Guard 실행 → `[AesEncryptionProvider] DB 암호화 활성화됨 (AES-256-GCM)` 로그 확인
- 회원가입 후 DB에서 `SELECT email, nickname FROM users` → Base64 암호문 확인
- 로그인/조회 시 복호화된 평문이 정상 반환되는지 확인
- local 프로필로 실행 → DB에 평문 저장 확인

## ❗ 참고 사항
- **기존 데이터**: 기존 평문 데이터가 있는 DB에서 staging/prod로 실행하면 복호화 시 에러 발생. 기존 데이터 마이그레이션 배치 필요 (후속 작업)
- **로컬 암호화 테스트**: `NoOpEncryptionProvider`의 `@Profile`에서 `local`을 제거하면 로컬에서도 암호화가 동작합니다. 테스트 후 다시 `local`을 넣어 원복하세요. `application-local.yaml`에 `encryption.db-key` 설정도 필요합니다!!
- **API-Gateway**: DB를 사용하지 않으므로 encryption 설정 불필요

cc. @hapumpum @vanillacustardcream