### PR TITLE
feat(auth-guard): AI 서버 전용 Internal API Key 인증 필터 구현

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goormgb.be.authguard.filter.InternalApiKeyFilter;
 import com.goormgb.be.authguard.jwt.filter.JwtAuthenticationFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 public class AuthGuardSecurityConfig {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final InternalApiKeyProperties internalApiKeyProperties;
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -30,11 +34,22 @@ public class AuthGuardSecurityConfig {
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(
-								"/kakao/**",
+								// Internal API (API Key 필터로 보호)
+								"/internal/users/{userId}/block",
+								"/internal/users/{userId}/unblock",
+								// Kakao OAuth
+								"/kakao/login-url",
+								"/kakao/login",
+								// Token
 								"/token/refresh",
-								"/dev/auth/**",
+								// Dev Auth (local/dev/test 프로필 전용)
+								"/dev/auth/signup",
+								"/dev/auth/login",
+								"/dev/auth/test/500",
+								// Load Test Auth
 								"/loadtest/signup",
 								"/loadtest/login",
+								// Swagger & Actuator
 								"/swagger-ui/**",
 								"/swagger-ui.html",
 								"/swagger-resources/**",
@@ -44,9 +59,15 @@ public class AuthGuardSecurityConfig {
 						).permitAll()
 						.anyRequest().authenticated()
 				)
-				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+				.addFilterBefore(internalApiKeyFilter(), jwtAuthenticationFilter.getClass());
 
 		return http.build();
+	}
+
+	@Bean
+	public InternalApiKeyFilter internalApiKeyFilter() {
+		return new InternalApiKeyFilter(internalApiKeyProperties, objectMapper);
 	}
 
 	@Bean

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/InternalApiKeyProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/InternalApiKeyProperties.java
@@ -1,0 +1,13 @@
+package com.goormgb.be.authguard.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "internal")
+public class InternalApiKeyProperties {
+	private final String apiKey;
+}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/filter/InternalApiKeyFilter.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/filter/InternalApiKeyFilter.java
@@ -1,6 +1,8 @@
 package com.goormgb.be.authguard.filter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,17 +36,17 @@ public class InternalApiKeyFilter extends OncePerRequestFilter {
 			HttpServletResponse response,
 			FilterChain filterChain
 	) throws ServletException, IOException {
-		String requestPath = request.getRequestURI();
+		String servletPath = request.getServletPath();
 
-		if (!requestPath.contains(INTERNAL_PATH_PREFIX)) {
+		if (!servletPath.startsWith(INTERNAL_PATH_PREFIX)) {
 			filterChain.doFilter(request, response);
 			return;
 		}
 
 		String apiKey = request.getHeader(HEADER_NAME);
 
-		if (apiKey == null || !apiKey.equals(properties.getApiKey())) {
-			log.warn("Internal API 인증 실패 - path: {}, remoteAddr: {}", requestPath, request.getRemoteAddr());
+		if (apiKey == null || !isEqual(apiKey, properties.getApiKey())) {
+			log.warn("Internal API 인증 실패 - path: {}, remoteAddr: {}", servletPath, request.getRemoteAddr());
 			sendErrorResponse(response);
 			return;
 		}
@@ -65,5 +67,12 @@ public class InternalApiKeyFilter extends OncePerRequestFilter {
 		);
 
 		objectMapper.writeValue(response.getWriter(), errorData);
+	}
+
+	private boolean isEqual(String a, String b) {
+		return MessageDigest.isEqual(
+				a.getBytes(StandardCharsets.UTF_8),
+				b.getBytes(StandardCharsets.UTF_8)
+		);
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/filter/InternalApiKeyFilter.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/filter/InternalApiKeyFilter.java
@@ -1,0 +1,69 @@
+package com.goormgb.be.authguard.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goormgb.be.authguard.config.InternalApiKeyProperties;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.response.ErrorResponse;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class InternalApiKeyFilter extends OncePerRequestFilter {
+
+	private static final String HEADER_NAME = "X-Internal-Api-Key";
+	private static final String INTERNAL_PATH_PREFIX = "/internal/";
+
+	private final InternalApiKeyProperties properties;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
+		String requestPath = request.getRequestURI();
+
+		if (!requestPath.contains(INTERNAL_PATH_PREFIX)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String apiKey = request.getHeader(HEADER_NAME);
+
+		if (apiKey == null || !apiKey.equals(properties.getApiKey())) {
+			log.warn("Internal API 인증 실패 - path: {}, remoteAddr: {}", requestPath, request.getRemoteAddr());
+			sendErrorResponse(response);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void sendErrorResponse(HttpServletResponse response) throws IOException {
+		ErrorCode errorCode = ErrorCode.INVALID_INTERNAL_API_KEY;
+
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ErrorResponse.ErrorData errorData = ErrorResponse.ErrorData.of(
+				errorCode.name(),
+				errorCode.getMessage()
+		);
+
+		objectMapper.writeValue(response.getWriter(), errorData);
+	}
+}

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -45,6 +45,9 @@ jwt:
     # SameSite=Lax, secure=false로 되돌릴 것.
     secure: true
 
+internal:
+  api-key: ${INTERNAL_API_KEY}
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -43,6 +43,9 @@ jwt:
   cookie:
     secure: false
 
+internal:
+  api-key: ${INTERNAL_API_KEY}
+
 encryption:
   db-key: ${DB_ENCRYPTION_KEY}
 

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/filter/InternalApiKeyFilterTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/filter/InternalApiKeyFilterTest.java
@@ -28,11 +28,17 @@ class InternalApiKeyFilterTest {
 		filter = new InternalApiKeyFilter(properties, objectMapper);
 	}
 
+	private MockHttpServletRequest createRequest(String method, String path) {
+		MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+		request.setServletPath(path);
+		return request;
+	}
+
 	@Test
 	@DisplayName("유효한 API Key로 /internal/** 요청 시 정상 통과")
 	void 유효한_API_Key_정상_통과() throws Exception {
 		// given
-		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/block");
+		MockHttpServletRequest request = createRequest("POST", "/internal/users/1/block");
 		request.addHeader(HEADER_NAME, VALID_API_KEY);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockFilterChain filterChain = new MockFilterChain();
@@ -49,7 +55,7 @@ class InternalApiKeyFilterTest {
 	@DisplayName("API Key 헤더 누락 시 401 응답")
 	void API_Key_헤더_누락_401() throws Exception {
 		// given
-		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/block");
+		MockHttpServletRequest request = createRequest("POST", "/internal/users/1/block");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockFilterChain filterChain = new MockFilterChain();
 
@@ -66,7 +72,7 @@ class InternalApiKeyFilterTest {
 	@DisplayName("잘못된 API Key로 요청 시 401 응답")
 	void 잘못된_API_Key_401() throws Exception {
 		// given
-		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/unblock");
+		MockHttpServletRequest request = createRequest("POST", "/internal/users/1/unblock");
 		request.addHeader(HEADER_NAME, "wrong-api-key");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockFilterChain filterChain = new MockFilterChain();
@@ -84,7 +90,7 @@ class InternalApiKeyFilterTest {
 	@DisplayName("/internal/** 이 아닌 경로는 필터를 통과")
 	void 일반_경로_필터_통과() throws Exception {
 		// given
-		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/token/refresh");
+		MockHttpServletRequest request = createRequest("POST", "/token/refresh");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockFilterChain filterChain = new MockFilterChain();
 

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/filter/InternalApiKeyFilterTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/filter/InternalApiKeyFilterTest.java
@@ -1,0 +1,98 @@
+package com.goormgb.be.authguard.filter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goormgb.be.authguard.config.InternalApiKeyProperties;
+
+class InternalApiKeyFilterTest {
+
+	private static final String VALID_API_KEY = "test-internal-api-key";
+	private static final String HEADER_NAME = "X-Internal-Api-Key";
+
+	private InternalApiKeyFilter filter;
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+		InternalApiKeyProperties properties = new InternalApiKeyProperties(VALID_API_KEY);
+		filter = new InternalApiKeyFilter(properties, objectMapper);
+	}
+
+	@Test
+	@DisplayName("유효한 API Key로 /internal/** 요청 시 정상 통과")
+	void 유효한_API_Key_정상_통과() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/block");
+		request.addHeader(HEADER_NAME, VALID_API_KEY);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = new MockFilterChain();
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(filterChain.getRequest()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("API Key 헤더 누락 시 401 응답")
+	void API_Key_헤더_누락_401() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/block");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = new MockFilterChain();
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+		assertThat(response.getContentAsString()).contains("INVALID_INTERNAL_API_KEY");
+		assertThat(filterChain.getRequest()).isNull();
+	}
+
+	@Test
+	@DisplayName("잘못된 API Key로 요청 시 401 응답")
+	void 잘못된_API_Key_401() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/internal/users/1/unblock");
+		request.addHeader(HEADER_NAME, "wrong-api-key");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = new MockFilterChain();
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+		assertThat(response.getContentAsString()).contains("INVALID_INTERNAL_API_KEY");
+		assertThat(filterChain.getRequest()).isNull();
+	}
+
+	@Test
+	@DisplayName("/internal/** 이 아닌 경로는 필터를 통과")
+	void 일반_경로_필터_통과() throws Exception {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/token/refresh");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = new MockFilterChain();
+
+		// when
+		filter.doFilterInternal(request, response, filterChain);
+
+		// then
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(filterChain.getRequest()).isNotNull();
+	}
+}

--- a/Auth-Guard/src/test/resources/application-test.yaml
+++ b/Auth-Guard/src/test/resources/application-test.yaml
@@ -36,6 +36,9 @@ jwt:
   cookie:
     secure: false
 
+internal:
+  api-key: test-internal-api-key
+
 kakao:
   client-id: test-client-id
   client-secret: test-client-secret

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 	REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
 	INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "잘못된 토큰 타입입니다."),
 	BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."),
+	INVALID_INTERNAL_API_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 API 키입니다."),
 	OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "토큰 발급에 실패했습니다."),
 	OAUTH_CODE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "인가 코드는 필수입니다."),
 	OAUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인가 코드가 만료되었거나 이미 사용되었습니다."),


### PR DESCRIPTION
## 🔧 작업 내용
- AI 서버(FastAPI)에서 유저 차단/해제 API 호출 시 API Key 인증 필터 추가
- VPC 내부 통신 + API Key 이중 보호 구조
- `/internal/**` 엔드포인트를 JWT 인증에서 제외하고, `X-Internal-Api-Key` 헤더 검증으로 대체

## 🧩 구현 상세
- `InternalApiKeyFilter` (OncePerRequestFilter): `/internal/` 경로 요청만  가로채서 API Key 헤더 검증
- `InternalApiKeyProperties`: `@ConfigurationProperties(prefix = "internal")`로 키 주입
- `SecurityConfig`: `/internal/**` permitAll 처리 + 와일드카드를 정확한 엔드포인트로 변경
- `ErrorCode.INVALID_INTERNAL_API_KEY` (401) 추가
- 인증 실패 시 JSON 에러 응답 직접 작성 (GlobalExceptionHandler 미경유)

## 🧪 테스트 방법
- `InternalApiKeyFilterTest` 단위 테스트 4개 케이스
  - 유효한 API Key → 정상 통과
  - 헤더 누락 → 401
  - 잘못된 API Key → 401
  - `/internal/` 외 경로 → 필터 무시

## ❗ 참고 사항
- 클라우드 팀에 `INTERNAL_API_KEY` 환경변수를 Auth-Guard, AI 서버 양쪽에 동일 값으로 세팅 요청 필요!! (cc. @212clab @jjyeah @Chemuchi 형)