### PR TITLE
feat(order): 이메일 알림 이벤트 구독 — 결제 완료/주문 취소 시 메일 발송 [GRGB-329]

### DIFF
--- a/Order-Core/build.gradle
+++ b/Order-Core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
     implementation platform('software.amazon.awssdk:bom:2.25.60')
     implementation 'software.amazon.awssdk:s3'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // 필수: Actuator & Prometheus
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/controller/EmailTestController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/controller/EmailTestController.java
@@ -1,0 +1,73 @@
+package com.goormgb.be.ordercore.email.controller;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/test/email")
+@RequiredArgsConstructor
+public class EmailTestController {
+
+	private final OrderRepository orderRepository;
+
+	@GetMapping("/kafka-message")
+	public Map<String, Object> getKafkaTestMessage(
+		@RequestParam(required = false) Long orderId
+	) {
+		Order order;
+		if (orderId != null) {
+			order = orderRepository.findById(orderId).orElse(null);
+			if (order == null) {
+				return Map.of("error", "주문 ID " + orderId + "를 찾을 수 없습니다.");
+			}
+		} else {
+			order = orderRepository.findAll().stream().findFirst().orElse(null);
+			if (order == null) {
+				return Map.of("error", "DB에 주문이 없습니다. 먼저 주문을 생성해주세요.");
+			}
+		}
+
+		Long id = order.getId();
+		String email = order.getOrdererEmail();
+
+		String paymentValue = String.format(
+			"{\"orderId\":%d,\"userId\":1,\"matchId\":1,\"matchSeatIds\":[1,2],"
+				+ "\"paymentMethod\":\"TOSS_PAY\",\"totalAmount\":30000,"
+				+ "\"occurredAt\":\"2026-04-02T08:00:00Z\"}",
+			id);
+
+		String cancelValue = String.format(
+			"{\"orderId\":%d,\"userId\":1,\"matchId\":1,\"matchSeatIds\":[1,2],"
+				+ "\"cancellationFee\":3000,\"refundedAmount\":27000,"
+				+ "\"occurredAt\":\"2026-04-02T08:00:00Z\"}",
+			id);
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		result.put("orderId", id);
+		result.put("ordererEmail", email);
+		result.put("1_payment_completed", Map.of(
+			"topic", "payment-completed",
+			"value", paymentValue,
+			"headers", "{\"__TypeId__\":\"com.goormgb.be.kafka.event.PaymentCompletedEvent\"}"
+		));
+		result.put("2_order_cancelled", Map.of(
+			"topic", "order-cancelled",
+			"value", cancelValue,
+			"headers", "{\"__TypeId__\":\"com.goormgb.be.kafka.event.OrderCancelledEvent\"}"
+		));
+		result.put("guide", "Kafka UI(localhost:8090) → 토픽 선택 → Produce Message → Value와 Headers에 위 값 복붙");
+		return result;
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/dto/EmailMessage.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/dto/EmailMessage.java
@@ -1,0 +1,4 @@
+package com.goormgb.be.ordercore.email.dto;
+
+public record EmailMessage(String to, String subject, String body) {
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
@@ -2,6 +2,7 @@ package com.goormgb.be.ordercore.email.event;
 
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.OrderCancelledEvent;
@@ -21,9 +22,10 @@ public class EmailEventConsumer {
 	private final EmailService emailService;
 	private final OrderRepository orderRepository;
 
+	@Transactional(readOnly = true)
 	@KafkaListener(
 		topics = EventTopic.PAYMENT_COMPLETED,
-		groupId = "order-core-notification"
+		groupId = "${spring.kafka.consumer.group-id}"
 	)
 	public void handlePaymentCompleted(PaymentCompletedEvent event) {
 		Order order = orderRepository.findById(event.getOrderId()).orElse(null);
@@ -35,9 +37,10 @@ public class EmailEventConsumer {
 		emailService.sendPaymentConfirmation(order, event);
 	}
 
+	@Transactional(readOnly = true)
 	@KafkaListener(
 		topics = EventTopic.ORDER_CANCELLED,
-		groupId = "order-core-notification"
+		groupId = "${spring.kafka.consumer.group-id}"
 	)
 	public void handleOrderCancelled(OrderCancelledEvent event) {
 		Order order = orderRepository.findById(event.getOrderId()).orElse(null);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
@@ -1,0 +1,51 @@
+package com.goormgb.be.ordercore.email.event;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.kafka.EventTopic;
+import com.goormgb.be.kafka.event.OrderCancelledEvent;
+import com.goormgb.be.kafka.event.PaymentCompletedEvent;
+import com.goormgb.be.ordercore.email.service.EmailService;
+import com.goormgb.be.ordercore.order.entity.Order;
+import com.goormgb.be.ordercore.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailEventConsumer {
+
+	private final EmailService emailService;
+	private final OrderRepository orderRepository;
+
+	@KafkaListener(
+		topics = EventTopic.PAYMENT_COMPLETED,
+		groupId = "order-core-notification"
+	)
+	public void handlePaymentCompleted(PaymentCompletedEvent event) {
+		Order order = orderRepository.findById(event.getOrderId()).orElse(null);
+		if (order == null) {
+			log.warn("[Kafka-Email] 주문 없음, 이메일 발송 스킵: orderId={}", event.getOrderId());
+			return;
+		}
+
+		emailService.sendPaymentConfirmation(order, event);
+	}
+
+	@KafkaListener(
+		topics = EventTopic.ORDER_CANCELLED,
+		groupId = "order-core-notification"
+	)
+	public void handleOrderCancelled(OrderCancelledEvent event) {
+		Order order = orderRepository.findById(event.getOrderId()).orElse(null);
+		if (order == null) {
+			log.warn("[Kafka-Email] 주문 없음, 이메일 발송 스킵: orderId={}", event.getOrderId());
+			return;
+		}
+
+		emailService.sendCancellationConfirmation(order, event);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailService.java
@@ -1,0 +1,103 @@
+package com.goormgb.be.ordercore.email.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import com.goormgb.be.kafka.event.OrderCancelledEvent;
+import com.goormgb.be.kafka.event.PaymentCompletedEvent;
+import com.goormgb.be.ordercore.email.dto.EmailMessage;
+import com.goormgb.be.ordercore.order.entity.Order;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	private final JavaMailSender mailSender;
+
+	public void sendPaymentConfirmation(Order order, PaymentCompletedEvent event) {
+		EmailMessage message = new EmailMessage(
+				order.getOrdererEmail(),
+				"[Playball] 결제 완료 안내",
+				buildPaymentConfirmationBody(order, event)
+		);
+		send(message);
+	}
+
+	public void sendCancellationConfirmation(Order order, OrderCancelledEvent event) {
+		EmailMessage message = new EmailMessage(
+				order.getOrdererEmail(),
+				"[Playball] 예매 취소 안내",
+				buildCancellationBody(order, event)
+		);
+		send(message);
+	}
+
+	private void send(EmailMessage message) {
+		try {
+			SimpleMailMessage mail = new SimpleMailMessage();
+			mail.setTo(message.to());
+			mail.setSubject(message.subject());
+			mail.setText(message.body());
+			mail.setFrom("grgbdev@gmail.com");
+			mailSender.send(mail);
+			log.info("[Email] 발송 성공: to={}, subject={}", maskEmail(message.to()), message.subject());
+		} catch (Exception e) {
+			log.error("[Email] 발송 실패: to={}, subject={}, error={}",
+					maskEmail(message.to()), message.subject(), e.getMessage(), e);
+		}
+	}
+
+	private String buildPaymentConfirmationBody(Order order, PaymentCompletedEvent event) {
+		return String.format("""
+						안녕하세요, Playball입니다.
+						
+						결제가 완료되었습니다.
+						
+						주문번호: %d
+						결제 금액: %,d원
+						결제 방법: %s
+						좌석 수: %d석
+						
+						즐거운 관람 되세요!
+						""",
+				order.getId(),
+				event.getTotalAmount(),
+				event.getPaymentMethod(),
+				event.getMatchSeatIds().size()
+		);
+	}
+
+	private String buildCancellationBody(Order order, OrderCancelledEvent event) {
+		return String.format("""
+						안녕하세요, Playball입니다.
+						
+						예매가 취소되었습니다.
+						
+						주문번호: %d
+						취소 수수료: %,d원
+						환불 금액: %,d원
+						
+						감사합니다.
+						""",
+				order.getId(),
+				event.getCancellationFee(),
+				event.getRefundedAmount()
+		);
+	}
+
+	private String maskEmail(String email) {
+		if (email == null || !email.contains("@"))
+			return "***";
+		String[] parts = email.split("@");
+		String local = parts[0];
+		String masked = local.length() <= 2
+				? "*".repeat(local.length())
+				: local.substring(0, 2) + "*".repeat(local.length() - 2);
+		return masked + "@" + parts[1];
+	}
+}

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -39,6 +39,15 @@ spring:
       properties:
         spring.json.trusted.packages: ${KAFKA_CONSUMER_TRUSTED_PACKAGES}
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
   data:
     redis:
       host: ${REDIS_HOST}

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -39,6 +39,15 @@ spring:
       properties:
         spring.json.trusted.packages: ${KAFKA_CONSUMER_TRUSTED_PACKAGES}
 
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
   data:
     redis:
       host: ${REDIS_HOST}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -223,6 +223,10 @@ services:
       S3_PREFIX: ${S3_PREFIX}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      MAIL_HOST: ${MAIL_HOST}
+      MAIL_PORT: ${MAIL_PORT}
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
     depends_on:
       local-postgres:
         condition: service_healthy


### PR DESCRIPTION
## 🔧 작업 내용 
- Order-Core에 `email` 패키지 추가하여 Kafka 이벤트 기반 이메일 발송 구현
- `payment-completed`, `order-cancelled` 토픽을 `order-core-notification` Consumer Group으로 구독
- 결제 완료 시 확인 메일, 주문 취소 시 안내 메일을 Gmail SMTP로 발송
- EDA 전환 완료!!!

## 🧩 구현 상세
### Consumer (Order-Core)
- `EmailEventConsumer`: `payment-completed`, `order-cancelled` 토픽 구독 (Consumer Group: `order-core-notification`)
- Seat 서비스의 `seat-service` 그룹과 독립적으로 같은 이벤트를 각각 수신
- 주문 조회 실패 시 WARN 로그 남기고 스킵 (이메일 실패가 비즈니스 로직에 영향 없음)

### EmailService
- `sendPaymentConfirmation()`: 결제 완료 안내 메일 (주문번호, 금액, 결제 수단, 좌석 수)
- `sendCancellationConfirmation()`: 예매 취소 안내 메일 (주문번호, 취소 수수료, 환불 금액)
- `SimpleMailMessage`로 텍스트 메일 발송 (HTML 템플릿은 후속 작업에서 구현)
- 이메일 주소 마스킹 처리 로그 (`go****@gmail.com`)
- try-catch로 발송 실패 시에도 서비스 중단 없음

### 📌 관련 Jira Issue
  - GRGB-329

  ## 🧪 테스트 방법
  1. Docker Kafka + Order-Core 서비스 기동 (local 프로필)
  2. Kafka UI → `payment-completed` 토픽에 메시지 발행
  3. Value: `{"orderId":실제주문ID,"userId":1,"matchId":1,"matchSeatIds":1],"paymentMethod":"TOSS_PAY","totalAmount":30000,"occurredAt":"2026-03-31T08:00:00Z"}`
4. Headers: `{"__TypeId__":"com.goormgb.be.kafka.event.PaymentCompletedEvent"}`
5. Order-Core 로그에서 `[Email] 발송 성공` 확인
6. 해당 주문의 `ordererEmail`로 실제 메일 수신 확인

## ❗ 참고 사항
- 현재는 텍스트 메일로 기본 정보만 발송 — HTML 이메일 템플릿(피그마 디자인 기반)은 별도 브랜치(`feat/email-html-template`)에서    후속 작업 예정                                                                                                                    
- 수신자 분기(가입 이메일 vs 예매자 이메일)도 HTML 템플릿 작업에서 함께 구현 예정
- `.env`에 `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD` 환경변수 추가 필요‼️‼️‼️‼️‼️
- IntelliJ에서 Gradle 코끼리 새로고침 필수 (`spring-boot-starter-mail` 의존성 반영)