### PR TITLE
fix(abstraction): Validation 실패 메시지는 운영 환경에서도 추상화 안하도록 수정

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/booking/dto/request/BookingOptionsRequest.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/dto/request/BookingOptionsRequest.java
@@ -5,7 +5,9 @@ import jakarta.validation.constraints.Min;
 
 public record BookingOptionsRequest(
 	boolean recommendationEnabled,
-	@Min(1) @Max(8) Integer ticketCount,
+	@Min(value = 1, message = "ticketCount: 1 이상이어야 합니다")
+	@Max(value = 8, message = "ticketCount: 8 이하여야 합니다")
+	Integer ticketCount,
 	boolean nearAdjacentToggle
 ) {
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse.ErrorData> handleValidationException(MethodArgumentNotValidException e) {
 		var details = Arrays.toString(e.getDetailMessageArguments());
 		var message = details.split(",", 2)[1].replace("]", "").trim();
-		return ErrorResponse.error(HttpStatus.BAD_REQUEST, message, errorResponseStrategy);
+		return ErrorResponse.error(HttpStatus.BAD_REQUEST, message);
 	}
 
 	@ExceptionHandler(AuthorizationDeniedException.class)


### PR DESCRIPTION
## 🔧 작업 내용

- @Min, @Max, @NotBlank 같은 validation 메시지를 운영 환경에서도 추상화하지 않고 사용자에게 그대로 보여주기 위해 수정
- handleValidationException() 에서 errorResponseStrategy 제거