### PR TITLE
feat(order,seat): 결제 완료 이벤트 발행/구독 — 좌석 SOLD 전환을 Kafka EDA로 전환 [GRGB-326]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
@@ -1,0 +1,17 @@
+package com.goormgb.be.ordercore.payment.event;
+
+import java.util.List;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PaymentCompletedInternalEvent {
+
+	private final Order order;
+	private final List<Long> matchSeatIds;
+	private final String paymentMethod;
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
@@ -4,14 +4,8 @@ import java.util.List;
 
 import com.goormgb.be.ordercore.order.entity.Order;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class PaymentCompletedInternalEvent {
-
-	private final Order order;
-	private final List<Long> matchSeatIds;
-	private final String paymentMethod;
+public record PaymentCompletedInternalEvent(
+		Order order,
+		List<Long> matchSeatIds,
+		String paymentMethod) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -36,27 +36,29 @@ public class PaymentEventPublisher {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handlePaymentCompleted(PaymentCompletedInternalEvent internalEvent) {
+		Order order = internalEvent.getOrder();
+
 		PaymentCompletedEvent event = PaymentCompletedEvent.builder()
-			.orderId(internalEvent.getOrder().getId())
-			.userId(internalEvent.getOrder().getUser().getId())
-			.matchId(internalEvent.getOrder().getMatch().getId())
+			.orderId(order.getId())
+			.userId(order.getUser().getId())
+			.matchId(order.getMatch().getId())
 			.matchSeatIds(internalEvent.getMatchSeatIds())
 			.paymentMethod(internalEvent.getPaymentMethod())
-			.totalAmount(internalEvent.getOrder().getTotalAmount())
+			.totalAmount(order.getTotalAmount())
 			.occurredAt(Instant.now())
 			.build();
 
 		kafkaTemplate.send(
 			EventTopic.PAYMENT_COMPLETED,
-			String.valueOf(internalEvent.getOrder().getId()),
+			String.valueOf(order.getId()),
 			event
 		).whenComplete((result, ex) -> {
 			if (ex != null) {
 				log.error("[Kafka] 결제 완료 이벤트 발행 실패: orderId={}, error={}",
-					internalEvent.getOrder().getId(), ex.getMessage(), ex);
+					order.getId(), ex.getMessage(), ex);
 			} else {
 				log.info("[Kafka] 결제 완료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
-					internalEvent.getOrder().getId(),
+					order.getId(),
 					internalEvent.getMatchSeatIds().size(),
 					result.getRecordMetadata().offset());
 			}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -36,14 +36,14 @@ public class PaymentEventPublisher {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handlePaymentCompleted(PaymentCompletedInternalEvent internalEvent) {
-		Order order = internalEvent.getOrder();
+		Order order = internalEvent.order();
 
 		PaymentCompletedEvent event = PaymentCompletedEvent.builder()
 			.orderId(order.getId())
 			.userId(order.getUser().getId())
 			.matchId(order.getMatch().getId())
-			.matchSeatIds(internalEvent.getMatchSeatIds())
-			.paymentMethod(internalEvent.getPaymentMethod())
+			.matchSeatIds(internalEvent.matchSeatIds())
+			.paymentMethod(internalEvent.paymentMethod())
 			.totalAmount(order.getTotalAmount())
 			.occurredAt(Instant.now())
 			.build();
@@ -59,7 +59,7 @@ public class PaymentEventPublisher {
 			} else {
 				log.info("[Kafka] 결제 완료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
 					order.getId(),
-					internalEvent.getMatchSeatIds().size(),
+					internalEvent.matchSeatIds().size(),
 					result.getRecordMetadata().offset());
 			}
 		});

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -1,0 +1,65 @@
+package com.goormgb.be.ordercore.payment.event;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.goormgb.be.kafka.EventTopic;
+import com.goormgb.be.kafka.event.PaymentCompletedEvent;
+import com.goormgb.be.ordercore.order.entity.Order;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventPublisher {
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	/**
+	 * 결제 완료 이벤트를 발행한다.
+	 * 트랜잭션 커밋 후 Kafka로 전송된다.
+	 */
+	public void publishPaymentCompleted(Order order, List<Long> matchSeatIds, String paymentMethod) {
+		applicationEventPublisher.publishEvent(
+			new PaymentCompletedInternalEvent(order, matchSeatIds, paymentMethod)
+		);
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handlePaymentCompleted(PaymentCompletedInternalEvent internalEvent) {
+		PaymentCompletedEvent event = PaymentCompletedEvent.builder()
+			.orderId(internalEvent.getOrder().getId())
+			.userId(internalEvent.getOrder().getUser().getId())
+			.matchId(internalEvent.getOrder().getMatch().getId())
+			.matchSeatIds(internalEvent.getMatchSeatIds())
+			.paymentMethod(internalEvent.getPaymentMethod())
+			.totalAmount(internalEvent.getOrder().getTotalAmount())
+			.occurredAt(Instant.now())
+			.build();
+
+		kafkaTemplate.send(
+			EventTopic.PAYMENT_COMPLETED,
+			String.valueOf(internalEvent.getOrder().getId()),
+			event
+		).whenComplete((result, ex) -> {
+			if (ex != null) {
+				log.error("[Kafka] 결제 완료 이벤트 발행 실패: orderId={}, error={}",
+					internalEvent.getOrder().getId(), ex.getMessage(), ex);
+			} else {
+				log.info("[Kafka] 결제 완료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
+					internalEvent.getOrder().getId(),
+					internalEvent.getMatchSeatIds().size(),
+					result.getRecordMetadata().offset());
+			}
+		});
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -19,9 +19,9 @@ import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.metrics.enums.PaymentMethodType;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.ordercore.payment.event.PaymentEventPublisher;
 import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
 import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
 import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
@@ -57,7 +57,7 @@ public class PaymentService {
 	private final OrderSeatRepository orderSeatRepository;
 	private final PaymentRepository paymentRepository;
 	private final CashReceiptRepository cashReceiptRepository;
-	private final SeatInfoQueryService seatInfoQueryService;
+	private final PaymentEventPublisher paymentEventPublisher;
 
 	/**
 	 * 결제 처리.
@@ -105,8 +105,9 @@ public class PaymentService {
 				log.info("[PaymentService] 현금영수증 신청 완료 - orderId={}, purpose={}", orderId, request.cashReceiptPurpose());
 			}
 
-			// 결제 수단과 무관하게 좌석을 SOLD로 전환 (스케줄러가 풀지 못하도록)
-			markSeatsAsSold(orderId);
+			// 결제 수단과 무관하게 좌석 SOLD 전환 이벤트 발행 (스케줄러가 BLOCKED를 풀지 못하도록)
+			List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(orderId);
+			paymentEventPublisher.publishPaymentCompleted(order, matchSeatIds, request.paymentMethod().name());
 
 			if (request.paymentMethod() != PaymentMethod.BANK_TRANSFER) {
 				// 간편결제(토스페이, 카카오페이) 목업 즉시 완료
@@ -172,16 +173,6 @@ public class PaymentService {
 		);
 
 		return order;
-	}
-
-	private void markSeatsAsSold(Long orderId) {
-		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(orderId);
-		int updated = seatInfoQueryService.markSoldIfBlocked(matchSeatIds);
-		log.info("[PaymentService] 좌석 SOLD 전환 - orderId={}, count={}", orderId, updated);
-		if (updated != matchSeatIds.size()) {
-			log.warn("[PaymentService] 좌석 SOLD 전환 개수 불일치 - orderId={}, expected={}, updated={}",
-				orderId, matchSeatIds.size(), updated);
-		}
 	}
 
 	private Payment buildPayment(Order order, PaymentMethod method) {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -27,9 +27,9 @@ import com.goormgb.be.ordercore.fixture.payment.PaymentFixture;
 import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.ordercore.payment.event.PaymentEventPublisher;
 import com.goormgb.be.ordercore.payment.dto.request.CashReceiptCreateRequest;
 import com.goormgb.be.ordercore.payment.dto.request.PaymentProcessRequest;
 import com.goormgb.be.ordercore.payment.dto.response.CashReceiptCreateResponse;
@@ -58,7 +58,7 @@ class PaymentServiceTest {
 	@Mock
 	private OrderMetricsService orderMetricsService;
 	@Mock
-	private SeatInfoQueryService seatInfoQueryService;
+	private PaymentEventPublisher paymentEventPublisher;
 
 	private PaymentService paymentService;
 	private Clock clock;
@@ -68,7 +68,7 @@ class PaymentServiceTest {
 		// 경기(2026-03-11 09:30 UTC)보다 이전 시점으로 고정
 		clock = Clock.fixed(Instant.parse("2026-03-04T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 		paymentService = new PaymentService(clock, orderMetricsService, orderRepository, orderSeatRepository,
-				paymentRepository, cashReceiptRepository, seatInfoQueryService);
+				paymentRepository, cashReceiptRepository, paymentEventPublisher);
 	}
 
 	private Order createOrderWithUser(Long orderId, Long userId) {
@@ -151,8 +151,8 @@ class PaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("결제 시 좌석을 BLOCKED에서 SOLD로 전환된다")
-		void processPayment_좌석_SOLD_전환() {
+		@DisplayName("간편결제 시 결제 완료 이벤트를 발행한다")
+		void processPayment_간편결제_이벤트발행() {
 			Long userId = 1L;
 			Long orderId = 1L;
 			Order order = createOrderWithUser(orderId, userId);
@@ -163,11 +163,28 @@ class PaymentServiceTest {
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(matchSeatIds);
-			given(seatInfoQueryService.markSoldIfBlocked(matchSeatIds)).willReturn(2);
 
 			paymentService.processPayment(userId, orderId, request);
 
-			then(seatInfoQueryService).should().markSoldIfBlocked(matchSeatIds);
+			then(paymentEventPublisher).should().publishPaymentCompleted(eq(order), eq(matchSeatIds), eq("TOSS_PAY"));
+		}
+
+		@Test
+		@DisplayName("무통장 입금 시에도 좌석 SOLD 전환 이벤트를 발행한다 (스케줄러가 BLOCKED를 풀지 못하도록)")
+		void processPayment_무통장입금_이벤트발행() {
+			Long userId = 1L;
+			Long orderId = 1L;
+			Order order = createOrderWithUser(orderId, userId);
+			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
+
+			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(List.of(101L));
+
+			paymentService.processPayment(userId, orderId, request);
+
+			then(paymentEventPublisher).should().publishPaymentCompleted(eq(order), eq(List.of(101L)), eq("BANK_TRANSFER"));
 		}
 
 		@Test
@@ -181,7 +198,7 @@ class PaymentServiceTest {
 			Clock nearMatchClock = Clock.fixed(matchAt.minus(Duration.ofHours(2)), ZoneId.of("Asia/Seoul"));
 			PaymentService nearMatchPaymentService = new PaymentService(nearMatchClock, orderMetricsService,
 					orderRepository, orderSeatRepository, paymentRepository, cashReceiptRepository,
-					seatInfoQueryService);
+					paymentEventPublisher);
 
 			Order order = createOrderWithUser(orderId, userId);
 			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -1,0 +1,51 @@
+package com.goormgb.be.seat.matchSeat.event;
+
+import java.util.List;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.kafka.EventTopic;
+import com.goormgb.be.kafka.event.PaymentCompletedEvent;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCompletedEventConsumer {
+
+	private final MatchSeatRepository matchSeatRepository;
+
+	@KafkaListener(topics = EventTopic.PAYMENT_COMPLETED, groupId = "seat-service")
+	@Transactional
+	public void handlePaymentCompleted(PaymentCompletedEvent event) {
+		List<MatchSeat> seats = matchSeatRepository.findAllById(event.getMatchSeatIds());
+
+		int soldCount = 0;
+		for (MatchSeat seat : seats) {
+			if (seat.getSaleStatus() == MatchSeatSaleStatus.BLOCKED) {
+				seat.markSold();
+				soldCount++;
+			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
+				log.debug("[Kafka] 이미 SOLD 상태, 스킵: matchSeatId={}", seat.getId());
+			} else {
+				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}",
+					seat.getId(), seat.getSaleStatus());
+			}
+		}
+
+		if (soldCount > 0) {
+			log.info("[Kafka] 결제 이벤트 처리 완료: orderId={}, 좌석 SOLD 전환={}건",
+				event.getOrderId(), soldCount);
+		} else {
+			log.info("[Kafka] 결제 이벤트 수신: orderId={}, SOLD 전환 대상 없음",
+				event.getOrderId());
+		}
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -25,7 +25,13 @@ public class PaymentCompletedEventConsumer {
 	@KafkaListener(topics = EventTopic.PAYMENT_COMPLETED, groupId = "seat-service")
 	@Transactional
 	public void handlePaymentCompleted(PaymentCompletedEvent event) {
-		List<MatchSeat> seats = matchSeatRepository.findAllById(event.getMatchSeatIds());
+		List<Long> requestedIds = event.getMatchSeatIds();
+		List<MatchSeat> seats = matchSeatRepository.findAllById(requestedIds);
+
+		if (seats.size() != requestedIds.size()) {
+			log.warn("[Kafka] 좌석 조회 수 불일치: orderId={}, 요청={}건, 조회={}건",
+				event.getOrderId(), requestedIds.size(), seats.size());
+		}
 
 		int soldCount = 0;
 		for (MatchSeat seat : seats) {
@@ -35,8 +41,9 @@ public class PaymentCompletedEventConsumer {
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				log.debug("[Kafka] 이미 SOLD 상태, 스킵: matchSeatId={}", seat.getId());
 			} else {
-				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}",
-					seat.getId(), seat.getSaleStatus());
+				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}, orderId={} — "
+						+ "Consumer Lag으로 인해 SeatHoldCleanupScheduler가 먼저 AVAILABLE로 복원했을 가능성 있음",
+					seat.getId(), seat.getSaleStatus(), event.getOrderId());
 			}
 		}
 

--- a/common-core/build.gradle
+++ b/common-core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-security'
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     api 'org.springframework.boot:spring-boot-starter-validation'
-    api 'org.springframework.kafka:spring-kafka'
+    api 'org.springframework.boot:spring-boot-starter-kafka'
     api 'org.springframework.boot:spring-boot-starter-webmvc'
     api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 


### PR DESCRIPTION
## 🔧 작업 내용
- Order-Core에서 Seat 테이블을 직접 UPDATE하던 크로스 모듈 코드를 Kafka 이벤트 발행으로 전환
- Seat 서비스에서 `payment-completed` 토픽을 구독하여 자체적으로 좌석 SOLD 전환 처리
- 좌석 상태 변경의 책임을 Seat 모듈로 통일 (EDA 전환 Phase 2)

## 🧩 구현 상세
### Producer (Order-Core)
- `PaymentEventPublisher`: 서비스에서 호출하는 `publishPaymentCompleted()` 메서드 + `@TransactionalEventListener(AFTER_COMMIT)`으로 트랜잭션 커밋 후 Kafka 발행
- `PaymentCompletedInternalEvent`: Spring 내부 이벤트 — DB 커밋과 Kafka 발행의 일관성 보장을 위한 중간 계층
- `PaymentService`: `markSeatsAsSold()` 제거 → `paymentEventPublisher.publishPaymentCompleted()` 호출로 교체
- `kafkaTemplate.send().whenComplete()` 콜백으로 비동기 전송 성공/실패 로깅
---
### 코드 리뷰 반영
- Consumer에서 `findAllById` 결과와 요청 ID 수 불일치 시 WARN 로그 추가 (DB에 없는 좌석 ID 조기 감지)                                                                                               
- AVAILABLE 좌석 WARN 로그에 "Consumer Lag으로 인해 SeatHoldCleanupScheduler가 먼저 복원했을 가능성" 맥락 추가                                                                                          
- Publisher에서 `internalEvent.getOrder()` 반복 호출을 `Order` 지역 변수로 추출하여 가독성 개선

### Consumer (Seat)
- `PaymentCompletedEventConsumer`: `payment-completed` 토픽 구독 (Consumer Group: `seat-service`)
- BLOCKED 상태일 때만 SOLD 전환 (기존 `markSoldIfBlocked` SQL의 WHERE 조건과 동일)
- 멱등성 보장: 이미 SOLD인 좌석은 스킵, 예상하지 못한 상태는 WARN 로깅
- SOLD 전환 여부에 따라 로그 메시지 분리 (`처리 완료` / `전환 대상 없음`)

### 설계 결정
- **무통장 입금도 이벤트 발행**: 기존 코드에서 결제 수단과 무관하게 SOLD 전환하던 설계를 유지. BLOCKED 상태로 두면  SeatHoldCleanupScheduler(60초)가 입금 대기 중 좌석을 풀어버리기 때문
- **@TransactionalEventListener 패턴**: 서비스 메서드 안에서 `kafkaTemplate.send()`를 직접 호출하면 DB 롤백 시에도 이벤트가   발행되는 Dual-Write 문제 발생. AFTER_COMMIT으로 해결

### 📌 관련 Jira Issue
- GRGB-326

## 🧪 테스트 방법
### 유닛 테스트
- `PaymentServiceTest` 실행
  - `processPayment_간편결제_이벤트발행()`: 토스페이 결제 시 이벤트 발행 검증
  - `processPayment_무통장입금_이벤트발행()`: 무통장 입금 시에도 이벤트 발행 검증

### 수동 테스트 (Kafka UI)
1. Docker Kafka + Seat 서비스 기동
2. Kafka UI (`http://localhost:8090`) → Topics → `payment-completed` → Produce Message
3. Value: `{"orderId":1,"userId":1,"matchId":1,"matchSeatIds":[좌석ID],"paymentMethod":"TOSS_PAY","totalAmount":30000,"occurredAt":"2026-03-31T08:00:00Z"}`
4. Headers: `{"__TypeId__":"com.goormgb.be.kafka.event.PaymentCompletedEvent"}`
5. Seat 로그에서 `[Kafka] 결제 이벤트 처리 완료` 확인 + DB에서 `sale_status = 'SOLD'` 확인
<img width="1490" height="250" alt="스크린샷 2026-03-31 오후 10 15 38" src="https://github.com/user-attachments/assets/7ea2b505-86be-47b3-9576-115ca6ea2134" />

## ❗ 참고 사항
- `SeatInfoQueryService.markSoldIfBlocked()` 메서드는 아직 남아있음 추후 작업 정리에서 제거 예정)
- 취소/만료 경로 (`MyPageTicketService`, `BankTransferCancelService`)는 아직 직접 DB 조작 유지 → 추후 작업에서 순차 전환 예정