### PR TITLE
hotfix(payment): 결제 시 현금영수증 신청 정보 함께 저장 처리

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
@@ -1,12 +1,24 @@
 package com.goormgb.be.ordercore.payment.dto.request;
 
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record PaymentProcessRequest(
 
 	@NotNull(message = "결제 수단은 필수입니다.")
-	PaymentMethod paymentMethod
+	PaymentMethod paymentMethod,
+
+	CashReceiptPurpose cashReceiptPurpose,
+
+	@Size(max = 50)
+	String cashReceiptNumber
 ) {
+
+	public boolean hasCashReceipt() {
+		return cashReceiptPurpose != null && cashReceiptNumber != null && !cashReceiptNumber.isBlank();
+	}
 }
+

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -94,6 +94,17 @@ public class PaymentService {
 			Payment payment = buildPayment(order, request.paymentMethod());
 			paymentRepository.save(payment);
 
+			// 현금영수증 신청 정보가 있으면 함께 저장
+			if (request.hasCashReceipt()) {
+				CashReceipt cashReceipt = CashReceipt.builder()
+					.payment(payment)
+					.purpose(request.cashReceiptPurpose())
+					.number(request.cashReceiptNumber())
+					.build();
+				cashReceiptRepository.save(cashReceipt);
+				log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.cashReceiptPurpose());
+			}
+
 			// 결제 수단과 무관하게 좌석을 SOLD로 전환 (스케줄러가 풀지 못하도록)
 			markSeatsAsSold(orderId);
 


### PR DESCRIPTION
## 🔧 작업 내용
- 결제 API(`POST /mypage/orders/{orderId}/payment`)에서 현금영수증 신청 정보를 함께 처리하도록 수정
- 기존에는 현금영수증 필드가 `PaymentProcessRequest`에 없어 프론트에서 현금영수증 정보를 보낼 수 없었음
- 결제와 현금영수증 신청을 하나의 트랜잭션으로 처리하여 데이터 정합성 확보

## 🧩 구현 상세
- `PaymentProcessRequest`에 `cashReceiptPurpose`, `cashReceiptNumber` 필드 추가 (optional)
- `PaymentService.processPayment()`에서 현금영수증 정보가 있으면 `CashReceipt` 엔티티를 함께 저장
- 현금영수증 미신청 시 기존 동작과 동일 (하위 호환)

## ❗ 참고 사항
- 실제 현금영수증 발급 연동 없이 DB 저장만 수행 (목업)
- 기존 `POST /{orderId}/cash-receipt` 별도 엔드포인트는 유지
- hotfix 사항으로 리뷰 없이 merge 하도록 하겠습니다