### PR TITLE
fix(order): 미결제 주문 취소 시 order_seats 미삭제로 인한 재주문 500 에러 수정

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -50,6 +50,18 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		@Param("now") Instant now
 	);
 
+	@Query("""
+		SELECT o.id FROM Order o
+		WHERE o.user.id = :userId
+		  AND o.match.id = :matchId
+		  AND o.status = :status
+		""")
+	List<Long> findIdsByUserIdAndMatchIdAndStatus(
+		@Param("userId") Long userId,
+		@Param("matchId") Long matchId,
+		@Param("status") OrderStatus status
+	);
+
 	@Modifying(clearAutomatically = true)
 	@Query("""
 		UPDATE Order o

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
@@ -3,6 +3,7 @@ package com.goormgb.be.ordercore.order.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +15,8 @@ public interface OrderSeatRepository extends JpaRepository<OrderSeat, Long> {
 
 	@Query("SELECT os.matchSeatId FROM OrderSeat os WHERE os.order.id = :orderId")
 	List<Long> findMatchSeatIdsByOrderId(@Param("orderId") Long orderId);
+
+	@Modifying
+	@Query("DELETE FROM OrderSeat os WHERE os.order.id IN :orderIds")
+	int deleteByOrderIdIn(@Param("orderIds") List<Long> orderIds);
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -130,17 +130,23 @@ public class OrderService {
 	}
 
 	/**
-	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 벌크 UPDATE로 자동 취소한다.
-	 * 결제 없이 이탈한 유저가 동일 좌석으로 재주문할 수 있도록 이전 주문을 정리한다.
+	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 자동 취소한다.
+	 * 이전 주문의 order_seats를 삭제하여 동일 좌석 재주문 시 unique constraint 위반을 방지한다.
 	 */
 	private void cancelExistingPendingOrders(Long userId, Long matchId) {
+		List<Long> pendingOrderIds = orderRepository.findIdsByUserIdAndMatchIdAndStatus(
+				userId, matchId, OrderStatus.PAYMENT_PENDING);
+
+		if (pendingOrderIds.isEmpty()) {
+			return;
+		}
+
+		int deletedSeats = orderSeatRepository.deleteByOrderIdIn(pendingOrderIds);
 		int cancelledCount = orderRepository.bulkUpdateStatus(
 				userId, matchId, OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED);
 
-		if (cancelledCount > 0) {
-			log.info("[OrderService] 미결제 주문 {}건 자동 취소 - userId={}, matchId={}",
-					cancelledCount, userId, matchId);
-		}
+		log.info("[OrderService] 미결제 주문 {}건 자동 취소 (좌석 {}건 삭제) - userId={}, matchId={}",
+				cancelledCount, deletedSeats, userId, matchId);
 	}
 
 	private String determineDayType(Instant matchAt) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/request/PaymentProcessRequest.java
@@ -1,12 +1,24 @@
 package com.goormgb.be.ordercore.payment.dto.request;
 
+import com.goormgb.be.ordercore.payment.enums.CashReceiptPurpose;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record PaymentProcessRequest(
 
 	@NotNull(message = "결제 수단은 필수입니다.")
-	PaymentMethod paymentMethod
+	PaymentMethod paymentMethod,
+
+	CashReceiptPurpose cashReceiptPurpose,
+
+	@Size(max = 50)
+	String cashReceiptNumber
 ) {
+
+	public boolean hasCashReceipt() {
+		return cashReceiptPurpose != null && cashReceiptNumber != null && !cashReceiptNumber.isBlank();
+	}
 }
+

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/entity/CashReceipt.java
@@ -52,4 +52,9 @@ public class CashReceipt extends BaseEntity {
 		this.purpose = purpose;
 		this.number = number;
 	}
+
+	public void update(CashReceiptPurpose purpose, String number) {
+		this.purpose = purpose;
+		this.number = number;
+	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -134,8 +134,8 @@ public class PaymentService {
 	}
 
 	/**
-	 * 현금영수증 신청.
-	 * 결제가 완료된 주문에 한해 현금영수증을 신청한다.
+	 * 현금영수증 신청 (목업).
+	 * 결제 상태와 무관하게 현금영수증 정보를 저장한다.
 	 */
 	public CashReceiptCreateResponse createCashReceipt(Long userId, Long orderId, CashReceiptCreateRequest request) {
 		Order order = findOrderAndValidateOwnership(userId, orderId);
@@ -143,20 +143,21 @@ public class PaymentService {
 		Payment payment = paymentRepository.findByOrderId(orderId)
 			.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
-		Preconditions.validate(
-			!cashReceiptRepository.findByPaymentId(payment.getId()).isPresent(),
-			ErrorCode.CASH_RECEIPT_ALREADY_EXISTS
-		);
+		CashReceipt cashReceipt = cashReceiptRepository.findByPaymentId(payment.getId())
+			.orElse(null);
 
-		CashReceipt cashReceipt = CashReceipt.builder()
-			.payment(payment)
-			.purpose(request.purpose())
-			.number(request.number())
-			.build();
-
-		cashReceiptRepository.save(cashReceipt);
-
-		log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.purpose());
+		if (cashReceipt != null) {
+			cashReceipt.update(request.purpose(), request.number());
+			log.info("[PaymentService] 현금영수증 정보 수정 - orderId={}, purpose={}", orderId, request.purpose());
+		} else {
+			cashReceipt = CashReceipt.builder()
+				.payment(payment)
+				.purpose(request.purpose())
+				.number(request.number())
+				.build();
+			cashReceiptRepository.save(cashReceipt);
+			log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.purpose());
+		}
 
 		return CashReceiptCreateResponse.of(orderId, cashReceipt);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -94,6 +94,17 @@ public class PaymentService {
 			Payment payment = buildPayment(order, request.paymentMethod());
 			paymentRepository.save(payment);
 
+			// 현금영수증 신청 정보가 있으면 함께 저장
+			if (request.hasCashReceipt()) {
+				CashReceipt cashReceipt = CashReceipt.builder()
+					.payment(payment)
+					.purpose(request.cashReceiptPurpose())
+					.number(request.cashReceiptNumber())
+					.build();
+				cashReceiptRepository.save(cashReceipt);
+				log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.cashReceiptPurpose());
+			}
+
 			// 결제 수단과 무관하게 좌석을 SOLD로 전환 (스케줄러가 풀지 못하도록)
 			markSeatsAsSold(orderId);
 


### PR DESCRIPTION
## 🔧 작업 내용

- 미결제 주문 자동 취소(`cancelExistingPendingOrders`) 시 `order_seats` 레코드를 함께 삭제하도록 수정
- 기존에는 주문 상태만 CANCELLED로 변경하고 order_seats는 남겨두어, 동일 좌석 재주문 시 unique constraint 위반(500)이 발생

## 🧩 구현 상세
- `OrderRepository`에 `findIdsByUserIdAndMatchIdAndStatus` 추가 (취소 대상 주문 ID 조회)
- `OrderSeatRepository`에 `deleteByOrderIdIn` 추가 (벌크 삭제)
- `cancelExistingPendingOrders`에서 order_seats 삭제 → 주문 취소 순서로 처리

## ❗ 참고 사항
- 기존 `isAlreadyOrdered` 쿼리는 유효 주문만 체크하도록 이미 수정되어 있으나, order_seats 잔존 문제는 해결되지 않았음
- hotfix 사항으로 리뷰 없이 merge 하도록 하겠습니다