### PR TITLE
chore(loadtest): 부하테스트 회원가입 중복 요청 시 원인 파악을 위한 warn 로그 추가 [GRGB-321]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -41,6 +41,7 @@ public class LoadTestAuthService {
 	@Transactional
 	public void signup(String loginId, String password) {
 		if (loadTestUserRepository.existsByLoginId(loginId)) {
+			log.warn("[LoadTest] 부하테스트 중복 아이디 요청 - loginId: {} (이미 존재하는 아이디)", loginId);
 			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
 		}
 
@@ -60,6 +61,7 @@ public class LoadTestAuthService {
 
 			log.info("[LoadTest] 부하테스트 유저 생성 - loginId: {}, userId: {}", loginId, user.getId());
 		} catch (DataIntegrityViolationException e) {
+			log.warn("[LoadTest] 부하테스트 동시 요청으로 인한 중복 충돌 - loginId: {} (Race Condition 발생)", loginId);
 			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
 		}
 	}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -61,7 +61,7 @@ public class LoadTestAuthService {
 
 			log.info("[LoadTest] 부하테스트 유저 생성 - loginId: {}, userId: {}", loginId, user.getId());
 		} catch (DataIntegrityViolationException e) {
-			log.warn("[LoadTest] 부하테스트 동시 요청으로 인한 중복 충돌 - loginId: {} (Race Condition 발생)", loginId);
+            log.warn("[LoadTest] 부하테스트 동시 요청으로 인한 중복 충돌 - loginId: {} (Race Condition 발생)", loginId, e);
 			throw new CustomException(ErrorCode.USER_ALREADY_EXISTS);
 		}
 	}


### PR DESCRIPTION
## 🔧 작업 내용
- 부하테스트 회원가입 시 동일 아이디로 동시 요청이 들어올 때 중복 원인을 파악할 수 있도록 warn 로그 추가
- 기존 존재하는 아이디 재요청과 Race Condition으로 인한 DB 충돌을 로그에서 구분 가능하도록 개선 

## 🧩 구현 상세 (선택)
- `LoadTestAuthService.signup()` 에서 두 가지 중복 케이스에 warn 로그 추가 
  - `existsByLoginId` 체크: 이미 존재하는 아이디로 재요청 
  - `DataIntegrityViolationException` catch: 동시 요청으로 인한 DB unique 제약 충돌 (Race Condition)

### 📌 관련 Jira Issue
- GRGB-321

## 🧪 테스트 방법(선택)
- dev/staging 환경에서 동일 아이디로 동시 회원가입 요청 시 409 응답 + warn 로그 출력 확인
