### PR TITLE
hotfix(auth-guard): 부하테스트 회원가입 동시 요청 시 중복 500 → 409 응답 처리 [GRGB-306]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,20 +44,24 @@ public class LoadTestAuthService {
 			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
 		}
 
-		User user = User.builder()
-				.email(loginId + "@loadtest.com")
-				.nickname(loginId)
-				.build();
-		userRepository.save(user);
+		try {
+			User user = User.builder()
+					.email(loginId + "@loadtest.com")
+					.nickname(loginId)
+					.build();
+			userRepository.save(user);
 
-		LoadTestUser loadTestUser = LoadTestUser.builder()
-				.loginId(loginId)
-				.passwordHash(passwordEncoder.encode(password))
-				.user(user)
-				.build();
-		loadTestUserRepository.save(loadTestUser);
+			LoadTestUser loadTestUser = LoadTestUser.builder()
+					.loginId(loginId)
+					.passwordHash(passwordEncoder.encode(password))
+					.user(user)
+					.build();
+			loadTestUserRepository.save(loadTestUser);
 
-		log.info("[LoadTest] 부하테스트 유저 생성 - loginId: {}, userId: {}", loginId, user.getId());
+			log.info("[LoadTest] 부하테스트 유저 생성 - loginId: {}, userId: {}", loginId, user.getId());
+		} catch (DataIntegrityViolationException e) {
+			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
+		}
 	}
 
 	@Transactional


### PR DESCRIPTION
 ## 🔧 작업 내용
- 부하테스트(k6) 동시 회원가입 요청 시 동일 loginId에 대한 500 에러 → 409 응답으로 수정
- 동시성 환경에서 발생하는 TOCTOU(Time-of-Check to Time-of-Use) Race Condition 대응

## 🧩 구현 상세
- `existsByLoginId` 체크와 `save` 사이 시간 갭에서 동시 요청이 들어오면 DB Unique Constraint Violation 발생
- `DataIntegrityViolationException` catch하여 `USER_ALREADY_EXISTS` (409) 반환
- 기존 `existsByLoginId` 체크도 유지하여 단일 요청 시 불필요한 DB INSERT 방지

### 📌 관련 Jira Issue
- GRGB-306

## ❗ 참고 사항
- dev 환경에서 부하테스트 중 발견된 이슈
- 부하테스트 전용 API(`/loadtest/signup`)에만 해당
- 지속적인 500에러 알람 해결로 리뷰없이 self merge 하겠습니다!