### PR TITLE
 fix(order): 미결제 주문 이탈 후 동일 좌석 재주문 시 400 에러 수정 [GRGB-320]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
@@ -131,7 +131,7 @@ public class SeatInfoQueryService {
 
 	/**
 	 * matchSeatId로 이미 유효한 주문이 존재하는 좌석인지 확인한다.
-	 * 미결제(PAYMENT_PENDING), 취소 완료(CANCELLED), 환불 완료(REFUND_COMPLETED) 주문은 제외한다.
+	 * 결제 완료(PAID), 취소 요청(CANCEL_REQUESTED), 환불 처리 중(REFUND_PROCESSING) 상태만 유효 주문으로 간주한다.
 	 */
 	public boolean isAlreadyOrdered(Long matchSeatId) {
 		String sql = """
@@ -139,7 +139,7 @@ public class SeatInfoQueryService {
 				FROM order_seats os
 				JOIN orders o ON os.order_id = o.id
 				WHERE os.match_seat_id = :matchSeatId
-				  AND o.status NOT IN ('PAYMENT_PENDING', 'CANCELLED', 'REFUND_COMPLETED')
+				  AND o.status IN ('PAID', 'CANCEL_REQUESTED', 'REFUND_PROCESSING')
 				""";
 
 		var params = Map.of("matchSeatId", matchSeatId);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
@@ -130,13 +130,16 @@ public class SeatInfoQueryService {
 	}
 
 	/**
-	 * matchSeatId로 이미 주문된 좌석인지 확인한다.
+	 * matchSeatId로 이미 유효한 주문이 존재하는 좌석인지 확인한다.
+	 * 미결제(PAYMENT_PENDING), 취소 완료(CANCELLED), 환불 완료(REFUND_COMPLETED) 주문은 제외한다.
 	 */
 	public boolean isAlreadyOrdered(Long matchSeatId) {
 		String sql = """
 				SELECT COUNT(*)
-				FROM order_seats
-				WHERE match_seat_id = :matchSeatId
+				FROM order_seats os
+				JOIN orders o ON os.order_id = o.id
+				WHERE os.match_seat_id = :matchSeatId
+				  AND o.status NOT IN ('PAYMENT_PENDING', 'CANCELLED', 'REFUND_COMPLETED')
 				""";
 
 		var params = Map.of("matchSeatId", matchSeatId);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -49,6 +49,18 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		@Param("now") Instant now
 	);
 
+	@Query("""
+		SELECT o FROM Order o
+		WHERE o.user.id = :userId
+		  AND o.match.id = :matchId
+		  AND o.status = :status
+		""")
+	List<Order> findAllByUserIdAndMatchIdAndStatus(
+		@Param("userId") Long userId,
+		@Param("matchId") Long matchId,
+		@Param("status") OrderStatus status
+	);
+
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("""
 		SELECT o

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -49,16 +50,19 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		@Param("now") Instant now
 	);
 
+	@Modifying(clearAutomatically = true)
 	@Query("""
-		SELECT o FROM Order o
+		UPDATE Order o
+		SET o.status = :newStatus
 		WHERE o.user.id = :userId
 		  AND o.match.id = :matchId
-		  AND o.status = :status
+		  AND o.status = :oldStatus
 		""")
-	List<Order> findAllByUserIdAndMatchIdAndStatus(
+	int bulkUpdateStatus(
 		@Param("userId") Long userId,
 		@Param("matchId") Long matchId,
-		@Param("status") OrderStatus status
+		@Param("oldStatus") OrderStatus oldStatus,
+		@Param("newStatus") OrderStatus newStatus
 	);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -19,6 +19,7 @@ import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
 import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.entity.OrderSeat;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
@@ -76,6 +77,8 @@ public class OrderService {
 	public OrderCreateResponse createOrder(Long userId, OrderCreateRequest request) {
 		Preconditions.validate(!request.matchSeatIds().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
 
+		cancelExistingPendingOrders(userId, request.matchId());
+
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Match match = matchRepository.findDetailByIdOrThrow(request.matchId());
 
@@ -124,6 +127,26 @@ public class OrderService {
 				order.getId(), userId, orderSeats.size(), request.totalPrice());
 
 		return OrderCreateResponse.of(order, orderSeats.size());
+	}
+
+	/**
+	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 자동 취소한다.
+	 * 결제 없이 이탈한 유저가 동일 좌석으로 재주문할 수 있도록 이전 주문을 정리한다.
+	 */
+	private void cancelExistingPendingOrders(Long userId, Long matchId) {
+		List<Order> pendingOrders = orderRepository
+				.findAllByUserIdAndMatchIdAndStatus(userId, matchId, OrderStatus.PAYMENT_PENDING);
+
+		if (pendingOrders.isEmpty()) {
+			return;
+		}
+
+		for (Order order : pendingOrders) {
+			order.updateStatus(OrderStatus.CANCELLED);
+		}
+
+		log.info("[OrderService] 미결제 주문 {}건 자동 취소 - userId={}, matchId={}",
+				pendingOrders.size(), userId, matchId);
 	}
 
 	private String determineDayType(Instant matchAt) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -130,23 +130,17 @@ public class OrderService {
 	}
 
 	/**
-	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 자동 취소한다.
+	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 벌크 UPDATE로 자동 취소한다.
 	 * 결제 없이 이탈한 유저가 동일 좌석으로 재주문할 수 있도록 이전 주문을 정리한다.
 	 */
 	private void cancelExistingPendingOrders(Long userId, Long matchId) {
-		List<Order> pendingOrders = orderRepository
-				.findAllByUserIdAndMatchIdAndStatus(userId, matchId, OrderStatus.PAYMENT_PENDING);
+		int cancelledCount = orderRepository.bulkUpdateStatus(
+				userId, matchId, OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED);
 
-		if (pendingOrders.isEmpty()) {
-			return;
+		if (cancelledCount > 0) {
+			log.info("[OrderService] 미결제 주문 {}건 자동 취소 - userId={}, matchId={}",
+					cancelledCount, userId, matchId);
 		}
-
-		for (Order order : pendingOrders) {
-			order.updateStatus(OrderStatus.CANCELLED);
-		}
-
-		log.info("[OrderService] 미결제 주문 {}건 자동 취소 - userId={}, matchId={}",
-				pendingOrders.size(), userId, matchId);
 	}
 
 	private String determineDayType(Instant matchAt) {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
@@ -204,6 +204,11 @@ class OrderServiceTest {
 			});
 		}
 
+		private void stubNoPendingOrders() {
+			given(orderRepository.findAllByUserIdAndMatchIdAndStatus(anyLong(), anyLong(), eq(OrderStatus.PAYMENT_PENDING)))
+				.willReturn(Collections.emptyList());
+		}
+
 		@Test
 		@DisplayName("유효한 단일 좌석 주문 시 totalAmount = 티켓가격 + 2000이다")
 		void createOrder_단일좌석_totalAmount_계산() {
@@ -213,6 +218,7 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -248,6 +254,7 @@ class OrderServiceTest {
 				"홍길동", "hong@test.com", "010-1234-5678", "990831"
 			);
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L, 102L)))
@@ -277,6 +284,7 @@ class OrderServiceTest {
 				"홍길동", "hong@test.com", "010-1234-5678", "990831"
 			);
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(2L)).willReturn(weekendMatch);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -298,6 +306,7 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -330,6 +339,7 @@ class OrderServiceTest {
 			Long userId = 999L;
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND))
 				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -346,6 +356,7 @@ class OrderServiceTest {
 			Match match = OrderFixture.createWeekdayMatch();
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(Collections.emptyList());
@@ -364,6 +375,7 @@ class OrderServiceTest {
 			SeatHoldInfo expiredHold = OrderFixture.createExpiredSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(expiredHold));
@@ -382,6 +394,7 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -401,6 +414,7 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
+			stubNoPendingOrders();
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -410,6 +424,59 @@ class OrderServiceTest {
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
 				.isInstanceOf(CustomException.class)
 				.hasMessage(ErrorCode.PRICE_POLICY_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("미결제 주문이 존재하면 자동 취소 후 재주문에 성공한다")
+		void createOrder_미결제_주문_자동취소_후_재주문_성공() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			Order pendingOrder = Order.builder()
+				.user(user).match(match).totalAmount(24000)
+				.ordererName("홍길동").ordererEmail("hong@test.com")
+				.ordererPhone("010-1234-5678").ordererBirthDate("990831")
+				.build();
+
+			given(orderRepository.findAllByUserIdAndMatchIdAndStatus(userId, 1L, OrderStatus.PAYMENT_PENDING))
+				.willReturn(List.of(pendingOrder));
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			stubSaveOrder(1L);
+
+			OrderCreateResponse response = orderService.createOrder(userId, request);
+
+			assertThat(pendingOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+		}
+
+		@Test
+		@DisplayName("미결제 주문이 없으면 취소 없이 바로 주문이 생성된다")
+		void createOrder_미결제_주문_없음_정상_생성() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			stubNoPendingOrders();
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			stubSaveOrder(1L);
+
+			OrderCreateResponse response = orderService.createOrder(userId, request);
+
+			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+			then(orderRepository).should().findAllByUserIdAndMatchIdAndStatus(userId, 1L, OrderStatus.PAYMENT_PENDING);
 		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
@@ -205,8 +205,9 @@ class OrderServiceTest {
 		}
 
 		private void stubNoPendingOrders() {
-			given(orderRepository.findAllByUserIdAndMatchIdAndStatus(anyLong(), anyLong(), eq(OrderStatus.PAYMENT_PENDING)))
-				.willReturn(Collections.emptyList());
+			given(orderRepository.bulkUpdateStatus(anyLong(), anyLong(),
+				eq(OrderStatus.PAYMENT_PENDING), eq(OrderStatus.CANCELLED)))
+				.willReturn(0);
 		}
 
 		@Test
@@ -427,7 +428,7 @@ class OrderServiceTest {
 		}
 
 		@Test
-		@DisplayName("미결제 주문이 존재하면 자동 취소 후 재주문에 성공한다")
+		@DisplayName("미결제 주문이 존재하면 벌크 취소 후 재주문에 성공한다")
 		void createOrder_미결제_주문_자동취소_후_재주문_성공() {
 			Long userId = 1L;
 			User user = OrderFixture.createUser();
@@ -435,14 +436,9 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
-			Order pendingOrder = Order.builder()
-				.user(user).match(match).totalAmount(24000)
-				.ordererName("홍길동").ordererEmail("hong@test.com")
-				.ordererPhone("010-1234-5678").ordererBirthDate("990831")
-				.build();
-
-			given(orderRepository.findAllByUserIdAndMatchIdAndStatus(userId, 1L, OrderStatus.PAYMENT_PENDING))
-				.willReturn(List.of(pendingOrder));
+			given(orderRepository.bulkUpdateStatus(userId, 1L,
+				OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED))
+				.willReturn(2);
 			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
 			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
@@ -452,8 +448,9 @@ class OrderServiceTest {
 
 			OrderCreateResponse response = orderService.createOrder(userId, request);
 
-			assertThat(pendingOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+			then(orderRepository).should().bulkUpdateStatus(userId, 1L,
+				OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED);
 		}
 
 		@Test
@@ -476,7 +473,8 @@ class OrderServiceTest {
 			OrderCreateResponse response = orderService.createOrder(userId, request);
 
 			assertThat(response.status()).isEqualTo(OrderStatus.PAYMENT_PENDING);
-			then(orderRepository).should().findAllByUserIdAndMatchIdAndStatus(userId, 1L, OrderStatus.PAYMENT_PENDING);
+			then(orderRepository).should().bulkUpdateStatus(userId, 1L,
+				OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED);
 		}
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 주문 생성 후 결제하지 않고 이탈 → 재추천 → 동일 좌석 재주문 시 `isAlreadyOrdered()`가 이전 미결제 OrderSeat를 감지하여 400 응답하던 버그 수정
- `isAlreadyOrdered()` 쿼리에서 미결제(PAYMENT_PENDING), 취소(CANCELLED), 환불 완료(REFUND_COMPLETED) 주문 제외      
- 재주문 시 같은 유저+같은 경기의 이전 미결제 주문을 자동 취소하는 로직 추가

## 🧩 구현 상세
- `SeatInfoQueryService.isAlreadyOrdered()`: `order_seats` 단독 조회 → `orders` JOIN 후 유효 상태(PAID, CANCEL_REQUESTED, REFUND_PROCESSING)만 카운트
- `OrderService.cancelExistingPendingOrders()`: `createOrder()` 시작 시 동일 유저+경기의 PAYMENT_PENDING 주문을 CANCELLED로 전환
- `OrderRepository.findAllByUserIdAndMatchIdAndStatus()`: 위 로직에 필요한 조회 메서드 추가
- 추천 좌석, 일반 좌석(포도알) 모두 동일하게 적용됨 (`createOrder()` 공유)
<img width="1206" height="679" alt="스크린샷 2026-03-30 오후 5 03 16" src="https://github.com/user-attachments/assets/6c7c93dd-d96d-4927-a1cb-bcdaa96dd689" />

### 📌 관련 Jira Issue
- GRGB-320
- fixes #213 

## 🧪 테스트 방법
- 미결제 주문 존재 시 → 재주문 성공 + 이전 주문 CANCELLED  전환 확인
- 미결제 주문 없을 때 → 기존과 동일하게 정상 생성 확인
- PAID 주문 좌석에 대한 재주문 → 여전히 400 차단 확인