### PR TITLE
feat(order,seat): 무통장 입금 만료 이벤트 발행/구독 — 좌석 AVAILABLE 복원을 Kafka EDA로 전환 [GRGB-328]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderCancelledInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderCancelledInternalEvent.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.ordercore.order.event;
 
+import java.time.Instant;
 import java.util.List;
 
 public record OrderCancelledInternalEvent(
@@ -8,5 +9,6 @@ public record OrderCancelledInternalEvent(
 		Long matchId,
 		Integer cancellationFee,
 		Integer refundedAmount,
-		List<Long> matchSeatIds) {
+		List<Long> matchSeatIds,
+		Instant occurredAt) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderEventPublisher.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -32,7 +33,8 @@ public class OrderEventPublisher {
 				order.getMatch().getId(),
 				order.getCancellationFee(),
 				order.getRefundedAmount(),
-				matchSeatIds
+				matchSeatIds,
+				Instant.now()
 			)
 		);
 	}
@@ -46,14 +48,14 @@ public class OrderEventPublisher {
 			.matchSeatIds(internalEvent.matchSeatIds())
 			.cancellationFee(internalEvent.cancellationFee())
 			.refundedAmount(internalEvent.refundedAmount())
-			.occurredAt(Instant.now())
+			.occurredAt(internalEvent.occurredAt())
 			.build();
 
 		kafkaTemplate.send(
 			EventTopic.ORDER_CANCELLED,
 			String.valueOf(internalEvent.orderId()),
 			event
-		).whenComplete((result, ex) -> {
+		).whenComplete((SendResult<String, Object> result, Throwable ex) -> {
 			if (ex != null) {
 				log.error("[Kafka] 주문 취소 이벤트 발행 실패: orderId={}, error={}",
 					internalEvent.orderId(), ex.getMessage(), ex);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/BankTransferExpiredInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/BankTransferExpiredInternalEvent.java
@@ -1,0 +1,11 @@
+package com.goormgb.be.ordercore.payment.event;
+
+import java.util.List;
+
+public record BankTransferExpiredInternalEvent(
+		Long orderId,
+		Long userId,
+		Long matchId,
+		Long paymentId,
+		List<Long> matchSeatIds) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/BankTransferExpiredInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/BankTransferExpiredInternalEvent.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.ordercore.payment.event;
 
+import java.time.Instant;
 import java.util.List;
 
 public record BankTransferExpiredInternalEvent(
@@ -7,5 +8,6 @@ public record BankTransferExpiredInternalEvent(
 		Long userId,
 		Long matchId,
 		Long paymentId,
-		List<Long> matchSeatIds) {
+		List<Long> matchSeatIds,
+		Instant occurredAt) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentCompletedInternalEvent.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.ordercore.payment.event;
 
+import java.time.Instant;
 import java.util.List;
 
 public record PaymentCompletedInternalEvent(
@@ -8,5 +9,6 @@ public record PaymentCompletedInternalEvent(
 		Long matchId,
 		List<Long> matchSeatIds,
 		Integer totalAmount,
-		String paymentMethod) {
+		String paymentMethod,
+		Instant occurredAt) {
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -10,8 +10,10 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.goormgb.be.kafka.EventTopic;
+import com.goormgb.be.kafka.event.BankTransferExpiredEvent;
 import com.goormgb.be.kafka.event.PaymentCompletedEvent;
 import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.payment.entity.Payment;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +41,50 @@ public class PaymentEventPublisher {
 				paymentMethod
 			)
 		);
+	}
+
+	/**
+	 * 무통장 입금 만료 이벤트를 발행한다.
+	 * 트랜잭션 커밋 후 Kafka로 전송된다.
+	 */
+	public void publishBankTransferExpired(Order order, Payment payment, List<Long> matchSeatIds) {
+		applicationEventPublisher.publishEvent(
+			new BankTransferExpiredInternalEvent(
+				order.getId(),
+				order.getUser().getId(),
+				order.getMatch().getId(),
+				payment.getId(),
+				matchSeatIds
+			)
+		);
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleBankTransferExpired(BankTransferExpiredInternalEvent internalEvent) {
+		BankTransferExpiredEvent event = BankTransferExpiredEvent.builder()
+			.orderId(internalEvent.orderId())
+			.userId(internalEvent.userId())
+			.matchId(internalEvent.matchId())
+			.paymentId(internalEvent.paymentId())
+			.matchSeatIds(internalEvent.matchSeatIds())
+			.occurredAt(Instant.now())
+			.build();
+
+		kafkaTemplate.send(
+			EventTopic.BANK_TRANSFER_EXPIRED,
+			String.valueOf(internalEvent.orderId()),
+			event
+		).whenComplete((result, ex) -> {
+			if (ex != null) {
+				log.error("[Kafka] 무통장 입금 만료 이벤트 발행 실패: orderId={}, error={}",
+					internalEvent.orderId(), ex.getMessage(), ex);
+			} else {
+				log.info("[Kafka] 무통장 입금 만료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
+					internalEvent.orderId(),
+					internalEvent.matchSeatIds().size(),
+					result.getRecordMetadata().offset());
+			}
+		});
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -38,7 +39,8 @@ public class PaymentEventPublisher {
 				order.getMatch().getId(),
 				matchSeatIds,
 				order.getTotalAmount(),
-				paymentMethod
+				paymentMethod,
+				Instant.now()
 			)
 		);
 	}
@@ -54,37 +56,10 @@ public class PaymentEventPublisher {
 				order.getUser().getId(),
 				order.getMatch().getId(),
 				payment.getId(),
-				matchSeatIds
+				matchSeatIds,
+				Instant.now()
 			)
 		);
-	}
-
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handleBankTransferExpired(BankTransferExpiredInternalEvent internalEvent) {
-		BankTransferExpiredEvent event = BankTransferExpiredEvent.builder()
-			.orderId(internalEvent.orderId())
-			.userId(internalEvent.userId())
-			.matchId(internalEvent.matchId())
-			.paymentId(internalEvent.paymentId())
-			.matchSeatIds(internalEvent.matchSeatIds())
-			.occurredAt(Instant.now())
-			.build();
-
-		kafkaTemplate.send(
-			EventTopic.BANK_TRANSFER_EXPIRED,
-			String.valueOf(internalEvent.orderId()),
-			event
-		).whenComplete((result, ex) -> {
-			if (ex != null) {
-				log.error("[Kafka] 무통장 입금 만료 이벤트 발행 실패: orderId={}, error={}",
-					internalEvent.orderId(), ex.getMessage(), ex);
-			} else {
-				log.info("[Kafka] 무통장 입금 만료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
-					internalEvent.orderId(),
-					internalEvent.matchSeatIds().size(),
-					result.getRecordMetadata().offset());
-			}
-		});
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -96,23 +71,38 @@ public class PaymentEventPublisher {
 			.matchSeatIds(internalEvent.matchSeatIds())
 			.paymentMethod(internalEvent.paymentMethod())
 			.totalAmount(internalEvent.totalAmount())
-			.occurredAt(Instant.now())
+			.occurredAt(internalEvent.occurredAt())
 			.build();
 
-		kafkaTemplate.send(
-			EventTopic.PAYMENT_COMPLETED,
-			String.valueOf(internalEvent.orderId()),
-			event
-		).whenComplete((result, ex) -> {
-			if (ex != null) {
-				log.error("[Kafka] 결제 완료 이벤트 발행 실패: orderId={}, error={}",
-					internalEvent.orderId(), ex.getMessage(), ex);
-			} else {
-				log.info("[Kafka] 결제 완료 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
-					internalEvent.orderId(),
-					internalEvent.matchSeatIds().size(),
-					result.getRecordMetadata().offset());
-			}
-		});
+		sendEvent(EventTopic.PAYMENT_COMPLETED, internalEvent.orderId(), event,
+			"결제 완료", internalEvent.matchSeatIds().size());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleBankTransferExpired(BankTransferExpiredInternalEvent internalEvent) {
+		BankTransferExpiredEvent event = BankTransferExpiredEvent.builder()
+			.orderId(internalEvent.orderId())
+			.userId(internalEvent.userId())
+			.matchId(internalEvent.matchId())
+			.paymentId(internalEvent.paymentId())
+			.matchSeatIds(internalEvent.matchSeatIds())
+			.occurredAt(internalEvent.occurredAt())
+			.build();
+
+		sendEvent(EventTopic.BANK_TRANSFER_EXPIRED, internalEvent.orderId(), event,
+			"무통장 입금 만료", internalEvent.matchSeatIds().size());
+	}
+
+	private void sendEvent(String topic, Long orderId, Object event, String eventName, int seatCount) {
+		kafkaTemplate.send(topic, String.valueOf(orderId), event)
+			.whenComplete((SendResult<String, Object> result, Throwable ex) -> {
+				if (ex != null) {
+					log.error("[Kafka] {} 이벤트 발행 실패: orderId={}, error={}",
+						eventName, orderId, ex.getMessage(), ex);
+				} else {
+					log.info("[Kafka] {} 이벤트 발행 성공: orderId={}, seatCount={}, offset={}",
+						eventName, orderId, seatCount, result.getRecordMetadata().offset());
+				}
+			});
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferCancelService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/scheduler/BankTransferCancelService.java
@@ -7,9 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.ordercore.order.entity.Order;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.event.PaymentEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class BankTransferCancelService {
 
 	private final OrderSeatRepository orderSeatRepository;
-	private final SeatInfoQueryService seatInfoQueryService;
+	private final PaymentEventPublisher paymentEventPublisher;
 
 	/**
 	 * 단일 무통장 입금 결제를 취소하고 좌석을 복원한다.
@@ -43,8 +43,9 @@ public class BankTransferCancelService {
 		order.updateStatus(OrderStatus.CANCELLED);
 		payment.cancel();
 
+		// 무통장 입금 만료 이벤트 발행 → Seat 서비스에서 좌석 SOLD → AVAILABLE 복원
 		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(order.getId());
-		seatInfoQueryService.markAvailableIfSold(matchSeatIds);
+		paymentEventPublisher.publishBankTransferExpired(order, payment, matchSeatIds);
 
 		return true;
 	}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -1,0 +1,57 @@
+package com.goormgb.be.seat.matchSeat.event;
+
+import java.util.List;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.kafka.EventTopic;
+import com.goormgb.be.kafka.event.BankTransferExpiredEvent;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankTransferExpiredEventConsumer {
+
+	private final MatchSeatRepository matchSeatRepository;
+
+	@KafkaListener(topics = EventTopic.BANK_TRANSFER_EXPIRED, groupId = "seat-service")
+	@Transactional
+	public void handleBankTransferExpired(BankTransferExpiredEvent event) {
+		List<Long> requestedIds = event.getMatchSeatIds();
+		List<MatchSeat> seats = matchSeatRepository.findAllById(requestedIds);
+
+		if (seats.size() != requestedIds.size()) {
+			log.warn("[Kafka] 좌석 조회 수 불일치: orderId={}, 요청={}건, 조회={}건",
+				event.getOrderId(), requestedIds.size(), seats.size());
+		}
+
+		int restoredCount = 0;
+		for (MatchSeat seat : seats) {
+			if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
+				seat.markAvailable();
+				restoredCount++;
+			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE) {
+				log.debug("[Kafka] 이미 AVAILABLE 상태, 스킵: matchSeatId={}", seat.getId());
+			} else {
+				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}, orderId={}",
+					seat.getId(), seat.getSaleStatus(), event.getOrderId());
+			}
+		}
+
+		if (restoredCount > 0) {
+			log.info("[Kafka] 무통장 만료 이벤트 처리 완료: orderId={}, paymentId={}, 좌석 AVAILABLE 복원={}건",
+				event.getOrderId(), event.getPaymentId(), restoredCount);
+		} else {
+			log.info("[Kafka] 무통장 만료 이벤트 수신: orderId={}, AVAILABLE 복원 대상 없음",
+				event.getOrderId());
+		}
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- BankTransferCancelService에서 Seat 테이블을 직접 UPDATE하던 크로스 모듈 코드를 Kafka 이벤트 발행으로 전환
- Seat 서비스에서 `bank-transfer-expired` 토픽을 구독하여 자체적으로 좌석 SOLD → AVAILABLE 복원 처리
- SeatInfoQueryService의 좌석 상태 변경 메서드(`markSoldIfBlocked`, `markAvailableIfSold`) 호출처 전부 제거 완료

## 🧩 구현 상세
 ### Producer (Order-Core)
  - `PaymentEventPublisher`에 `publishBankTransferExpired()` 메서드 추가  -> `@TransactionalEventListener(AFTER_COMMIT)`로 트랜잭션 커밋 후 Kafka 발행
- `BankTransferExpiredInternalEvent`: Java record, primitive 값만 전달 (LazyInitializationException 방지)
- `BankTransferCancelService`: `seatInfoQueryService.markAvailableIfSold()` 제거 → `paymentEventPublisher.publishBankTransferExpired()` 호출로 교체

### Consumer (Seat)
- `BankTransferExpiredEventConsumer`: `bank-transfer-expired` 토픽 구독 (Consumer Group: `seat-service`)
- SOLD 상태일 때만 AVAILABLE 복원 (멱등성 보장)
- `findAllById` 결과와 요청 ID 수 불일치 시 WARN 로그
- 복원 여부에 따라 로그 메시지 분리 (`처리 완료` / `복원 대상 없음`)

### 설계 결정
- 기존 `BankTransferExpireScheduler`(5분 폴링)는 그대로 유지 — 스케줄러가 만료 건을 찾아서 Order/Payment 상태를 변경하고, 좌석 복원만 이벤트로 분리
- `PaymentEventPublisher`에 결제 완료 + 무통장 만료 이벤트를 함께 관리 — 결제 관련 이벤트를 하나의 Publisher로 통합

### SeatInfoQueryService 좌석 변경 호출처 현황
- `markSoldIfBlocked()` — #225 에서 제거 완료 (PaymentService)
- `markAvailableIfSold()` — #226 에서 제거 (MyPageTicketService) + 이번 PR 에서 제거 (BankTransferCancelService)
- 메서드 정의 자체는 SeatInfoQueryService에 남아있으며, 추후 정리에서 삭제 예정

### 📌 관련 Jira Issue
- GRGB-328

## 🧪 테스트 방법
 ### 수동 테스트 (Kafka UI)
  1. DB에서 좌석을 SOLD 상태로 준비: `UPDATE match_seats SET sale_status = 'SOLD' WHERE id = 1;`
  2. Kafka UI (`http://localhost:8090`) → Topics → `bank-transfer-expired` → Produce Message
  3. Value: `{"orderId":1,"userId":1,"matchId":1,"paymentId":1,"matchSeatIds":[1],"occurredAt":"2026-03-31T08:00:00Z"}`
  4. Headers: `{"__TypeId__":"com.goormgb.be.kafka.event.BankTransferExpiredEvent"}`
  5. Seat 로그에서 `[Kafka] 무통장 만료 이벤트 처리 완료` 확인
  6. DB에서 `SELECT id, sale_status FROM match_seats WHERE id = 1;` → `AVAILABLE` 확인
<img width="1668" height="149" alt="스크린샷 2026-04-01 오후 10 01 41" src="https://github.com/user-attachments/assets/b97d2e4d-0d6a-4841-8f0e-f8102be5fb0b" />
<img width="459" height="185" alt="스크린샷 2026-04-01 오후 10 01 58" src="https://github.com/user-attachments/assets/30936b92-3dc6-4930-add5-376e516e9840" />


  ## ❗ 참고 사항
- `SeatInfoQueryService`의 `markSoldIfBlocked()`, `markAvailableIfSold()` 메서드 정의는 아직 남아있음 — 호출처는 없으며 추후 제거 예정
- Kafka 발행 실패 시 재처리 경로(Outbox 패턴)는 추후 안정화 단계에서 검토 예정

