### PR TITLE
 feat(seat): 추천 블럭 응답 연석 필드를 availableConsecutiveCount로 통합 [GRGB-331]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -13,11 +13,12 @@ public record BlockRecommendationResponse(
 	public static BlockRecommendationResponse of(
 		Long matchId,
 		Integer ticketCount,
-		List<BlockRecommendation> recommendations
+		List<BlockRecommendation> recommendations,
+		boolean nearAdjacentToggle
 	) {
 		List<RecommendedBlock> blocks = new java.util.ArrayList<>();
 		for (int i = 0; i < recommendations.size(); i++) {
-			blocks.add(RecommendedBlock.from(recommendations.get(i), i + 1));
+			blocks.add(RecommendedBlock.from(recommendations.get(i), i + 1, nearAdjacentToggle));
 		}
 		return new BlockRecommendationResponse(matchId, ticketCount, blocks);
 	}
@@ -28,22 +29,25 @@ public record BlockRecommendationResponse(
 		String sectionName,
 		String areaName,
 		String viewpoint,
-		int realConsecutiveCount,
-		int semiConsecutiveCount,
+		int availableConsecutiveCount,
 		long remainingSeatCount,
 		int rank
 	) {
 
-		public static RecommendedBlock from(BlockRecommendation recommendation, int rank) {
+		public static RecommendedBlock from(
+			BlockRecommendation recommendation, int rank, boolean nearAdjacentToggle
+		) {
 			var block = recommendation.block();
+			int availableCount = nearAdjacentToggle
+				? recommendation.combinedCount()
+				: recommendation.realConsecutiveCount();
 			return new RecommendedBlock(
 				block.getBlockNum(),
 				block.getBlockCode(),
 				block.getSection().getName(),
 				block.getArea().getName(),
 				block.getViewpoint().name(),
-				recommendation.realConsecutiveCount(),
-				recommendation.semiConsecutiveCount(),
+				availableCount,
 				recommendation.remainingSeatCount(),
 				rank
 			);

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/dto/response/BlockRecommendationResponse.java
@@ -4,9 +4,15 @@ import java.util.List;
 
 import com.goormgb.be.seat.recommendation.dto.internal.BlockRecommendation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "추천 블럭 리스트 응답")
 public record BlockRecommendationResponse(
+	@Schema(description = "경기 ID", example = "1")
 	Long matchId,
+	@Schema(description = "티켓 수량 (N연석 기준)", example = "2")
 	Integer ticketCount,
+	@Schema(description = "추천 블럭 리스트 (추천 순위 정렬)")
 	List<RecommendedBlock> blocks
 ) {
 
@@ -23,14 +29,23 @@ public record BlockRecommendationResponse(
 		return new BlockRecommendationResponse(matchId, ticketCount, blocks);
 	}
 
+	@Schema(description = "추천 블럭 정보")
 	public record RecommendedBlock(
+		@Schema(description = "블럭 ID", example = "205")
 		Long blockId,
+		@Schema(description = "블럭 코드", example = "205")
 		String blockCode,
+		@Schema(description = "구역 이름", example = "오렌지석(응원석)")
 		String sectionName,
+		@Schema(description = "영역 이름", example = "1루 외야")
 		String areaName,
+		@Schema(description = "시야 타입", example = "HOME_BEHIND")
 		String viewpoint,
+		@Schema(description = "이용 가능 연석 조합 수 (준연석 토글 ON: 찐연석+준연석 합산 / OFF: 찐연석만)", example = "5")
 		int availableConsecutiveCount,
+		@Schema(description = "잔여 좌석 수", example = "132")
 		long remainingSeatCount,
+		@Schema(description = "추천 순위 (1부터 시작)", example = "1")
 		int rank
 	) {
 

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -93,7 +93,7 @@ public class SeatRecommendationService {
 			// 추천 좌석 탐색 성공 횟수 증가
 			seatMetricsService.increaseRecommendSuccess();
 
-			return BlockRecommendationResponse.of(matchId, ticketCount, recommendations);
+			return BlockRecommendationResponse.of(matchId, ticketCount, recommendations, nearAdjacentToggle);
 		} catch (CustomException e) {
 			// 추천 좌석 탐색 실패 횟수 증가 (예외 발생, 조건 불일치 등 실패 케이스 추적)
 			seatMetricsService.increaseRecommendFail();


### PR DESCRIPTION
## 🔧 작업 내용
- 추천 블럭 응답의 `realConsecutiveCount`, `semiConsecutiveCount` 두 필드를 `availableConsecutiveCount` 하나로 통합
- 준연석 토글 ON: 찐연석 + 준연석 합산 / OFF: 찐연석만 반환
- Swagger `@Schema` 어노테이션 추가

## 🧩 구현 상세
- `BlockRecommendationResponse.of()`에 `nearAdjacentToggle` 파라미터 추가하여  응답 생성 시 분기 처리
- 내부 `BlockRecommendation.combinedCount()` 재활용

### 지라 티켓
GRGB-331

## ❗ 참고 사항
- 프론트엔드에서 기존 `realConsecutiveCount` → `availableConsecutiveCount`로 필드명 변경 필요