### PR TITLE
fead(order): 누락된 무통장 입금 기한 만료 시 자동 취소 스케줄러 추가

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferExpireScheduler.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferExpireScheduler.java
@@ -1,0 +1,79 @@
+package com.goormgb.be.ordercore.payment.scheduler;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
+import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
+import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 무통장 입금 기한 만료 시 자동 취소 스케줄러.
+ *
+ * <p>입금 기한(depositDeadline)이 지났는데 여전히 PENDING 상태인 무통장 입금 건을 찾아
+ * 주문을 자동 취소하고 좌석을 AVAILABLE로 복원한다.</p>
+ *
+ * <h3>입금 기한 규칙</h3>
+ * <ul>
+ *   <li>일반: 다음날 23:59 KST</li>
+ *   <li>경기 당일 예매: 경기 시작 3시간 전</li>
+ *   <li>둘 중 빠른 시각 적용</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankTransferExpireScheduler {
+
+	private final PaymentRepository paymentRepository;
+	private final OrderSeatRepository orderSeatRepository;
+	private final SeatInfoQueryService seatInfoQueryService;
+
+	/**
+	 * 5분마다 만료된 무통장 입금 건을 조회하여 자동 취소한다.
+	 */
+	@Scheduled(fixedDelay = 300_000)
+	@Transactional
+	public void cancelExpiredBankTransfers() {
+		Instant now = Instant.now();
+		List<Payment> expiredPayments = paymentRepository.findExpiredBankTransfers(PaymentStatus.PENDING, now);
+
+		if (expiredPayments.isEmpty()) {
+			return;
+		}
+
+		int cancelledCount = 0;
+		for (Payment payment : expiredPayments) {
+			Order order = payment.getOrder();
+
+			if (order.getStatus() != OrderStatus.PAYMENT_PENDING) {
+				continue;
+			}
+
+			// 주문 취소 + 결제 취소
+			order.updateStatus(OrderStatus.CANCELLED);
+			payment.cancel();
+
+			// 좌석 SOLD → AVAILABLE 복원
+			List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(order.getId());
+			seatInfoQueryService.markAvailableIfSold(matchSeatIds);
+
+			cancelledCount++;
+		}
+
+		if (cancelledCount > 0) {
+			log.info("[BankTransferExpireScheduler] 무통장 입금 기한 만료 자동 취소: {}건", cancelledCount);
+		}
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferExpireScheduler.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferExpireScheduler.java
@@ -5,12 +5,7 @@ import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.goormgb.be.ordercore.order.entity.Order;
-import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
-import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.payment.entity.Payment;
 import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
 import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
@@ -23,6 +18,9 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>입금 기한(depositDeadline)이 지났는데 여전히 PENDING 상태인 무통장 입금 건을 찾아
  * 주문을 자동 취소하고 좌석을 AVAILABLE로 복원한다.</p>
+ *
+ * <p>각 결제 취소는 {@link BankTransferCancelService}에서 개별 트랜잭션으로 처리되므로,
+ * 한 건의 실패가 다른 건에 영향을 주지 않는다.</p>
  *
  * <h3>입금 기한 규칙</h3>
  * <ul>
@@ -37,14 +35,12 @@ import lombok.extern.slf4j.Slf4j;
 public class BankTransferExpireScheduler {
 
 	private final PaymentRepository paymentRepository;
-	private final OrderSeatRepository orderSeatRepository;
-	private final SeatInfoQueryService seatInfoQueryService;
+	private final BankTransferCancelService bankTransferCancelService;
 
 	/**
 	 * 5분마다 만료된 무통장 입금 건을 조회하여 자동 취소한다.
 	 */
 	@Scheduled(fixedDelay = 300_000)
-	@Transactional
 	public void cancelExpiredBankTransfers() {
 		Instant now = Instant.now();
 		List<Payment> expiredPayments = paymentRepository.findExpiredBankTransfers(PaymentStatus.PENDING, now);
@@ -54,26 +50,26 @@ public class BankTransferExpireScheduler {
 		}
 
 		int cancelledCount = 0;
+		int failedCount = 0;
+
 		for (Payment payment : expiredPayments) {
-			Order order = payment.getOrder();
-
-			if (order.getStatus() != OrderStatus.PAYMENT_PENDING) {
-				continue;
+			try {
+				boolean cancelled = bankTransferCancelService.cancelSinglePayment(payment);
+				if (cancelled) {
+					cancelledCount++;
+				}
+			} catch (Exception e) {
+				failedCount++;
+				log.error("[BankTransferExpireScheduler] 자동 취소 실패 - paymentId={}: {}",
+						payment.getId(), e.getMessage(), e);
 			}
-
-			// 주문 취소 + 결제 취소
-			order.updateStatus(OrderStatus.CANCELLED);
-			payment.cancel();
-
-			// 좌석 SOLD → AVAILABLE 복원
-			List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(order.getId());
-			seatInfoQueryService.markAvailableIfSold(matchSeatIds);
-
-			cancelledCount++;
 		}
 
 		if (cancelledCount > 0) {
 			log.info("[BankTransferExpireScheduler] 무통장 입금 기한 만료 자동 취소: {}건", cancelledCount);
+		}
+		if (failedCount > 0) {
+			log.warn("[BankTransferExpireScheduler] 자동 취소 실패: {}건", failedCount);
 		}
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 입금 기한(depositDeadline)이 지난 PENDING 상태 무통장 입금 건을 5분 주기로 자동 취소
- 주문 상태 CANCELLED 전환 + 결제 CANCEL 처리 + 좌석 AVAILABLE 복원

## 🧩 구현 상세
- `BankTransferExpireScheduler`: 5분마다 만료된 무통장 입금 건 조회 → 자동 취소
- 입금 기한 규칙: 일반(다음날 23:59 KST) vs 경기 당일(경기 시작 3시간 전) 중 빠른 시각
- PAYMENT_PENDING 상태인 주문만 취소 대상 (이미 결제 완료된 건은 스킵)
- 좌석 복원은 기존 `SeatInfoQueryService.markAvailableIfSold()` 재사용

 ## 🧪 테스트 방법
- 무통장 입금 주문 생성 → 입금 기한 경과 → 스케줄러 실행 → 주문 CANCELLED 확인
- 좌석이 AVAILABLE로 복원되는지 확인
<img width="1394" height="606" alt="image" src="https://github.com/user-attachments/assets/f62f4427-0b27-4f9f-aeb6-3b405cafa54f" />

## ❗ 참고 사항
- `@Scheduled(fixedDelay = 300_000)` — 5분 간격 실행
- 좌석 복원은 `markAvailableIfSold()`로 SOLD 상태만 복원 (BLOCKED 좌석은 건드리지 않음)
