### PR TITLE
fix(seat-common): 일반 좌석 선점 과정에서 티켓 수 비교하는 로직 삭제 [GRGB-308]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldService.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service;
 
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
-import com.goormgb.be.seat.booking.model.BookingOptions;
-import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
 
@@ -27,7 +25,7 @@ import lombok.RequiredArgsConstructor;
  *
  * <h3>처리 흐름</h3>
  * <ol>
- *   <li>seatIds 정규화 및 검증 (중복, null, 티켓 수 일치)</li>
+ *   <li>seatIds 정규화 및 검증 (중복, null)</li>
  *   <li>좌석 단위 Redisson 분산 락 획득 (정렬 순서로 데드락 방지)</li>
  *   <li>트랜잭션 서비스에서 Hold 생성/갱신 + 커밋</li>
  *   <li>락 해제</li>
@@ -37,13 +35,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SeatHoldService {
 
-	private final BookingOptionsRedisRepository bookingOptionsRedisRepository;
 	private final SeatHoldLockManager seatHoldLockManager;
 	private final SeatHoldTransactionalService seatHoldTransactionalService;
 
 	public SeatHoldCreateResponse createOrRefreshHold(Long userId, Long matchId, List<Long> seatIds) {
 		List<Long> normalizedSeatIds = normalizeSeatIds(seatIds);
-		validateSeatCount(userId, matchId, normalizedSeatIds.size());
 
 		List<RLock> locks = seatHoldLockManager.lockAll(matchId, normalizedSeatIds);
 		try {
@@ -71,17 +67,5 @@ public class SeatHoldService {
 		return seatIds.stream()
 				.sorted(Comparator.naturalOrder())
 				.toList();
-	}
-
-	private void validateSeatCount(Long userId, Long matchId, int requestedCount) {
-		BookingOptions bookingOptions =
-				bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
-
-		Integer ticketCount = bookingOptions.ticketCount();
-		if (ticketCount != null) {
-			Preconditions.validate(
-					ticketCount == requestedCount,
-					ErrorCode.INVALID_SEAT_HOLD_REQUEST);
-		}
 	}
 }

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatHoldServiceTest.java
@@ -18,8 +18,6 @@ import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.seat.common.dto.response.SeatHoldCreateResponse;
 import com.goormgb.be.seat.common.service.lock.SeatHoldLockManager;
-import com.goormgb.be.seat.booking.model.BookingOptions;
-import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldServiceTest {
@@ -28,19 +26,12 @@ class SeatHoldServiceTest {
 	private static final Long MATCH_ID = 10L;
 
 	@Mock
-	private BookingOptionsRedisRepository bookingOptionsRedisRepository;
-	@Mock
 	private SeatHoldLockManager seatHoldLockManager;
 	@Mock
 	private SeatHoldTransactionalService seatHoldTransactionalService;
 
 	@InjectMocks
 	private SeatHoldService seatHoldService;
-
-	private void setupSession(int ticketCount) {
-		given(bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(USER_ID, MATCH_ID))
-			.willReturn(new BookingOptions(USER_ID, MATCH_ID, true, ticketCount, false, Instant.now()));
-	}
 
 	@Test
 	@DisplayName("seatIds가 중복이면 INVALID_SEAT_HOLD_REQUEST 예외가 발생한다")
@@ -67,25 +58,9 @@ class SeatHoldServiceTest {
 	}
 
 	@Test
-	@DisplayName("티켓 수와 좌석 수가 다르면 INVALID_SEAT_HOLD_REQUEST 예외가 발생한다")
-	void 티켓수_불일치_예외() {
-		// given
-		setupSession(3);
-
-		// when & then
-		assertThatThrownBy(() -> seatHoldService.createOrRefreshHold(USER_ID, MATCH_ID, List.of(1L, 2L)))
-			.isInstanceOf(CustomException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.INVALID_SEAT_HOLD_REQUEST);
-
-		verifyNoInteractions(seatHoldLockManager);
-	}
-
-	@Test
 	@DisplayName("정상 요청 시 락 획득 후 트랜잭션 서비스를 호출하고 락을 해제한다")
 	void 정상_요청_락_트랜잭션_순서() {
 		// given
-		setupSession(2);
 		RLock lock1 = mock(RLock.class);
 		RLock lock2 = mock(RLock.class);
 		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));
@@ -111,7 +86,6 @@ class SeatHoldServiceTest {
 	@DisplayName("트랜잭션 서비스에서 예외 발생 시에도 락이 해제된다")
 	void 트랜잭션_예외시_락_해제() {
 		// given
-		setupSession(2);
 		RLock lock1 = mock(RLock.class);
 		RLock lock2 = mock(RLock.class);
 		given(seatHoldLockManager.lockAll(MATCH_ID, List.of(206313L, 206314L))).willReturn(List.of(lock1, lock2));

--- a/Seat/src/test/java/com/goormgb/be/seat/support/WebMvcTestSupport.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/support/WebMvcTestSupport.java
@@ -5,6 +5,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.goormgb.be.global.environment.ErrorResponseStrategy;
 import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import tools.jackson.databind.ObjectMapper;
@@ -20,4 +21,7 @@ public abstract class WebMvcTestSupport {
 
 	@MockitoBean
 	protected XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
+
+	@MockitoBean
+	protected ErrorResponseStrategy errorResponseStrategy;
 }


### PR DESCRIPTION
## 🔧 작업 내용

- 일반 좌석 선점 경로에서 `bookingOptions.ticketCount()` 일치 검증 제거
- `SeatHoldService`의 불필요한 `bookingOptions` 조회 의존성 정리
- 관련 단위 테스트 시나리오 업데이트


### 📌 관련 Jira Issue

- GRGB-308

## 🧪 테스트 방법(선택)

> 티켓 수 검증 테스트 삭제
