### PR TITLE
fix(order): 주문서 경기장 정보 하드코딩 제거 및 DB 조회로 변경

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderSheetGetResponse.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 
 import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.domain.stadium.entity.Stadium;
 import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,23 +22,15 @@ public record OrderSheetGetResponse(
 			@Schema(description = "경기 일시 (UTC)", example = "2026-03-29T05:00:00Z") Instant matchAt,
 			@Schema(description = "홈 구단 정보") ClubInfo homeClub,
 			@Schema(description = "원정 구단 정보") ClubInfo awayClub,
-			@Schema(description = "경기장 정보 (잠실야구장 고정)") StadiumInfo stadium
+			@Schema(description = "경기장 정보") StadiumInfo stadium
 	) {
-		private static final Long JAMSIL_STADIUM_ID = 1L;
-		private static final String JAMSIL_STADIUM_NAME = "잠실종합운동장 잠실야구장";
-		private static final String JAMSIL_STADIUM_ADDRESS = "서울 송파구 올림픽로 19-2 서울종합운동장";
-
 		public static MatchInfo from(Match match) {
 			return new MatchInfo(
 					match.getId(),
 					match.getMatchAt(),
 					new ClubInfo(match.getHomeClub().getId(), match.getHomeClub().getKoName()),
 					new ClubInfo(match.getAwayClub().getId(), match.getAwayClub().getKoName()),
-					new StadiumInfo(
-							JAMSIL_STADIUM_ID,
-							JAMSIL_STADIUM_NAME,
-							JAMSIL_STADIUM_ADDRESS
-					)
+					StadiumInfo.from(match.getStadium())
 			);
 		}
 	}
@@ -55,6 +48,13 @@ public record OrderSheetGetResponse(
 			@Schema(description = "경기장명", example = "잠실종합운동장 잠실야구장") String koName,
 			@Schema(description = "경기장 주소", example = "서울 송파구 올림픽로 19-2 서울종합운동장") String address
 	) {
+		public static StadiumInfo from(Stadium stadium) {
+			return new StadiumInfo(
+					stadium.getId(),
+					stadium.getKoName(),
+					stadium.getAddress()
+			);
+		}
 	}
 
 	@Schema(description = "좌석 정보")


### PR DESCRIPTION
fixes #217
## 🔧 작업 내용
- 주문서(OrderSheetGetResponse)에서 경기장 정보가 잠실야구장으로 하드코딩되어 있던 부분 수정
- `match.getStadium()`을 통해 DB에 저장된 실제 경기장 정보를 조회하도록 변경

## 🧩 구현 상세
- 좌석 템플릿은 잠실야구장만 사용하지만, 실제 KBO 일정은 수원, 고척, 대전, 대구, 광주 등 다양한 경기장에서 열림
- 주문서, 결제 정보 등 유저에게 보여주는 경기 정보에는 해당 경기가 실제로 열리는 구장을 표기해야 함
- 기존: `JAMSIL_STADIUM_ID`, `JAMSIL_STADIUM_NAME`, `JAMSIL_STADIUM_ADDRESS` 상수로 고정 반환
- 수정: `StadiumInfo.from(match.getStadium())`으로 DB 기반 조회
- 다른 API 응답(SeatEntryResponse, MatchGuideDto, MyPageTicketDetailResponse 등)은 이미 DB 조회 중이었으며, OrderSheetGetResponse만 하드코딩된 잠실 야구장으로 내려가고 있엇음.

### 📌 관련 Github Issue
  - #217 

## 🧪 테스트 방법
- 잠실이 아닌 경기장(수원, 고척 등)에서 열리는 경기 → 주문서 조회 → 해당 경기장 정보가 정상 표시되는지 확인

## ❗ 참고 사항
- 밤새서 정신이 없어서 그냥 잠실 야구장 상수로 처리 했었는데 지금 보니 기존대로 DB 기반으로 노출하는게 맞았네요..
- 좌석 템플릿(블럭, 섹션, 좌석 배치)은 잠실야구장 기준 — 이건 변경 없음
- 경기장 정보 표기만 DB 기반으로 변경한 것 