### PR TITLE
chore(docker): docker-compose 누락 환경변수 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
       DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
-      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:?INTERNAL_API_KEY is required}
     depends_on:
       local-postgres:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -99,6 +99,8 @@ services:
       KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
       KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET}
       KAKAO_REDIRECT_URI: ${KAKAO_REDIRECT_URI}
+      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -123,6 +125,7 @@ services:
       REDIS_PORT: 6379
       ADMISSION_PRIVATE_KEY: ${ADMISSION_PRIVATE_KEY}
       ADMISSION_PUBLIC_KEY: ${ADMISSION_PUBLIC_KEY}
+      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -146,6 +149,7 @@ services:
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
       ADMISSION_PUBLIC_KEY: ${ADMISSION_PUBLIC_KEY}
+      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy
@@ -168,6 +172,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       REDIS_HOST: local-redis
       REDIS_PORT: 6379
+      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
     depends_on:
       local-postgres:
         condition: service_healthy


### PR DESCRIPTION
## 🔧 작업 내용
- DB 암호화 키, Internal API Key 환경변수가 docker-compose에 누락되어 추가
- auth-guard: `DB_ENCRYPTION_KEY`, `INTERNAL_API_KEY` 추가
- queue, seat, order-core: `DB_ENCRYPTION_KEY` 추가

## ❗ 참고 사항
- `.env` 파일에 `DB_ENCRYPTION_KEY`, `INTERNAL_API_KEY` 값이 세팅되어 있어야 정상 기동됨
- `INTERNAL_API_KEY`는 auth-guard에서만 사용 (AI 서버 → Auth-Guard 내부 API 인증용)
