### PR TITLE
feat(user-account): 유저 계정 정보 (닉네임) 수정 API [GRGB-312]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -5,12 +5,16 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PutMapping;
 
 import com.goormgb.be.global.response.ApiResult;
+import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -34,6 +38,26 @@ import lombok.RequiredArgsConstructor;
 public class MyPageController {
 
 	private final MyPageService myPageService;
+
+	@Operation(
+		summary = "개인정보 수정",
+		description = "로그인한 사용자의 닉네임을 수정합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "수정 성공"),
+		@ApiResponse(responseCode = "400", description = "닉네임 입력값 오류", content = @Content),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+	})
+	@PutMapping("/account")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<MyPageAccountResponse> updateAccount(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody MyPageAccountUpdateRequest request
+	) {
+		return ApiResult.ok("수정 성공", myPageService.updateAccount(userId, request));
+	}
 
 	@Operation(
 		summary = "마이페이지 프로필 요약 조회",

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "MyPage", description = "마이페이지 API")
@@ -54,7 +55,7 @@ public class MyPageController {
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageAccountResponse> updateAccount(
 		@AuthenticationPrincipal Long userId,
-		@RequestBody MyPageAccountUpdateRequest request
+		@Valid @RequestBody MyPageAccountUpdateRequest request
 	) {
 		return ApiResult.ok("수정 성공", myPageService.updateAccount(userId, request));
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/request/MyPageAccountUpdateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/request/MyPageAccountUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.goormgb.be.ordercore.mypage.dto.request;
+
+public record MyPageAccountUpdateRequest(
+	String nickname
+) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/request/MyPageAccountUpdateRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/request/MyPageAccountUpdateRequest.java
@@ -1,6 +1,11 @@
 package com.goormgb.be.ordercore.mypage.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record MyPageAccountUpdateRequest(
+	@NotBlank(message = "닉네임은 공백일 수 없습니다.")
+	@Size(max = 15, message = "닉네임은 15자 이하여야 합니다.")
 	String nickname
 ) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
@@ -1,0 +1,30 @@
+package com.goormgb.be.ordercore.mypage.dto.response;
+
+import java.util.List;
+
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.entity.UserSns;
+
+public record MyPageAccountResponse(
+	String email,
+	String nickname,
+	List<SnsAccount> snsAccounts
+) {
+
+	public record SnsAccount(
+		String provider,
+		String providerUserId
+	) {
+	}
+
+	public static MyPageAccountResponse of(User user, List<UserSns> userSnsList) {
+		List<SnsAccount> snsAccounts = userSnsList.stream()
+			.map(sns -> new SnsAccount(sns.getProvider().name(), sns.getProviderUserId()))
+			.toList();
+		return new MyPageAccountResponse(
+			user.getEmail(),
+			user.getNickname(),
+			snsAccounts
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
@@ -1,14 +1,12 @@
 package com.goormgb.be.ordercore.mypage.dto.response;
 
-import java.util.List;
-
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
 
 public record MyPageAccountResponse(
 	String email,
 	String nickname,
-	List<SnsAccount> snsAccounts
+	SnsAccount snsAccount
 ) {
 
 	public record SnsAccount(
@@ -17,14 +15,14 @@ public record MyPageAccountResponse(
 	) {
 	}
 
-	public static MyPageAccountResponse of(User user, List<UserSns> userSnsList) {
-		List<SnsAccount> snsAccounts = userSnsList.stream()
-			.map(sns -> new SnsAccount(sns.getProvider().name(), sns.getProviderUserId()))
-			.toList();
+	public static MyPageAccountResponse of(User user, UserSns userSns) {
+		SnsAccount snsAccount = userSns == null
+			? null
+			: new SnsAccount(userSns.getProvider().name(), userSns.getProviderUserId());
 		return new MyPageAccountResponse(
 			user.getEmail(),
 			user.getNickname(),
-			snsAccounts
+			snsAccount
 		);
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -86,7 +86,7 @@ public class MyPageService {
 
 	@Transactional
 	public MyPageAccountResponse updateAccount(Long userId, MyPageAccountUpdateRequest request) {
-		String nickname = request.nickname() == null ? "" : request.nickname().trim();
+		String nickname = request.nickname().trim();
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		user.updateNickname(nickname);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -1,12 +1,12 @@
 package com.goormgb.be.ordercore.mypage.service;
 
 import java.math.BigDecimal;
-import java.time.Clock;
 import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +23,8 @@ import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
 import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRepository;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
+import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -34,10 +36,10 @@ import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
-import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
+import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.repository.UserRepository;
@@ -81,6 +83,21 @@ public class MyPageService {
 	private final MyPageQueryService myPageQueryService;
 	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
 	private final Clock clock;
+
+	@Transactional
+	public MyPageAccountResponse updateAccount(Long userId, MyPageAccountUpdateRequest request) {
+		String nickname = request.nickname() == null ? "" : request.nickname().trim();
+		Preconditions.validate(!nickname.isBlank() && nickname.length() <= 15, ErrorCode.INVALID_NICKNAME);
+
+		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
+		user.updateNickname(nickname);
+
+		List<UserSns> userSnsList = userSnsRepository.findByUserId(userId)
+			.map(List::of)
+			.orElseGet(List::of);
+
+		return MyPageAccountResponse.of(user, userSnsList);
+	}
 
 	/**
 	 * 마이페이지 프로필 요약 조회
@@ -317,7 +334,8 @@ public class MyPageService {
 
 	private void validateQrIssuableTime(Instant matchAt, Instant now) {
 		Preconditions.validate(now.isBefore(matchAt), ErrorCode.ENTRY_QR_MATCH_STARTED);
-		Preconditions.validate(!now.isBefore(matchAt.minus(ENTRY_OPEN_BEFORE_MATCH)), ErrorCode.ENTRY_QR_NOT_AVAILABLE_YET);
+		Preconditions.validate(!now.isBefore(matchAt.minus(ENTRY_OPEN_BEFORE_MATCH)),
+			ErrorCode.ENTRY_QR_NOT_AVAILABLE_YET);
 	}
 
 	private QrToken issueNewQrToken(Order order, Instant now) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -87,7 +87,6 @@ public class MyPageService {
 	@Transactional
 	public MyPageAccountResponse updateAccount(Long userId, MyPageAccountUpdateRequest request) {
 		String nickname = request.nickname() == null ? "" : request.nickname().trim();
-		Preconditions.validate(!nickname.isBlank() && nickname.length() <= 15, ErrorCode.INVALID_NICKNAME);
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		user.updateNickname(nickname);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageService.java
@@ -91,11 +91,9 @@ public class MyPageService {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		user.updateNickname(nickname);
 
-		List<UserSns> userSnsList = userSnsRepository.findByUserId(userId)
-			.map(List::of)
-			.orElseGet(List::of);
+		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
 
-		return MyPageAccountResponse.of(user, userSnsList);
+		return MyPageAccountResponse.of(user, userSns);
 	}
 
 	/**

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -35,7 +35,7 @@ public final class MyPageFixture {
 		return new MyPageAccountResponse(
 			"user@example.com",
 			"goorm_new",
-			List.of(new MyPageAccountResponse.SnsAccount("KAKAO", "kakao-user-id-12345"))
+			new MyPageAccountResponse.SnsAccount("KAKAO", "kakao-user-id-12345")
 		);
 	}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.goormgb.be.domain.ticket.enums.TicketType;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -27,6 +28,14 @@ public final class MyPageFixture {
 		return new MyPageProfileResponse(
 			new MyPageProfileResponse.ProfileInfo("goorm123", null, "KAKAO"),
 			new MyPageProfileResponse.TicketSummary(2, 1, 5)
+		);
+	}
+
+	public static MyPageAccountResponse createAccountResponse() {
+		return new MyPageAccountResponse(
+			"user@example.com",
+			"goorm_new",
+			List.of(new MyPageAccountResponse.SnsAccount("KAKAO", "kakao-user-id-12345"))
 		);
 	}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -73,7 +73,7 @@ class MyPageControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.message").value("수정 성공"))
 				.andExpect(jsonPath("$.data.email").value("user@example.com"))
 				.andExpect(jsonPath("$.data.nickname").value("goorm_new"))
-				.andExpect(jsonPath("$.data.snsAccounts[0].provider").value("KAKAO"));
+				.andExpect(jsonPath("$.data.snsAccount.provider").value("KAKAO"));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -21,6 +21,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.mypage.MyPageFixture;
+import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -42,6 +44,71 @@ class MyPageControllerTest extends WebMvcTestSupport {
 			new UsernamePasswordAuthenticationToken(userId, null,
 				List.of(new SimpleGrantedAuthority("ROLE_USER")))
 		);
+	}
+
+	@Nested
+	@DisplayName("PUT /mypage/account — 개인정보 수정")
+	class UpdateAccount {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 수정된 계정 정보를 반환한다")
+		void updateAccount_성공() throws Exception {
+			MyPageAccountResponse response = MyPageFixture.createAccountResponse();
+			given(myPageService.updateAccount(eq(1L), any(MyPageAccountUpdateRequest.class))).willReturn(response);
+
+			mockMvc.perform(put("/mypage/account")
+					.contentType("application/json")
+					.content("""
+						{
+						  "nickname": "goorm_new"
+						}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.message").value("수정 성공"))
+				.andExpect(jsonPath("$.data.email").value("user@example.com"))
+				.andExpect(jsonPath("$.data.nickname").value("goorm_new"))
+				.andExpect(jsonPath("$.data.snsAccounts[0].provider").value("KAKAO"));
+		}
+
+		@Test
+		@DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+		void updateAccount_닉네임오류_400() throws Exception {
+			given(myPageService.updateAccount(eq(1L), any(MyPageAccountUpdateRequest.class)))
+				.willThrow(new CustomException(ErrorCode.INVALID_NICKNAME));
+
+			mockMvc.perform(put("/mypage/account")
+					.contentType("application/json")
+					.content("""
+						{
+						  "nickname": "   "
+						}
+						"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("닉네임은 공백일 수 없고 20자 이하여야 합니다."));
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 404를 반환한다")
+		void updateAccount_사용자없음_404() throws Exception {
+			given(myPageService.updateAccount(eq(1L), any(MyPageAccountUpdateRequest.class)))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			mockMvc.perform(put("/mypage/account")
+					.contentType("application/json")
+					.content("""
+						{
+						  "nickname": "goorm_new"
+						}
+						"""))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+		}
 	}
 
 	@Nested

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -90,7 +90,7 @@ class MyPageControllerTest extends WebMvcTestSupport {
 						}
 						"""))
 				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.message").value("닉네임은 공백일 수 없고 20자 이하여야 합니다."));
+				.andExpect(jsonPath("$.message").value("닉네임은 공백일 수 없고 15자 이하여야 합니다."));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -79,9 +79,6 @@ class MyPageControllerTest extends WebMvcTestSupport {
 		@Test
 		@DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
 		void updateAccount_닉네임오류_400() throws Exception {
-			given(myPageService.updateAccount(eq(1L), any(MyPageAccountUpdateRequest.class)))
-				.willThrow(new CustomException(ErrorCode.INVALID_NICKNAME));
-
 			mockMvc.perform(put("/mypage/account")
 					.contentType("application/json")
 					.content("""
@@ -90,7 +87,7 @@ class MyPageControllerTest extends WebMvcTestSupport {
 						}
 						"""))
 				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.message").value("닉네임은 공백일 수 없고 15자 이하여야 합니다."));
+				.andExpect(jsonPath("$.message").value("nickname: 닉네임은 공백일 수 없습니다."));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -30,6 +30,8 @@ import com.goormgb.be.ordercore.cancellation.entity.CancellationFeePolicy;
 import com.goormgb.be.ordercore.cancellation.repository.CancellationFeePolicyRepository;
 import com.goormgb.be.ordercore.fixture.mypage.MyPageFixture;
 import com.goormgb.be.ordercore.fixture.order.OrderFixture;
+import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketDetailBaseRow;
 import com.goormgb.be.ordercore.mypage.dto.query.TicketSeatDetailRow;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
@@ -91,6 +93,61 @@ class MyPageServiceTest {
 			.provider(SocialProvider.KAKAO)
 			.providerUserId("kakao-12345")
 			.build();
+	}
+
+	@Nested
+	@DisplayName("updateAccount — 개인정보 수정")
+	class UpdateAccount {
+
+		@Test
+		@DisplayName("유효한 닉네임이면 계정 정보가 수정된다")
+		void updateAccount_성공() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			UserSns userSns = createUserSns(user);
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(userSnsRepository.findByUserId(userId)).willReturn(Optional.of(userSns));
+
+			MyPageAccountResponse response = myPageService.updateAccount(
+				userId,
+				new MyPageAccountUpdateRequest("  goorm_new  ")
+			);
+
+			assertThat(response.nickname()).isEqualTo("goorm_new");
+			assertThat(response.email()).isEqualTo("test@test.com");
+			assertThat(response.snsAccounts()).hasSize(1);
+			assertThat(response.snsAccounts().get(0).provider()).isEqualTo("KAKAO");
+			assertThat(user.getNickname()).isEqualTo("goorm_new");
+		}
+
+		@Test
+		@DisplayName("닉네임이 공백이면 INVALID_NICKNAME 예외가 발생한다")
+		void updateAccount_닉네임공백_예외() {
+			assertThatThrownBy(() -> myPageService.updateAccount(1L, new MyPageAccountUpdateRequest("   ")))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.INVALID_NICKNAME.getMessage());
+		}
+
+		@Test
+		@DisplayName("닉네임이 20자를 초과하면 INVALID_NICKNAME 예외가 발생한다")
+		void updateAccount_닉네임길이초과_예외() {
+			assertThatThrownBy(() -> myPageService.updateAccount(1L, new MyPageAccountUpdateRequest("abcdefghijklmnopqrstu")))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.INVALID_NICKNAME.getMessage());
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 USER_NOT_FOUND 예외가 발생한다")
+		void updateAccount_사용자없음_예외() {
+			Long userId = 999L;
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			assertThatThrownBy(() -> myPageService.updateAccount(userId, new MyPageAccountUpdateRequest("goorm_new")))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+		}
 	}
 
 	@Nested

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -130,7 +130,7 @@ class MyPageServiceTest {
 		}
 
 		@Test
-		@DisplayName("닉네임이 20자를 초과하면 INVALID_NICKNAME 예외가 발생한다")
+		@DisplayName("닉네임이 15자를 초과하면 INVALID_NICKNAME 예외가 발생한다")
 		void updateAccount_닉네임길이초과_예외() {
 			assertThatThrownBy(() -> myPageService.updateAccount(1L, new MyPageAccountUpdateRequest("abcdefghijklmnopqrstu")))
 				.isInstanceOf(CustomException.class)
@@ -516,6 +516,7 @@ class MyPageServiceTest {
 
 			User user = OrderFixture.createUserWithId(userId);
 			Order order = OrderFixture.createOrderWithId(ticketId, user, match, 42000);
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now(clock));
 			order.updateStatus(status);
 			return order;
 		}
@@ -620,6 +621,7 @@ class MyPageServiceTest {
 
 			User user = OrderFixture.createUserWithId(userId);
 			Order order = OrderFixture.createOrderWithId(ticketId, user, match, 42000);
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now(clock));
 			order.updateStatus(status);
 			return order;
 		}
@@ -682,7 +684,7 @@ class MyPageServiceTest {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now().plus(10, ChronoUnit.DAYS));
-			ReflectionTestUtils.setField(order, "createdAt", Instant.now().minus(1, ChronoUnit.DAYS));
+			ReflectionTestUtils.setField(order, "createdAt", Instant.now(clock).minus(1, ChronoUnit.DAYS));
 
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 				.daysBeforeMatchMin(7)

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -122,22 +122,6 @@ class MyPageServiceTest {
 		}
 
 		@Test
-		@DisplayName("닉네임이 공백이면 INVALID_NICKNAME 예외가 발생한다")
-		void updateAccount_닉네임공백_예외() {
-			assertThatThrownBy(() -> myPageService.updateAccount(1L, new MyPageAccountUpdateRequest("   ")))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_NICKNAME.getMessage());
-		}
-
-		@Test
-		@DisplayName("닉네임이 15자를 초과하면 INVALID_NICKNAME 예외가 발생한다")
-		void updateAccount_닉네임길이초과_예외() {
-			assertThatThrownBy(() -> myPageService.updateAccount(1L, new MyPageAccountUpdateRequest("abcdefghijklmnopqrstu")))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_NICKNAME.getMessage());
-		}
-
-		@Test
 		@DisplayName("사용자가 없으면 USER_NOT_FOUND 예외가 발생한다")
 		void updateAccount_사용자없음_예외() {
 			Long userId = 999L;

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceTest.java
@@ -116,8 +116,8 @@ class MyPageServiceTest {
 
 			assertThat(response.nickname()).isEqualTo("goorm_new");
 			assertThat(response.email()).isEqualTo("test@test.com");
-			assertThat(response.snsAccounts()).hasSize(1);
-			assertThat(response.snsAccounts().get(0).provider()).isEqualTo("KAKAO");
+			assertThat(response.snsAccount()).isNotNull();
+			assertThat(response.snsAccount().provider()).isEqualTo("KAKAO");
 			assertThat(user.getNickname()).isEqualTo("goorm_new");
 		}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/support/WebMvcTestSupport.java
@@ -5,6 +5,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.goormgb.be.global.environment.ErrorResponseStrategy;
 import com.goormgb.be.global.security.filter.XUserIdAuthenticationFilter;
 
 import tools.jackson.databind.ObjectMapper;
@@ -20,4 +21,7 @@ public abstract class WebMvcTestSupport {
 
 	@MockitoBean
 	protected XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
+
+	@MockitoBean
+	protected ErrorResponseStrategy errorResponseStrategy;
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -118,7 +118,6 @@ public enum ErrorCode {
 	// Mypage
 	INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "size는 최대 10까지 허용됩니다."),
 	INVALID_TICKET_TAB(HttpStatus.BAD_REQUEST, "유효하지 않은 탭 값입니다."),
-	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 공백일 수 없고 15자 이하여야 합니다."),
 	TICKET_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "취소 가능한 기간이 아닙니다."),
 	ENTRY_QR_NOT_AVAILABLE_YET(HttpStatus.BAD_REQUEST, "아직 입장 가능 시간이 아닙니다."),
 	ENTRY_QR_MATCH_STARTED(HttpStatus.BAD_REQUEST, "경기 시작 이후에는 QR을 발급할 수 없습니다."),

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -118,6 +118,7 @@ public enum ErrorCode {
 	// Mypage
 	INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "size는 최대 10까지 허용됩니다."),
 	INVALID_TICKET_TAB(HttpStatus.BAD_REQUEST, "유효하지 않은 탭 값입니다."),
+	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 공백일 수 없고 20자 이하여야 합니다."),
 	TICKET_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "취소 가능한 기간이 아닙니다."),
 	ENTRY_QR_NOT_AVAILABLE_YET(HttpStatus.BAD_REQUEST, "아직 입장 가능 시간이 아닙니다."),
 	ENTRY_QR_MATCH_STARTED(HttpStatus.BAD_REQUEST, "경기 시작 이후에는 QR을 발급할 수 없습니다."),

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -118,7 +118,7 @@ public enum ErrorCode {
 	// Mypage
 	INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "size는 최대 10까지 허용됩니다."),
 	INVALID_TICKET_TAB(HttpStatus.BAD_REQUEST, "유효하지 않은 탭 값입니다."),
-	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 공백일 수 없고 20자 이하여야 합니다."),
+	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 공백일 수 없고 15자 이하여야 합니다."),
 	TICKET_CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "취소 가능한 기간이 아닙니다."),
 	ENTRY_QR_NOT_AVAILABLE_YET(HttpStatus.BAD_REQUEST, "아직 입장 가능 시간이 아닙니다."),
 	ENTRY_QR_MATCH_STARTED(HttpStatus.BAD_REQUEST, "경기 시작 이후에는 QR을 발급할 수 없습니다."),

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -83,6 +83,10 @@ public class User extends BaseEntity {
 		}
 	}
 
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
 	public void deactivate() {
 		this.status = UserStatus.DEACTIVATE;
 	}


### PR DESCRIPTION
## 🔧 작업 내용

- 마이페이지 계정 정보 수정 API를 추가했습니다.
- 로그인 사용자의 nickname 변경을 지원합니다.
- 닉네임 유효성 검증을 컨트롤러 단에서 @Valid로 수행하도록 반영했습니다.

## 🧩 구현 상세 (선택)

- `PUT /mypage/account` 엔드포인트 추가
- `MyPageService.updateAccount(userId, request)`
- 사용자 조회 후 닉네임 trim + 업데이트
- 연동 SNS 계정 조회 후 응답 구성

> 테스트 에러 나는 부분 수정했습니다.

### 📌 관련 Jira Issue

- GRGB-312

## 🧪 테스트 방법(선택)

<img width="1013" height="428" alt="image" src="https://github.com/user-attachments/assets/19537c7f-4e8f-4ab8-aa0d-3b6197c8f5b6" />


<img width="1044" height="396" alt="image" src="https://github.com/user-attachments/assets/3d275b90-4469-4f9e-851a-b299ce8785f5" />


## ❗ 참고 사항

> MypageService 너무 많은 내용이 있어서 다음 브랜치에서 해당 파일 리펙토링 먼저 진행하겠슴니다
> 이후에 계정 정보 조회 API가 없어서 다다음 브랜치에서 만들겠슴다