### PR TITLE
feat(mypage): 유저 계정 정보 조회 API [GRGB-314]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -43,6 +43,24 @@ public class MyPageController {
 	private final MyPageTicketService myPageTicketService;
 
 	@Operation(
+		summary = "개인정보 조회",
+		description = "로그인한 사용자의 계정 기본 정보를 조회합니다.",
+		security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+	})
+	@GetMapping("/account")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<MyPageAccountResponse> getAccount(
+		@AuthenticationPrincipal Long userId
+	) {
+		return ApiResult.ok("조회 성공", myPageProfileService.getAccount(userId));
+	}
+
+	@Operation(
 		summary = "개인정보 수정",
 		description = "로그인한 사용자의 닉네임을 수정합니다.",
 		security = @SecurityRequirement(name = "BearerAuth")

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageAccountResponse.java
@@ -6,6 +6,7 @@ import com.goormgb.be.user.entity.UserSns;
 public record MyPageAccountResponse(
 	String email,
 	String nickname,
+	String profileImageUrl,
 	SnsAccount snsAccount
 ) {
 
@@ -22,6 +23,7 @@ public record MyPageAccountResponse(
 		return new MyPageAccountResponse(
 			user.getEmail(),
 			user.getNickname(),
+			user.getProfileImageUrl(),
 			snsAccount
 		);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
@@ -45,28 +45,30 @@ public class MyPageProfileService {
 	private final OrderRepository orderRepository;
 	private final Clock clock;
 
+	private record UserInfo(User user, UserSns userSns) {
+	}
+
+	private UserInfo findUserInfo(Long userId) {
+		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
+		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
+		return new UserInfo(user, userSns);
+	}
+
 	@Transactional
 	public MyPageAccountResponse updateAccount(Long userId, MyPageAccountUpdateRequest request) {
 		String nickname = request.nickname().trim();
-
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
-		user.updateNickname(nickname);
-
-		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
-
-		return MyPageAccountResponse.of(user, userSns);
+		UserInfo userInfo = findUserInfo(userId);
+		userInfo.user().updateNickname(nickname);
+		return MyPageAccountResponse.of(userInfo.user(), userInfo.userSns());
 	}
 
 	public MyPageAccountResponse getAccount(Long userId) {
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
-		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
-
-		return MyPageAccountResponse.of(user, userSns);
+		UserInfo userInfo = findUserInfo(userId);
+		return MyPageAccountResponse.of(userInfo.user(), userInfo.userSns());
 	}
 
 	public MyPageProfileResponse getProfile(Long userId) {
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
-		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
+		UserInfo userInfo = findUserInfo(userId);
 
 		Instant now = Instant.now(clock);
 		OrderMyPageSummaryCounts counts = orderRepository.findMyPageSummaryCounts(
@@ -84,6 +86,13 @@ public class MyPageProfileService {
 		log.info("[MyPageProfileService] 프로필 조회 - userId={}, upcomingCount={}, cancelRefundCount={}, completedCount={}",
 			userId, upcomingCount, cancelRefundCount, completedCount);
 
-		return MyPageProfileResponse.of(user, userSns, upcomingCount, cancelRefundCount, completedCount);
+		return MyPageProfileResponse.of(
+			userInfo.user(),
+			userInfo.userSns(),
+			upcomingCount,
+			cancelRefundCount,
+			completedCount
+		);
 	}
+
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
@@ -57,6 +57,13 @@ public class MyPageProfileService {
 		return MyPageAccountResponse.of(user, userSns);
 	}
 
+	public MyPageAccountResponse getAccount(Long userId) {
+		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
+		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);
+
+		return MyPageAccountResponse.of(user, userSns);
+	}
+
 	public MyPageProfileResponse getProfile(Long userId) {
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		UserSns userSns = userSnsRepository.findByUserId(userId).orElse(null);

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/mypage/MyPageFixture.java
@@ -35,6 +35,7 @@ public final class MyPageFixture {
 		return new MyPageAccountResponse(
 			"user@example.com",
 			"goorm_new",
+			"https://cdn.goormgb.com/profile/user-1.png",
 			new MyPageAccountResponse.SnsAccount("KAKAO", "kakao-user-id-12345")
 		);
 	}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -71,6 +71,7 @@ class MyPageControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.message").value("조회 성공"))
 				.andExpect(jsonPath("$.data.email").value("user@example.com"))
 				.andExpect(jsonPath("$.data.nickname").value("goorm_new"))
+				.andExpect(jsonPath("$.data.profileImageUrl").value("https://cdn.goormgb.com/profile/user-1.png"))
 				.andExpect(jsonPath("$.data.snsAccount.provider").value("KAKAO"));
 		}
 
@@ -114,6 +115,7 @@ class MyPageControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.message").value("수정 성공"))
 				.andExpect(jsonPath("$.data.email").value("user@example.com"))
 				.andExpect(jsonPath("$.data.nickname").value("goorm_new"))
+				.andExpect(jsonPath("$.data.profileImageUrl").value("https://cdn.goormgb.com/profile/user-1.png"))
 				.andExpect(jsonPath("$.data.snsAccount.provider").value("KAKAO"));
 		}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -51,6 +51,42 @@ class MyPageControllerTest extends WebMvcTestSupport {
 	}
 
 	@Nested
+	@DisplayName("GET /mypage/account — 개인정보 조회")
+	class GetAccount {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 계정 정보를 반환한다")
+		void getAccount_성공() throws Exception {
+			MyPageAccountResponse response = MyPageFixture.createAccountResponse();
+			given(myPageProfileService.getAccount(1L)).willReturn(response);
+
+			mockMvc.perform(get("/mypage/account"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.message").value("조회 성공"))
+				.andExpect(jsonPath("$.data.email").value("user@example.com"))
+				.andExpect(jsonPath("$.data.nickname").value("goorm_new"))
+				.andExpect(jsonPath("$.data.snsAccount.provider").value("KAKAO"));
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 404를 반환한다")
+		void getAccount_사용자없음_404() throws Exception {
+			given(myPageProfileService.getAccount(1L))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			mockMvc.perform(get("/mypage/account"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+		}
+	}
+
+	@Nested
 	@DisplayName("PUT /mypage/account — 개인정보 수정")
 	class UpdateAccount {
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
@@ -85,6 +85,7 @@ class MyPageProfileServiceTest {
 
 			assertThat(response.nickname()).isEqualTo("goorm_new");
 			assertThat(response.email()).isEqualTo("test@test.com");
+			assertThat(response.profileImageUrl()).isNull();
 			assertThat(response.snsAccount()).isNotNull();
 			assertThat(response.snsAccount().provider()).isEqualTo("KAKAO");
 			assertThat(user.getNickname()).isEqualTo("goorm_new");
@@ -122,6 +123,7 @@ class MyPageProfileServiceTest {
 
 			assertThat(response.email()).isEqualTo("test@test.com");
 			assertThat(response.nickname()).isEqualTo("테스터");
+			assertThat(response.profileImageUrl()).isNull();
 			assertThat(response.snsAccount()).isNotNull();
 			assertThat(response.snsAccount().provider()).isEqualTo("KAKAO");
 		}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
@@ -104,6 +104,56 @@ class MyPageProfileServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("getAccount — 개인정보 조회")
+	class GetAccount {
+
+		@Test
+		@DisplayName("유효한 userId이면 계정 정보를 반환한다")
+		void getAccount_성공() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			UserSns userSns = createUserSns(user);
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(userSnsRepository.findByUserId(userId)).willReturn(Optional.of(userSns));
+
+			MyPageAccountResponse response = myPageProfileService.getAccount(userId);
+
+			assertThat(response.email()).isEqualTo("test@test.com");
+			assertThat(response.nickname()).isEqualTo("테스터");
+			assertThat(response.snsAccount()).isNotNull();
+			assertThat(response.snsAccount().provider()).isEqualTo("KAKAO");
+		}
+
+		@Test
+		@DisplayName("SNS 정보가 없으면 snsAccount는 null이다")
+		void getAccount_SNS없음_null() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(userSnsRepository.findByUserId(userId)).willReturn(Optional.empty());
+
+			MyPageAccountResponse response = myPageProfileService.getAccount(userId);
+
+			assertThat(response.snsAccount()).isNull();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 userId이면 USER_NOT_FOUND 예외가 발생한다")
+		void getAccount_사용자없음_예외() {
+			Long userId = 999L;
+
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			assertThatThrownBy(() -> myPageProfileService.getAccount(userId))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+		}
+	}
+
 	@Test
 	@DisplayName("유효한 userId이면 프로필과 티켓 요약을 반환한다")
 	void getProfile_성공() {


### PR DESCRIPTION
## 🔧 작업 내용

- `GET /mypage/account` 엔드포인트 추가
- 계정 조회 응답을 기존 `MyPageAccountResponse`로 통일

## 🧩 구현 상세 (선택)

- 조회/수정 API 모두 `MyPageAccountResponse` 사용
- `user_sns`는 단건 연결 전제로 `snsAccount` 단일 객체로 반환
- SNS 미연동 시 `snsAccount=null `반환

- `MyPageAccountResponse`에 `profileImageUrl(users.profile_image_url)` 매핑 추가

응답 예시
```
{
  "code": "OK",
  "message": "조회 성공",
  "data": {
    "email": "user@example.com",
    "nickname": "goorm123",
    "profileImageUrl": "https://cdn.goormgb.com/profile/user-1.png",
    "snsAccount": {
      "provider": "KAKAO",
      "providerUserId": "kakao-user-id-12345"
    }
  }
}
```

### 📌 관련 Jira Issue

- GRGB-314

## 🧪 테스트 방법(선택)

<img width="1036" height="423" alt="image" src="https://github.com/user-attachments/assets/e83c8cc3-0ef9-464c-88c4-cddf5d567a3d" />

<img width="962" height="403" alt="image" src="https://github.com/user-attachments/assets/1b75b5c7-78cd-4d9b-b43c-3898a80ab9ff" />



## ❗ 참고 사항

