### PR TITLE
fix(order): 결제 완료 시 match_seat SOLD 상태 전환 누락 수정 [GRGB-318]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -174,7 +174,10 @@ public class MyPageTicketService {
 		// 결제된 좌석을 SOLD → AVAILABLE로 복원
 		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(ticketId);
 		int restored = seatInfoQueryService.markAvailableIfSold(matchSeatIds);
-		log.info("[MyPageTicketService] 좌석 AVAILABLE 복원 - orderId={}, count={}", ticketId, restored);
+		if (restored != matchSeatIds.size()) {
+			log.warn("[MyPageTicketService] 좌석 AVAILABLE 복원 개수 불일치 - orderId={}, expected={}, restored={}",
+				ticketId, matchSeatIds.size(), restored);
+		}
 
 		return MyPageTicketCancelResponse.of(order);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -29,8 +29,10 @@ import com.goormgb.be.ordercore.mypage.service.support.MyPageTicketListAssembler
 import com.goormgb.be.ordercore.mypage.service.support.MyPageTicketQrSupport;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
 import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 
@@ -46,19 +48,21 @@ public class MyPageTicketService {
 	private static final int MAX_PAGE_SIZE = 10;
 
 	private static final List<OrderStatus> UPCOMING_STATUSES = List.of(
-		OrderStatus.PAYMENT_PENDING,
-		OrderStatus.PAID
+			OrderStatus.PAYMENT_PENDING,
+			OrderStatus.PAID
 	);
 
 	private static final List<OrderStatus> CANCEL_PROCESSING_STATUSES = List.of(
-		OrderStatus.CANCEL_REQUESTED,
-		OrderStatus.REFUND_PROCESSING
+			OrderStatus.CANCEL_REQUESTED,
+			OrderStatus.REFUND_PROCESSING
 	);
 
 	private final OrderRepository orderRepository;
+	private final OrderSeatRepository orderSeatRepository;
 	private final QrTokenRepository qrTokenRepository;
 	private final MyPageQueryService myPageQueryService;
 	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
+	private final SeatInfoQueryService seatInfoQueryService;
 	private final Clock clock;
 
 	public MyPageTicketListResponse getTickets(Long userId, String tab, int page, int size) {
@@ -69,12 +73,12 @@ public class MyPageTicketService {
 
 		Instant now = Instant.now(clock);
 		OrderMyPageSummaryCounts counts = orderRepository.findMyPageSummaryCounts(
-			userId,
-			UPCOMING_STATUSES,
-			CANCEL_PROCESSING_STATUSES,
-			CANCEL_PROCESSING_STATUSES,
-			OrderStatus.PAID,
-			now
+				userId,
+				UPCOMING_STATUSES,
+				CANCEL_PROCESSING_STATUSES,
+				CANCEL_PROCESSING_STATUSES,
+				OrderStatus.PAID,
+				now
 		);
 		int totalCount = (int)counts.totalCount();
 		int upcomingCount = (int)counts.upcomingCount();
@@ -98,42 +102,43 @@ public class MyPageTicketService {
 		boolean hasNext = (long)(page + 1) * size < totalElements;
 
 		log.info("[MyPageTicketService] 예매 내역 조회 - userId={}, tab={}, page={}, size={}, totalElements={}",
-			userId, tab, page, size, totalElements);
+				userId, tab, page, size, totalElements);
 
 		return MyPageTicketListResponse.of(
-			totalCount, upcomingCount, cancelProcessingCount, completedCount,
-			ticketTab.name(), page, size, totalElements, totalPages, hasNext, tickets
+				totalCount, upcomingCount, cancelProcessingCount, completedCount,
+				ticketTab.name(), page, size, totalElements, totalPages, hasNext, tickets
 		);
 	}
 
 	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {
 		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderId(ticketId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 		Preconditions.validate(base.userId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
 
 		MyPageTicketDetailResponse.PaymentInfo payment = MyPageTicketDetailAssembler.toPaymentInfo(base);
 
 		MyPageTicketDetailResponse.CancellationPolicy cancellationPolicy =
-			MyPageTicketDetailAssembler.buildCancellationPolicy(base.matchAt(), clock, cancellationFeePolicyRepository);
+				MyPageTicketDetailAssembler.buildCancellationPolicy(base.matchAt(), clock,
+						cancellationFeePolicyRepository);
 
 		MyPageTicketDetailResponse.VirtualAccount virtualAccount = MyPageTicketDetailAssembler.toVirtualAccount(base);
 		MyPageTicketDetailResponse.CancellationInfo cancellation = MyPageTicketDetailAssembler.toCancellation(base);
 
 		return MyPageTicketDetailResponse.of(
-			base,
-			seatRows,
-			payment,
-			cancellationPolicy,
-			virtualAccount,
-			cancellation
+				base,
+				seatRows,
+				payment,
+				cancellationPolicy,
+				virtualAccount,
+				cancellation
 		);
 	}
 
 	@Transactional
 	public MyPageTicketQrResponse getTicketEntryQr(Long userId, Long ticketId) {
 		Order order = orderRepository.findByIdForUpdate(ticketId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
@@ -141,7 +146,7 @@ public class MyPageTicketService {
 		MyPageTicketQrSupport.validateQrIssuableTime(order.getMatch().getMatchAt(), now);
 
 		QrToken qrToken = qrTokenRepository.findByOrderIdAndExpiresAtAfter(ticketId, now)
-			.orElseGet(() -> MyPageTicketQrSupport.issueNewQrToken(order, now, qrTokenRepository));
+				.orElseGet(() -> MyPageTicketQrSupport.issueNewQrToken(order, now, qrTokenRepository));
 
 		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
 		return MyPageTicketQrResponse.of(order, seatRows, qrToken.getQrToken(), qrToken.getExpiresAt());
@@ -151,20 +156,25 @@ public class MyPageTicketService {
 	public MyPageTicketCancelResponse requestTicketCancel(Long userId, Long ticketId) {
 		Instant now = Instant.now(clock);
 		Order order = orderRepository.findByIdForUpdate(ticketId)
-			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		CancellationFeePolicy policy = MyPageTicketCancellationCalculator.findCancellationPolicy(
-			order.getMatch().getMatchAt(),
-			now,
-			cancellationFeePolicyRepository
+				order.getMatch().getMatchAt(),
+				now,
+				cancellationFeePolicyRepository
 		);
 		Preconditions.validate(Boolean.TRUE.equals(policy.getCancellable()), ErrorCode.TICKET_CANCEL_NOT_ALLOWED);
 
 		int cancellationFee = MyPageTicketCancellationCalculator.calculateCancellationFee(order, policy, now);
 		int refundedAmount = order.getTotalAmount() - cancellationFee;
 		order.cancel(cancellationFee, refundedAmount);
+
+		// 결제된 좌석을 SOLD → AVAILABLE로 복원
+		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(ticketId);
+		int restored = seatInfoQueryService.markAvailableIfSold(matchSeatIds);
+		log.info("[MyPageTicketService] 좌석 AVAILABLE 복원 - orderId={}, count={}", ticketId, restored);
 
 		return MyPageTicketCancelResponse.of(order);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
@@ -82,6 +82,54 @@ public class SeatInfoQueryService {
 	}
 
 	/**
+	 * BLOCKED 상태인 좌석들을 SOLD로 일괄 전환한다.
+	 * 결제 확정 시 호출되며, BLOCKED가 아닌 좌석은 건드리지 않는다.
+	 *
+	 * @return 변경된 행 수
+	 */
+	public int markSoldIfBlocked(List<Long> matchSeatIds) {
+		if (matchSeatIds.isEmpty()) {
+			return 0;
+		}
+
+		String sql = """
+				UPDATE match_seats
+				SET sale_status = 'SOLD'
+				WHERE id IN (:matchSeatIds)
+				  AND sale_status = 'BLOCKED'
+				""";
+
+		var params = new MapSqlParameterSource()
+				.addValue("matchSeatIds", matchSeatIds);
+
+		return namedJdbc.update(sql, params);
+	}
+
+	/**
+	 * SOLD 상태인 좌석들을 AVAILABLE로 일괄 복원한다.
+	 * 주문 취소 시 호출되며, SOLD가 아닌 좌석은 건드리지 않는다.
+	 *
+	 * @return 변경된 행 수
+	 */
+	public int markAvailableIfSold(List<Long> matchSeatIds) {
+		if (matchSeatIds.isEmpty()) {
+			return 0;
+		}
+
+		String sql = """
+				UPDATE match_seats
+				SET sale_status = 'AVAILABLE'
+				WHERE id IN (:matchSeatIds)
+				  AND sale_status = 'SOLD'
+				""";
+
+		var params = new MapSqlParameterSource()
+				.addValue("matchSeatIds", matchSeatIds);
+
+		return namedJdbc.update(sql, params);
+	}
+
+	/**
 	 * matchSeatId로 이미 주문된 좌석인지 확인한다.
 	 */
 	public boolean isAlreadyOrdered(Long matchSeatId) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
@@ -3,10 +3,15 @@ package com.goormgb.be.ordercore.order.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.ordercore.order.entity.OrderSeat;
 
 public interface OrderSeatRepository extends JpaRepository<OrderSeat, Long> {
 
 	List<OrderSeat> findByOrderId(Long orderId);
+
+	@Query("SELECT os.matchSeatId FROM OrderSeat os WHERE os.order.id = :orderId")
+	List<Long> findMatchSeatIdsByOrderId(@Param("orderId") Long orderId);
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/PaymentRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/repository/PaymentRepository.java
@@ -1,12 +1,29 @@
 package com.goormgb.be.ordercore.payment.repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
 	Optional<Payment> findByOrderId(Long orderId);
+
+	@Query("""
+		SELECT p FROM Payment p
+		JOIN FETCH p.order o
+		WHERE p.paymentMethod = com.goormgb.be.ordercore.payment.enums.PaymentMethod.BANK_TRANSFER
+		  AND p.status = :status
+		  AND p.depositDeadline < :now
+		""")
+	List<Payment> findExpiredBankTransfers(
+		@Param("status") PaymentStatus status,
+		@Param("now") Instant now
+	);
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.ordercore.payment.service;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -50,6 +51,7 @@ public class PaymentService {
 	// 무통장 입금 기한: 다음날 23:59 KST, 경기 당일이면 경기 3시간 전
 	private static final Duration MATCH_DAY_DEADLINE_BEFORE = Duration.ofHours(3);
 
+	private final Clock clock;
 	private final OrderMetricsService orderMetricsService;
 	private final OrderRepository orderRepository;
 	private final OrderSeatRepository orderSeatRepository;
@@ -84,7 +86,7 @@ public class PaymentService {
 			if (request.paymentMethod() == PaymentMethod.BANK_TRANSFER) {
 				Instant matchDeadline = order.getMatch().getMatchAt().minus(MATCH_DAY_DEADLINE_BEFORE);
 				Preconditions.validate(
-					Instant.now().isBefore(matchDeadline),
+					clock.instant().isBefore(matchDeadline),
 					ErrorCode.BANK_TRANSFER_NOT_AVAILABLE
 				);
 			}
@@ -164,6 +166,10 @@ public class PaymentService {
 		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(orderId);
 		int updated = seatInfoQueryService.markSoldIfBlocked(matchSeatIds);
 		log.info("[PaymentService] 좌석 SOLD 전환 - orderId={}, count={}", orderId, updated);
+		if (updated != matchSeatIds.size()) {
+			log.warn("[PaymentService] 좌석 SOLD 전환 개수 불일치 - orderId={}, expected={}, updated={}",
+				orderId, matchSeatIds.size(), updated);
+		}
 	}
 
 	private Payment buildPayment(Order order, PaymentMethod method) {
@@ -193,7 +199,7 @@ public class PaymentService {
 	 * - 둘 중 빠른 시각을 적용
 	 */
 	private Instant calculateDepositDeadline(Instant matchAt) {
-		ZonedDateTime now = ZonedDateTime.now(KST);
+		ZonedDateTime now = clock.instant().atZone(KST);
 
 		// 일반 기한: 다음날 23:59 KST
 		Instant tomorrowEnd = now.toLocalDate().plusDays(1)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.goormgb.be.ordercore.payment.service;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +15,9 @@ import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.metrics.enums.PaymentMethodType;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
 import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
 import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
@@ -42,8 +45,10 @@ public class PaymentService {
 
 	private final OrderMetricsService orderMetricsService;
 	private final OrderRepository orderRepository;
+	private final OrderSeatRepository orderSeatRepository;
 	private final PaymentRepository paymentRepository;
 	private final CashReceiptRepository cashReceiptRepository;
+	private final SeatInfoQueryService seatInfoQueryService;
 
 	/**
 	 * 결제 처리.
@@ -76,6 +81,7 @@ public class PaymentService {
 				// 간편결제(토스페이, 카카오페이) 목업 즉시 완료
 				payment.complete();
 				order.updateStatus(OrderStatus.PAID);
+				markSeatsAsSold(orderId);
 				log.info("[PaymentService] 간편결제 완료(목업) - orderId={}, method={}", orderId, request.paymentMethod());
 
 				// 즉시 결제 완료 건수 증가 (간편결제 목업 성공)
@@ -138,6 +144,12 @@ public class PaymentService {
 		);
 
 		return order;
+	}
+
+	private void markSeatsAsSold(Long orderId) {
+		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(orderId);
+		int updated = seatInfoQueryService.markSoldIfBlocked(matchSeatIds);
+		log.info("[PaymentService] 좌석 SOLD 전환 - orderId={}, count={}", orderId, updated);
 	}
 
 	private Payment buildPayment(Order order, PaymentMethod method) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -2,7 +2,10 @@ package com.goormgb.be.ordercore.payment.service;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -37,11 +40,15 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class PaymentService {
 
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
 	// 무통장 입금 목업 계좌 정보
 	private static final String ACCOUNT_BANK = "신한은행";
 	private static final String ACCOUNT_NUMBER = "110-123-456789";
 	private static final String ACCOUNT_HOLDER = "주식회사 구름공방";
-	private static final int DEPOSIT_DEADLINE_DAYS = 3;
+
+	// 무통장 입금 기한: 다음날 23:59 KST, 경기 당일이면 경기 3시간 전
+	private static final Duration MATCH_DAY_DEADLINE_BEFORE = Duration.ofHours(3);
 
 	private final OrderMetricsService orderMetricsService;
 	private final OrderRepository orderRepository;
@@ -77,22 +84,21 @@ public class PaymentService {
 			Payment payment = buildPayment(order, request.paymentMethod());
 			paymentRepository.save(payment);
 
+			// 결제 수단과 무관하게 좌석을 SOLD로 전환 (스케줄러가 풀지 못하도록)
+			markSeatsAsSold(orderId);
+
 			if (request.paymentMethod() != PaymentMethod.BANK_TRANSFER) {
 				// 간편결제(토스페이, 카카오페이) 목업 즉시 완료
 				payment.complete();
 				order.updateStatus(OrderStatus.PAID);
-				markSeatsAsSold(orderId);
 				log.info("[PaymentService] 간편결제 완료(목업) - orderId={}, method={}", orderId, request.paymentMethod());
 
 				// 즉시 결제 완료 건수 증가 (간편결제 목업 성공)
 				switch (request.paymentMethod()) {
 					case KAKAO_PAY -> orderMetricsService.increasePaymentSuccess(PaymentMethodType.KAKAOPAY);
 					case TOSS_PAY -> orderMetricsService.increasePaymentSuccess(PaymentMethodType.TOSSPAY);
-					// 다른 간편결제 수단이 추가될 경우 여기에 case를 추가할 수 있습니다.
 					default -> log.warn("[PaymentService] 알 수 없는 간편결제 타입에 대한 성공 메트릭이 누락되었습니다. - method={}", request.paymentMethod());
 				}
-			} else {
-				log.info("[PaymentService] 무통장 입금 계좌 안내 - orderId={}", orderId);
 			}
 
 			return PaymentProcessResponse.of(payment);
@@ -154,7 +160,7 @@ public class PaymentService {
 
 	private Payment buildPayment(Order order, PaymentMethod method) {
 		if (method == PaymentMethod.BANK_TRANSFER) {
-			Instant depositDeadline = Instant.now().plus(DEPOSIT_DEADLINE_DAYS, ChronoUnit.DAYS);
+			Instant depositDeadline = calculateDepositDeadline(order.getMatch().getMatchAt());
 
 			return Payment.builder()
 				.order(order)
@@ -170,5 +176,27 @@ public class PaymentService {
 			.order(order)
 			.paymentMethod(method)
 			.build();
+	}
+
+	/**
+	 * 무통장 입금 기한을 계산한다.
+	 * - 일반: 다음날 23:59 KST
+	 * - 경기 당일 예매: 경기 시작 3시간 전
+	 * - 둘 중 빠른 시각을 적용
+	 */
+	private Instant calculateDepositDeadline(Instant matchAt) {
+		ZonedDateTime now = ZonedDateTime.now(KST);
+
+		// 일반 기한: 다음날 23:59 KST
+		Instant tomorrowEnd = now.toLocalDate().plusDays(1)
+			.atTime(LocalTime.of(23, 59))
+			.atZone(KST)
+			.toInstant();
+
+		// 경기 기한: 경기 시작 3시간 전
+		Instant matchDeadline = matchAt.minus(MATCH_DAY_DEADLINE_BEFORE);
+
+		// 둘 중 빠른 시각 적용
+		return tomorrowEnd.isBefore(matchDeadline) ? tomorrowEnd : matchDeadline;
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -81,6 +81,14 @@ public class PaymentService {
 				ErrorCode.PAYMENT_ALREADY_COMPLETED
 			);
 
+			if (request.paymentMethod() == PaymentMethod.BANK_TRANSFER) {
+				Instant matchDeadline = order.getMatch().getMatchAt().minus(MATCH_DAY_DEADLINE_BEFORE);
+				Preconditions.validate(
+					Instant.now().isBefore(matchDeadline),
+					ErrorCode.BANK_TRANSFER_NOT_AVAILABLE
+				);
+			}
+
 			Payment payment = buildPayment(order, request.paymentMethod());
 			paymentRepository.save(payment);
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -41,8 +41,10 @@ import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
 import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 import com.goormgb.be.user.entity.User;
@@ -54,11 +56,15 @@ class MyPageTicketServiceTest {
 	@Mock
 	private OrderRepository orderRepository;
 	@Mock
+	private OrderSeatRepository orderSeatRepository;
+	@Mock
 	private MyPageQueryService myPageQueryService;
 	@Mock
 	private CancellationFeePolicyRepository cancellationFeePolicyRepository;
 	@Mock
 	private QrTokenRepository qrTokenRepository;
+	@Mock
+	private SeatInfoQueryService seatInfoQueryService;
 
 	private MyPageTicketService myPageService;
 	private Clock clock;
@@ -68,9 +74,11 @@ class MyPageTicketServiceTest {
 		clock = Clock.fixed(Instant.parse("2026-03-26T00:00:00Z"), ZoneOffset.UTC);
 		myPageService = new MyPageTicketService(
 			orderRepository,
+			orderSeatRepository,
 			qrTokenRepository,
 			myPageQueryService,
 			cancellationFeePolicyRepository,
+			seatInfoQueryService,
 			clock
 		);
 	}
@@ -492,6 +500,7 @@ class MyPageTicketServiceTest {
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
 			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
 
@@ -521,6 +530,7 @@ class MyPageTicketServiceTest {
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
 			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
 
@@ -546,6 +556,7 @@ class MyPageTicketServiceTest {
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
 			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -73,31 +73,31 @@ class MyPageTicketServiceTest {
 	void setUp() {
 		clock = Clock.fixed(Instant.parse("2026-03-26T00:00:00Z"), ZoneOffset.UTC);
 		myPageService = new MyPageTicketService(
-			orderRepository,
-			orderSeatRepository,
-			qrTokenRepository,
-			myPageQueryService,
-			cancellationFeePolicyRepository,
-			seatInfoQueryService,
-			clock
+				orderRepository,
+				orderSeatRepository,
+				qrTokenRepository,
+				myPageQueryService,
+				cancellationFeePolicyRepository,
+				seatInfoQueryService,
+				clock
 		);
 	}
 
 	private void givenSummaryCounts(
-		Long userId,
-		long totalCount,
-		long upcomingCount,
-		long cancelProcessingCount,
-		long completedCount
+			Long userId,
+			long totalCount,
+			long upcomingCount,
+			long cancelProcessingCount,
+			long completedCount
 	) {
 		given(orderRepository.findMyPageSummaryCounts(eq(userId), any(), any(), any(), any(), any()))
-			.willReturn(new OrderMyPageSummaryCounts(
-				totalCount,
-				upcomingCount,
-				0L,
-				cancelProcessingCount,
-				completedCount
-			));
+				.willReturn(new OrderMyPageSummaryCounts(
+						totalCount,
+						upcomingCount,
+						0L,
+						cancelProcessingCount,
+						completedCount
+				));
 	}
 
 	@Nested
@@ -207,16 +207,16 @@ class MyPageTicketServiceTest {
 		@DisplayName("size가 10을 초과하면 INVALID_PAGE_SIZE 예외가 발생한다")
 		void getTickets_size초과_예외() {
 			assertThatThrownBy(() -> myPageService.getTickets(1L, "BOOKED", 0, 11))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_PAGE_SIZE.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.INVALID_PAGE_SIZE.getMessage());
 		}
 
 		@Test
 		@DisplayName("유효하지 않은 탭 값이면 INVALID_TICKET_TAB 예외가 발생한다")
 		void getTickets_잘못된탭_예외() {
 			assertThatThrownBy(() -> myPageService.getTickets(1L, "INVALID_TAB", 0, 10))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_TICKET_TAB.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.INVALID_TICKET_TAB.getMessage());
 		}
 
 		@Test
@@ -249,12 +249,12 @@ class MyPageTicketServiceTest {
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.PAID);
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(1)
-				.daysBeforeMatchMax(6)
-				.cancellable(true)
-				.ticketFeeRate(new BigDecimal("0.100"))
-				.bookingFeeRefundable(false)
-				.build();
+					.daysBeforeMatchMin(1)
+					.daysBeforeMatchMax(6)
+					.cancellable(true)
+					.ticketFeeRate(new BigDecimal("0.100"))
+					.bookingFeeRefundable(false)
+					.build();
 
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
@@ -278,18 +278,18 @@ class MyPageTicketServiceTest {
 			Long userId = 1L;
 			Long ticketId = 102L;
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId,
-				OrderStatus.PAYMENT_PENDING);
+					OrderStatus.PAYMENT_PENDING);
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(7)
-				.daysBeforeMatchMax(null)
-				.cancellable(true)
-				.ticketFeeRate(BigDecimal.ZERO)
-				.bookingFeeRefundable(true)
-				.build();
+					.daysBeforeMatchMin(7)
+					.daysBeforeMatchMax(null)
+					.cancellable(true)
+					.ticketFeeRate(BigDecimal.ZERO)
+					.bookingFeeRefundable(true)
+					.build();
 
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
-				.willReturn(MyPageFixture.createTicketSeatDetailRows());
+					.willReturn(MyPageFixture.createTicketSeatDetailRows());
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 
 			MyPageTicketDetailResponse response = myPageService.getTicketDetail(userId, ticketId);
@@ -308,16 +308,16 @@ class MyPageTicketServiceTest {
 			Long ticketId = 103L;
 			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(ticketId, OrderStatus.CANCELLED);
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(1)
-				.daysBeforeMatchMax(6)
-				.cancellable(true)
-				.ticketFeeRate(new BigDecimal("0.100"))
-				.bookingFeeRefundable(false)
-				.build();
+					.daysBeforeMatchMin(1)
+					.daysBeforeMatchMax(6)
+					.cancellable(true)
+					.ticketFeeRate(new BigDecimal("0.100"))
+					.bookingFeeRefundable(false)
+					.build();
 
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
-				.willReturn(MyPageFixture.createTicketSeatDetailRows());
+					.willReturn(MyPageFixture.createTicketSeatDetailRows());
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 
 			MyPageTicketDetailResponse response = myPageService.getTicketDetail(userId, ticketId);
@@ -334,8 +334,8 @@ class MyPageTicketServiceTest {
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -346,8 +346,8 @@ class MyPageTicketServiceTest {
 			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
 
 			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 	}
 
@@ -360,12 +360,12 @@ class MyPageTicketServiceTest {
 			var homeClub = OrderFixture.createHomeClub(stadium);
 			var awayClub = OrderFixture.createAwayClub(stadium);
 			Match match = Match.builder()
-				.matchAt(matchAt)
-				.homeClub(homeClub)
-				.awayClub(awayClub)
-				.stadium(stadium)
-				.saleStatus(SaleStatus.ON_SALE)
-				.build();
+					.matchAt(matchAt)
+					.homeClub(homeClub)
+					.awayClub(awayClub)
+					.stadium(stadium)
+					.saleStatus(SaleStatus.ON_SALE)
+					.build();
 			ReflectionTestUtils.setField(match, "id", 55L);
 
 			User user = OrderFixture.createUserWithId(userId);
@@ -381,16 +381,16 @@ class MyPageTicketServiceTest {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID,
-				Instant.now(clock).plus(10, ChronoUnit.MINUTES));
+					Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 			QrToken existing = QrToken.builder()
-				.qrToken("existing-qr-token")
-				.expiresAt(Instant.now(clock).plus(2, ChronoUnit.MINUTES))
-				.build();
+					.qrToken("existing-qr-token")
+					.expiresAt(Instant.now(clock).plus(2, ChronoUnit.MINUTES))
+					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(qrTokenRepository.findByOrderIdAndExpiresAtAfter(eq(ticketId), any())).willReturn(
-				Optional.of(existing));
+					Optional.of(existing));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
 
 			MyPageTicketQrResponse response = myPageService.getTicketEntryQr(userId, ticketId);
@@ -406,7 +406,7 @@ class MyPageTicketServiceTest {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID,
-				Instant.now(clock).plus(10, ChronoUnit.MINUTES));
+					Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
@@ -427,12 +427,12 @@ class MyPageTicketServiceTest {
 		void getTicketEntryQr_notPaid_예외() {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.PAYMENT_PENDING,
-				Instant.now(clock).plus(10, ChronoUnit.MINUTES));
+					Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
 		}
 
 		@Test
@@ -443,8 +443,8 @@ class MyPageTicketServiceTest {
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ENTRY_QR_NOT_AVAILABLE_YET.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ENTRY_QR_NOT_AVAILABLE_YET.getMessage());
 		}
 
 		@Test
@@ -455,8 +455,8 @@ class MyPageTicketServiceTest {
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ENTRY_QR_MATCH_STARTED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ENTRY_QR_MATCH_STARTED.getMessage());
 		}
 	}
 
@@ -469,12 +469,12 @@ class MyPageTicketServiceTest {
 			var homeClub = OrderFixture.createHomeClub(stadium);
 			var awayClub = OrderFixture.createAwayClub(stadium);
 			Match match = Match.builder()
-				.matchAt(matchAt)
-				.homeClub(homeClub)
-				.awayClub(awayClub)
-				.stadium(stadium)
-				.saleStatus(SaleStatus.ON_SALE)
-				.build();
+					.matchAt(matchAt)
+					.homeClub(homeClub)
+					.awayClub(awayClub)
+					.stadium(stadium)
+					.saleStatus(SaleStatus.ON_SALE)
+					.build();
 			ReflectionTestUtils.setField(match, "id", 55L);
 
 			User user = OrderFixture.createUserWithId(userId);
@@ -491,12 +491,12 @@ class MyPageTicketServiceTest {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(1)
-				.daysBeforeMatchMax(6)
-				.cancellable(true)
-				.ticketFeeRate(new BigDecimal("0.100"))
-				.bookingFeeRefundable(false)
-				.build();
+					.daysBeforeMatchMin(1)
+					.daysBeforeMatchMax(6)
+					.cancellable(true)
+					.ticketFeeRate(new BigDecimal("0.100"))
+					.bookingFeeRefundable(false)
+					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -521,12 +521,12 @@ class MyPageTicketServiceTest {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(10, ChronoUnit.DAYS));
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(7)
-				.daysBeforeMatchMax(null)
-				.cancellable(true)
-				.ticketFeeRate(BigDecimal.ZERO)
-				.bookingFeeRefundable(true)
-				.build();
+					.daysBeforeMatchMin(7)
+					.daysBeforeMatchMax(null)
+					.cancellable(true)
+					.ticketFeeRate(BigDecimal.ZERO)
+					.bookingFeeRefundable(true)
+					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -547,12 +547,12 @@ class MyPageTicketServiceTest {
 			ReflectionTestUtils.setField(order, "createdAt", Instant.now(clock).minus(1, ChronoUnit.DAYS));
 
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(7)
-				.daysBeforeMatchMax(null)
-				.cancellable(true)
-				.ticketFeeRate(BigDecimal.ZERO)
-				.bookingFeeRefundable(true)
-				.build();
+					.daysBeforeMatchMin(7)
+					.daysBeforeMatchMax(null)
+					.cancellable(true)
+					.ticketFeeRate(BigDecimal.ZERO)
+					.bookingFeeRefundable(true)
+					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -570,19 +570,19 @@ class MyPageTicketServiceTest {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now(clock).plus(1, ChronoUnit.HOURS));
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
-				.daysBeforeMatchMin(0)
-				.daysBeforeMatchMax(0)
-				.cancellable(false)
-				.ticketFeeRate(BigDecimal.ZERO)
-				.bookingFeeRefundable(false)
-				.build();
+					.daysBeforeMatchMin(0)
+					.daysBeforeMatchMax(0)
+					.cancellable(false)
+					.ticketFeeRate(BigDecimal.ZERO)
+					.bookingFeeRefundable(false)
+					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.TICKET_CANCEL_NOT_ALLOWED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.TICKET_CANCEL_NOT_ALLOWED.getMessage());
 		}
 
 		@Test
@@ -593,8 +593,8 @@ class MyPageTicketServiceTest {
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
 		}
 
 		@Test
@@ -605,8 +605,33 @@ class MyPageTicketServiceTest {
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+		}
+
+		@Test
+		@DisplayName("취소 시 좌석을 SOLD에서 AVAILABLE로 복원된다")
+		void requestTicketCancel_좌석_AVAILABLE_복원() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			List<Long> matchSeatIds = List.of(101L, 102L);
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+					.daysBeforeMatchMin(1)
+					.daysBeforeMatchMax(6)
+					.cancellable(true)
+					.ticketFeeRate(new BigDecimal("0.100"))
+					.bookingFeeRefundable(false)
+					.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(matchSeatIds);
+			given(seatInfoQueryService.markAvailableIfSold(matchSeatIds)).willReturn(2);
+
+			myPageService.requestTicketCancel(userId, ticketId);
+
+			then(seatInfoQueryService).should().markAvailableIfSold(matchSeatIds);
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -22,7 +22,9 @@ import com.goormgb.be.ordercore.fixture.payment.PaymentFixture;
 import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
 import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
 import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
@@ -43,18 +45,22 @@ class PaymentServiceTest {
 	@Mock
 	private OrderRepository orderRepository;
 	@Mock
+	private OrderSeatRepository orderSeatRepository;
+	@Mock
 	private PaymentRepository paymentRepository;
 	@Mock
 	private CashReceiptRepository cashReceiptRepository;
 	@Mock
 	private OrderMetricsService orderMetricsService;
+	@Mock
+	private SeatInfoQueryService seatInfoQueryService;
 
 	private PaymentService paymentService;
 
 	@BeforeEach
 	void setUp() {
-		paymentService = new PaymentService(orderMetricsService, orderRepository, paymentRepository,
-			cashReceiptRepository);
+		paymentService = new PaymentService(orderMetricsService, orderRepository, orderSeatRepository,
+			paymentRepository, cashReceiptRepository, seatInfoQueryService);
 	}
 
 	private Order createOrderWithUser(Long orderId, Long userId) {
@@ -79,6 +85,7 @@ class PaymentServiceTest {
 			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(java.util.List.of());
 
 			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
 
@@ -100,6 +107,7 @@ class PaymentServiceTest {
 			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(java.util.List.of());
 
 			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -4,6 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -56,11 +61,14 @@ class PaymentServiceTest {
 	private SeatInfoQueryService seatInfoQueryService;
 
 	private PaymentService paymentService;
+	private Clock clock;
 
 	@BeforeEach
 	void setUp() {
-		paymentService = new PaymentService(orderMetricsService, orderRepository, orderSeatRepository,
-			paymentRepository, cashReceiptRepository, seatInfoQueryService);
+		// 경기(2026-03-11 09:30 UTC)보다 이전 시점으로 고정
+		clock = Clock.fixed(Instant.parse("2026-03-04T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+		paymentService = new PaymentService(clock, orderMetricsService, orderRepository, orderSeatRepository,
+				paymentRepository, cashReceiptRepository, seatInfoQueryService);
 	}
 
 	private Order createOrderWithUser(Long orderId, Long userId) {
@@ -128,6 +136,7 @@ class PaymentServiceTest {
 			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(List.of());
 
 			PaymentProcessResponse response = paymentService.processPayment(userId, orderId, request);
 
@@ -142,15 +151,61 @@ class PaymentServiceTest {
 		}
 
 		@Test
+		@DisplayName("결제 시 좌석을 BLOCKED에서 SOLD로 전환된다")
+		void processPayment_좌석_SOLD_전환() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			List<Long> matchSeatIds = List.of(101L, 102L);
+			PaymentProcessRequest request = PaymentFixture.createTossPayRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(matchSeatIds);
+			given(seatInfoQueryService.markSoldIfBlocked(matchSeatIds)).willReturn(2);
+
+			paymentService.processPayment(userId, orderId, request);
+
+			then(seatInfoQueryService).should().markSoldIfBlocked(matchSeatIds);
+		}
+
+		@Test
+		@DisplayName("경기 시작 3시간 이내에 무통장 입금을 선택하면 BANK_TRANSFER_NOT_AVAILABLE 예외가 발생한다")
+		void processPayment_무통장입금_3시간이내_차단() {
+			Long userId = 1L;
+			Long orderId = 1L;
+
+			// 경기 시작 2시간 전으로 Clock 고정
+			Instant matchAt = Instant.parse("2026-03-11T09:30:00Z");
+			Clock nearMatchClock = Clock.fixed(matchAt.minus(Duration.ofHours(2)), ZoneId.of("Asia/Seoul"));
+			PaymentService nearMatchPaymentService = new PaymentService(nearMatchClock, orderMetricsService,
+					orderRepository, orderSeatRepository, paymentRepository, cashReceiptRepository,
+					seatInfoQueryService);
+
+			Order order = createOrderWithUser(orderId, userId);
+			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+
+			assertThatThrownBy(
+					() -> nearMatchPaymentService.processPayment(userId, orderId, request)
+			)
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.BANK_TRANSFER_NOT_AVAILABLE.getMessage());
+		}
+
+		@Test
 		@DisplayName("주문이 없으면 ORDER_NOT_FOUND 예외가 발생한다")
 		void processPayment_주문_미발견_예외() {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -163,10 +218,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -179,10 +234,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 
 		@Test
@@ -197,10 +252,10 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(existingPayment));
 
 			assertThatThrownBy(
-				() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
+					() -> paymentService.processPayment(userId, orderId, PaymentFixture.createTossPayRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_ALREADY_COMPLETED.getMessage());
 		}
 	}
 
@@ -260,11 +315,11 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(userId, orderId,
-					PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(userId, orderId,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.PAYMENT_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -281,11 +336,11 @@ class PaymentServiceTest {
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.of(existing));
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(userId, orderId,
-					PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(userId, orderId,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.CASH_RECEIPT_ALREADY_EXISTS.getMessage());
 		}
 
 		@Test
@@ -298,11 +353,11 @@ class PaymentServiceTest {
 			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(attackerId, 1L,
-					PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(attackerId, 1L,
+							PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
 		}
 
 		@Test
@@ -311,10 +366,10 @@ class PaymentServiceTest {
 			given(orderRepository.findById(99L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
-				() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
+					() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())
 			)
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+					.isInstanceOf(CustomException.class)
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -114,6 +114,7 @@ public enum ErrorCode {
 	PAYMENT_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 주문입니다."),
 	CASH_RECEIPT_ALREADY_EXISTS(HttpStatus.CONFLICT, "현금영수증이 이미 신청되었습니다."),
 	INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "지원하지 않는 결제 수단입니다."),
+	BANK_TRANSFER_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "경기 시작 3시간 이내에는 무통장 입금을 이용할 수 없습니다."),
 
 	// Mypage
 	INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "size는 최대 10까지 허용됩니다."),


### PR DESCRIPTION
 ## 🔧 작업 내용
 - 결제 완료 후 `match_seat.sale_status`가 `BLOCKED`로 유지되어, 스케줄러(SeatHoldCleanupScheduler)가 Hold 만료 시 결제된 좌석을 `AVAILABLE`로 복원하는 버그 수정
- `MatchSeat.markSold()` 메서드가 엔티티에 정의만 되어 있고 호출처가 0곳이었음
- 결제 확정 시 `BLOCKED → SOLD`, 주문 취소 시 `SOLD → AVAILABLE` 전환 추가

### 버그 재현 흐름 (수정 전)
1. 유저가 좌석 선점 → BLOCKED + SeatHold 생성 (TTL 5분)
2. 유저가 결제 완료 → Order PAID, 좌석은 여전히 BLOCKED
3. 5분 후 스케줄러 → 만료된 Hold 정리 → BLOCKED → AVAILABLE 복원
4. 다른 유저가 결제된 좌석 선택 가능 → 중복 결제 시도 → 400 에러

### 수정 후 흐름
선점:  AVAILABLE → BLOCKED
결제:  BLOCKED → SOLD        ← 추가
취소:  SOLD → AVAILABLE      ← 추가
스케줄러: WHERE sale_status = BLOCKED 조건이라 SOLD 좌석은 건드리지 않음

## 🧩 구현 상세
### 1. SeatInfoQueryService — JDBC UPDATE 메서드 추가
기존 Order-Core → Seat 모듈 간 DB 접근 패턴(Jdbc템플릿)을 그대로 사용. ( 추후 카프카로 바뀔예정)
별도 내부 API 없이 직접 UPDATE 쿼리로 좌석 상태를 변경.

- `markSoldIfBlocked()`: `WHERE sale_status = 'BLOCKED'` 조건부 UPDAT
- `markAvailableIfSold()`: `WHERE sale_status = 'SOLD'` 조건부 UPDATE

### 2. OrderSeatRepository — matchSeatId 프로젝션 쿼리 추가

`findByOrderId()`로 엔티티 전체를 로드 후 stream으로 matchSeatId를 추출하는 대신, `findMatchSeatIdsByOrderId()`로 필요한 컬럼(match_seat_id)만 직접 조회.

### 3. PaymentService — 결제 확정 시 SOLD 전환
`order.updateStatus(OrderStatus.PAID)` 직후 `markSeatsAsSold()` 호출. 간편결제(토스페이/카카오페이) 확정 시에만 적용. 무통장입금은 입금 확인 후 별도 처리 필요.

### 4. MyPageTicketService — 주문 취소 시 AVAILABLE 복원
`order.cancel()` 직후 해당 주문의 좌석을 `SOLD → AVAILABLE`로 복원.

### 📌 관련 Jira Issue
- GRGB-318

## 🧪 테스트 방법
- `./gradlew :Order-Core:build` 빌드 및 테스트 통과 확인
- 일반 좌석 선점 → 결제 완료 → DB에서 `match_seat.sale_status = 'SOLD'` 확인
- 결제 완료 후 5분 대기 → 스케줄러 실행 후에도 좌석 SOLD 유지 확인
- 주문 취소 → `match_seat.sale_status = 'AVAILABLE'` 복원 확인

## ❗ 참고 사항
- 무통장입금 기한(다음날 23:59 KST / 경기 3시간 전 중 빠른 시각) 내 미입금 시 BankTransferExpireScheduler가 자동 취소 처리. PaymentRepository.findExpiredBankTransfers() 쿼리로 만료 대상을 조회하여 주문 취소 및 좌석 AVAILABLE 복원 수행 