### PR TITLE
feat(common-core): 프로필별 에러 응답 코드 추상화 전략 추가

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
@@ -1,0 +1,36 @@
+package com.goormgb.be.global.environment;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.global.exception.ErrorCode;
+
+/**
+ * 운영 환경용 에러 응답 전략 (staging, prod).
+ *
+ * <p>ErrorCode를 HTTP 상태 시리즈(CLIENT_ERROR, SERVER_ERROR)로 추상화하여
+ * 내부 에러 코드가 외부에 노출되지 않도록 한다.</p>
+ *
+ * <p>응답 예시:</p>
+ * <pre>
+ * {
+ *   "code": "CLIENT_ERROR",
+ *   "message": "온보딩 선호도 정보를 찾을 수 없습니다."
+ * }
+ * </pre>
+ *
+ * <p>추후 에러 코드 추상화 작업 시 이 클래스를 확장하여
+ * 특정 ErrorCode에 대해 커스텀 코드를 반환하도록 구현할 수 있다.</p>
+ *
+ * @see ErrorResponseStrategy
+ * @see DetailedErrorResponseStrategy
+ */
+@Component
+@Profile({"staging", "prod"})
+public class AbstractErrorResponseStrategy implements ErrorResponseStrategy {
+
+	@Override
+	public String resolveCode(ErrorCode errorCode) {
+		return errorCode.getStatus().series().name();
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/environment/DetailedErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/DetailedErrorResponseStrategy.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.global.environment;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.global.exception.ErrorCode;
+
+/**
+ * 개발 환경용 에러 응답 전략 (local, dev, test).
+ *
+ * <p>ErrorCode enum 이름을 그대로 에러 코드로 반환하여 디버깅을 용이하게 한다.</p>
+ *
+ * <p>응답 예시:</p>
+ * <pre>
+ * {
+ *   "code": "PREFERENCE_NOT_FOUND",
+ *   "message": "온보딩 선호도 정보를 찾을 수 없습니다."
+ * }
+ * </pre>
+ *
+ * @see ErrorResponseStrategy
+ * @see AbstractErrorResponseStrategy
+ */
+@Component
+@Profile({"local", "dev", "test"})
+public class DetailedErrorResponseStrategy implements ErrorResponseStrategy {
+
+	@Override
+	public String resolveCode(ErrorCode errorCode) {
+		return errorCode.name();
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/environment/ErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/ErrorResponseStrategy.java
@@ -1,0 +1,22 @@
+package com.goormgb.be.global.environment;
+
+import com.goormgb.be.global.exception.ErrorCode;
+
+/**
+ * 프로필별 에러 응답 코드 전략 인터페이스.
+ *
+ * <p>환경에 따라 클라이언트에 노출되는 에러 코드의 상세 수준을 결정한다.</p>
+ *
+ * <ul>
+ *   <li>{@link DetailedErrorResponseStrategy} (local/dev/test) - ErrorCode enum 이름 그대로 노출 (예: PREFERENCE_NOT_FOUND)</li>
+ *   <li>{@link AbstractErrorResponseStrategy} (staging/prod) - HTTP 상태 시리즈로 추상화 (예: CLIENT_ERROR, SERVER_ERROR)</li>
+ * </ul>
+ *
+ * <p>GlobalExceptionHandler에서 CustomException 처리 시 사용된다.</p>
+ *
+ * @see com.goormgb.be.global.exception.GlobalExceptionHandler
+ * @see com.goormgb.be.global.response.ErrorResponse#error(ErrorCode, ErrorResponseStrategy)
+ */
+public interface ErrorResponseStrategy {
+	String resolveCode(ErrorCode errorCode);
+}

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -13,13 +13,18 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import com.goormgb.be.global.environment.ErrorResponseStrategy;
 import com.goormgb.be.global.response.ErrorResponse;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+	private final ErrorResponseStrategy errorResponseStrategy;
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleException(Exception e) {
@@ -29,7 +34,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleCustomException(CustomException e) {
-		return ErrorResponse.error(e.getErrorCode());
+		return ErrorResponse.error(e.getErrorCode(), errorResponseStrategy);
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
@@ -52,7 +57,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MissingRequestCookieException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleMissingCookie(MissingRequestCookieException e) {
-		return ErrorResponse.error(HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_TOKEN.getMessage());
+		return ErrorResponse.error(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)

--- a/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
+++ b/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.goormgb.be.global.response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.goormgb.be.global.environment.ErrorResponseStrategy;
 import com.goormgb.be.global.exception.ErrorCode;
 
 import lombok.AllArgsConstructor;
@@ -18,9 +19,9 @@ public class ErrorResponse {
 		return ResponseEntity.status(status).body(ErrorData.of(status.series().name(), message));
 	}
 
-	public static ResponseEntity<ErrorData> error(ErrorCode errorCode) {
+	public static ResponseEntity<ErrorData> error(ErrorCode errorCode, ErrorResponseStrategy strategy) {
 		return ResponseEntity.status(errorCode.getStatus())
-				.body(ErrorData.of(errorCode.name(), errorCode.getMessage()));
+				.body(ErrorData.of(strategy.resolveCode(errorCode), errorCode.getMessage()));
 	}
 
 	@Getter


### PR DESCRIPTION
 ## 🔧 작업 내용
- local/dev/test: ErrorCode enum 이름 노출 (예: PREFERENCE_NOT_FOUND)
- staging/prod: HTTP 시리즈명으로 추상화 (예: CLIENT_ERROR)
- @Profile 기반 ErrorResponseStrategy 분기

 ## ❗ 참고 사항
- 추후 에러 코드 추상화 작업은 AbstractErrorResponseStrategy 확장하여 구현