### PR TITLE
fix(global): 침투 테스트 대응 보안 강화 [GRGB-333]

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/CorsGlobalFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/CorsGlobalFilter.java
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono;
 @Component
 public class CorsGlobalFilter implements WebFilter, Ordered {
 
-	@Value("${ALLOWED_ORIGINS:*}")
+	@Value("${ALLOWED_ORIGINS}")
 	private String allowedOrigins;
 
 	@Override
@@ -27,7 +27,8 @@ public class CorsGlobalFilter implements WebFilter, Ordered {
 			headers.set("Access-Control-Allow-Origin", origin);
 			headers.set("Access-Control-Allow-Credentials", "true");
 			headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-			headers.set("Access-Control-Allow-Headers", "*");
+			headers.set("Access-Control-Allow-Headers",
+				"Authorization, Content-Type, X-Requested-With, Accept, Origin");
 			headers.set("Vary", "Origin");
 		}
 
@@ -40,9 +41,6 @@ public class CorsGlobalFilter implements WebFilter, Ordered {
 	}
 
 	private boolean isAllowed(String origin) {
-		if ("*".equals(allowedOrigins)) {
-			return true;
-		}
 		for (String allowed : allowedOrigins.split(",")) {
 			if (origin.equalsIgnoreCase(allowed.trim())) {
 				return true;

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/jwt/provider/JwtTokenProvider.java
@@ -40,6 +40,8 @@ public class JwtTokenProvider {
 		try {
 			return Jwts.parser()
 					.verifyWith(publicKey)
+					.requireIssuer(jwtProperties.getIssuer())
+					.requireAudience(jwtProperties.getAccessToken().getAudience())
 					.build()
 					.parseSignedClaims(token)
 					.getPayload();

--- a/API-Gateway/src/main/resources/application-dev.yaml
+++ b/API-Gateway/src/main/resources/application-dev.yaml
@@ -58,6 +58,22 @@ management:
       export:
         enabled: true
 
+springdoc:
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    urls:
+      - name: Auth-Guard
+        url: /auth/v3/api-docs
+      - name: Queue
+        url: /queue/v3/api-docs
+      - name: Seat
+        url: /seat/v3/api-docs
+      - name: Order-Core
+        url: /order/v3/api-docs
+  api-docs:
+    enabled: true
+
 logging:
   level:
     root: INFO

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -44,16 +44,9 @@ jwt:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui.html
-    urls:
-      - name: Auth-Guard
-        url: /auth/v3/api-docs
-      - name: Queue
-        url: /queue/v3/api-docs
-      - name: Seat
-        url: /seat/v3/api-docs
-      - name: Order-Core
-        url: /order/v3/api-docs
+    enabled: false
+  api-docs:
+    enabled: false
 
 management:
   endpoints:

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -31,6 +31,13 @@ public class AuthGuardSecurityConfig {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
 				.logout(AbstractHttpConfigurer::disable)
+				.headers(headers -> headers
+					.contentTypeOptions(ctOptions -> {})
+					.frameOptions(frame -> frame.deny())
+					.httpStrictTransportSecurity(hsts -> hsts
+						.includeSubDomains(true)
+						.maxAgeInSeconds(31536000))
+				)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
@@ -37,5 +37,6 @@ public class JwtProperties {
 	@Setter
 	public static class Cookie {
 		private boolean secure = true;
+		private String sameSite = "Lax";
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
@@ -27,13 +27,11 @@ public class CookieUtils {
 		long maxAgeSeconds = TimeUnit.DAYS.toSeconds(jwtProperties.getRefreshToken().getExpirationDays());
 
 		return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-				.httpOnly(true)     // XSS 방지
+				.httpOnly(true)
 				.secure(jwtProperties.getCookie().isSecure())
-				// TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
-				//  SameSite=Lax, secure=false로 되돌릴 것.
-				.sameSite("None")   // cross-site 요청에서도 쿠키 전송 (HTTPS 필수)
-				.path("/")          // 모든 경로에서 쿠키전송
-				.maxAge(maxAgeSeconds)// 7일 만료
+				.sameSite(jwtProperties.getCookie().getSameSite())
+				.path("/")
+				.maxAge(maxAgeSeconds)
 				.build();
 	}
 
@@ -44,11 +42,9 @@ public class CookieUtils {
 		return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
 				.httpOnly(true)
 				.secure(jwtProperties.getCookie().isSecure())
-				// TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
-				//  SameSite=Lax, secure=false로 되돌릴 것.
-				.sameSite("None")
+				.sameSite(jwtProperties.getCookie().getSameSite())
 				.path("/")
-				.maxAge(0)    // 즉시 만료 -> 브라우저에서 삭제
+				.maxAge(0)
 				.build();
 	}
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
@@ -1,5 +1,7 @@
 package com.goormgb.be.authguard.kakao.client;
 
+import java.net.URI;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -97,12 +99,24 @@ public class KakaoOAuthClient {
 
 		if (properties.getAllowedRedirectUris() != null
 			&& properties.getAllowedRedirectUris().stream()
-				.anyMatch(allowed -> customRedirectUri.startsWith(allowed))) {
+				.anyMatch(allowed -> matchesOrigin(customRedirectUri, allowed))) {
 			return customRedirectUri;
 		}
 
 		log.warn("[OAuth] 허용되지 않은 redirectUri 요청: {}", customRedirectUri);
 		throw new CustomException(ErrorCode.OAUTH_REDIRECT_URI_MISMATCH);
+	}
+
+	private boolean matchesOrigin(String redirectUri, String allowedOrigin) {
+		try {
+			URI target = URI.create(redirectUri);
+			URI allowed = URI.create(allowedOrigin);
+			return target.getScheme().equals(allowed.getScheme())
+				&& target.getHost().equals(allowed.getHost())
+				&& target.getPort() == allowed.getPort();
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	/**

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/client/KakaoOAuthClient.java
@@ -40,9 +40,7 @@ public class KakaoOAuthClient {
 	 * 프론트에서 이 URL로 location.href 이동
 	 */
 	public String createLoginUrl(String customRedirectUri) {
-		String redirectUri = StringUtils.hasText(customRedirectUri)
-				? customRedirectUri
-				: properties.getRedirectUri();
+		String redirectUri = resolveAndValidateRedirectUri(customRedirectUri);
 
 		return UriComponentsBuilder.fromUriString(properties.getAuthUrl())
 				.queryParam("response_type", "code")
@@ -58,9 +56,7 @@ public class KakaoOAuthClient {
 	 * @return 카카오 Access Token
 	 */
 	public KakaoTokenResponse requestAccessToken(String authorizationCode, String redirectUri) {
-		String effectiveRedirectUri = StringUtils.hasText(redirectUri)
-				? redirectUri
-				: properties.getRedirectUri();
+		String effectiveRedirectUri = resolveAndValidateRedirectUri(redirectUri);
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
@@ -92,6 +88,21 @@ public class KakaoOAuthClient {
 			}
 			throw new CustomException(ErrorCode.OAUTH_PROVIDER_ERROR, e);
 		}
+	}
+
+	private String resolveAndValidateRedirectUri(String customRedirectUri) {
+		if (!StringUtils.hasText(customRedirectUri)) {
+			return properties.getRedirectUri();
+		}
+
+		if (properties.getAllowedRedirectUris() != null
+			&& properties.getAllowedRedirectUris().stream()
+				.anyMatch(allowed -> customRedirectUri.startsWith(allowed))) {
+			return customRedirectUri;
+		}
+
+		log.warn("[OAuth] 허용되지 않은 redirectUri 요청: {}", customRedirectUri);
+		throw new CustomException(ErrorCode.OAUTH_REDIRECT_URI_MISMATCH);
 	}
 
 	/**

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/config/KakaoOAuthProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/config/KakaoOAuthProperties.java
@@ -1,5 +1,7 @@
 package com.goormgb.be.authguard.kakao.config;
 
+import java.util.List;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Getter;
@@ -12,6 +14,7 @@ public class KakaoOAuthProperties {
 	private final String clientId;
 	private final String clientSecret;
 	private final String redirectUri;
+	private final List<String> allowedRedirectUris;
 
 	private final String authUrl;
 	private final String tokenUrl;

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -41,9 +41,8 @@ jwt:
     audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
     expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
   cookie:
-    # TODO: 프론트 배포 환경이 동일 도메인(goormgb.space)으로 확정되면
-    # SameSite=Lax, secure=false로 되돌릴 것.
     secure: true
+    same-site: None
 
 internal:
   api-key: ${INTERNAL_API_KEY}
@@ -52,6 +51,10 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  allowed-redirect-uris:
+    - http://localhost:3000
+    - https://playball.one
+    - https://staging.playball.one
 
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
@@ -69,6 +72,12 @@ management:
     metrics:
       export:
         enabled: true
+
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
 
 logging:
   level:

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -53,6 +53,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  allowed-redirect-uris:
+    - https://playball.one
+    - https://staging.playball.one
 
   auth-url: https://kauth.kakao.com/oauth/authorize
   token-url: https://kauth.kakao.com/oauth/token
@@ -74,6 +77,12 @@ management:
     distribution:
       percentiles-histogram:
         http.server.requests: true
+
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
 
 logging:
   config: classpath:logback-spring.xml

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -24,6 +24,13 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
+				.headers(headers -> headers
+					.contentTypeOptions(ctOptions -> {})
+					.frameOptions(frame -> frame.deny())
+					.httpStrictTransportSecurity(hsts -> hsts
+						.includeSubDomains(true)
+						.maxAgeInSeconds(31536000))
+				)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -81,6 +81,12 @@ management:
       export:
         enabled: true
 
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+
 logging:
   level:
     root: INFO

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -88,6 +88,12 @@ management:
       percentiles-histogram:
         http.server.requests: true
 
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
@@ -24,6 +24,13 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
+				.headers(headers -> headers
+					.contentTypeOptions(ctOptions -> {})
+					.frameOptions(frame -> frame.deny())
+					.httpStrictTransportSecurity(hsts -> hsts
+						.includeSubDomains(true)
+						.maxAgeInSeconds(31536000))
+				)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -69,6 +69,12 @@ management:
       export:
         enabled: true
 
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+
 logging:
   level:
     root: INFO

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -76,6 +76,12 @@ management:
       percentiles-histogram:
         http.server.requests: true
 
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -24,6 +24,13 @@ public class SecurityConfig {
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)
+				.headers(headers -> headers
+					.contentTypeOptions(ctOptions -> {})
+					.frameOptions(frame -> frame.deny())
+					.httpStrictTransportSecurity(hsts -> hsts
+						.includeSubDomains(true)
+						.maxAgeInSeconds(31536000))
+				)
 				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -62,6 +62,12 @@ management:
       export:
         enabled: true
 
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+
 logging:
   level:
     root: INFO

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -69,6 +69,12 @@ management:
       percentiles-histogram:
         http.server.requests: true
 
+springdoc:
+  swagger-ui:
+    enabled: false
+  api-docs:
+    enabled: false
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/common-core/src/main/java/com/goormgb/be/global/environment/DetailedErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/DetailedErrorResponseStrategy.java
@@ -37,6 +37,11 @@ public class DetailedErrorResponseStrategy implements ErrorResponseStrategy {
 	}
 
 	@Override
+	public String resolveCode(HttpStatus status) {
+		return status.name();
+	}
+
+	@Override
 	public String resolveMessage(String detailedMessage, HttpStatus status) {
 		return detailedMessage;
 	}

--- a/common-core/src/main/java/com/goormgb/be/global/environment/ErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/ErrorResponseStrategy.java
@@ -24,5 +24,9 @@ public interface ErrorResponseStrategy {
 
 	String resolveMessage(ErrorCode errorCode);
 
+	default String resolveCode(HttpStatus status) {
+		return status.series().name();
+	}
+
 	String resolveMessage(String detailedMessage, HttpStatus status);
 }

--- a/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -49,6 +50,11 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(AuthorizationDeniedException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> handleAuthorizationDenied(AuthorizationDeniedException e) {
 		return ErrorResponse.error(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", errorResponseStrategy);
+	}
+
+	@ExceptionHandler(NoResourceFoundException.class)
+	public ResponseEntity<ErrorResponse.ErrorData> handleNoResourceFound(NoResourceFoundException e) {
+		return ErrorResponse.error(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다.", errorResponseStrategy);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)

--- a/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
+++ b/common-core/src/main/java/com/goormgb/be/global/response/ErrorResponse.java
@@ -27,7 +27,7 @@ public class ErrorResponse {
 	public static ResponseEntity<ErrorData> error(HttpStatus status, String detailedMessage,
 		ErrorResponseStrategy strategy) {
 		return ResponseEntity.status(status)
-			.body(ErrorData.of(status.series().name(), strategy.resolveMessage(detailedMessage, status)));
+			.body(ErrorData.of(strategy.resolveCode(status), strategy.resolveMessage(detailedMessage, status)));
 	}
 
 	@Getter


### PR DESCRIPTION
## 🔧 작업 내용
### 기존 Staging, prod의 보안 내역을 dev에도 반영하여 보안 강화를 defalut로, profile별로 다르게 보안을 적용하도록 했습니다
- 침투 테스트에서 발견된 보안 취약점 대응
- staging/prod 환경에서 불필요한 정보 노출 차단 및 인증/인가 강화
- 전 모듈(Auth-Guard, API-Gateway, Seat, Queue, Order-Core) 공통 보안 설정 적용

## 🧩 구현 상세
### CORS 강화 (API-Gateway)
- `ALLOWED_ORIGINS` 기본값 `*` 제거 → 환경변수 필수 (미설정 시 앱 시작 실패)
- `Access-Control-Allow-Headers` 와일드카드 → 명시적 화이트리스트 (`Authorization, Content-Type,  X-Requested-With, Accept, Origin`)

### JWT 검증 강화 (API-Gateway)
- `requireIssuer()`, `requireAudience()` 추가 → 서명 외 발급자/수신자 일치 여부 검증

### 보안 헤더 추가 (전 모듈 SecurityConfig)
- `X-Content-Type-Options: nosniff` — MIME 스니핑 차단
- `X-Frame-Options: DENY` — 클릭재킹 방지
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — HTTPS 강제

### Cookie SameSite 환경변수화 (Auth-Guard)
- 하드코딩 제거 → `jwt.cookie.same-site` 프로퍼티로 주입
- local/dev: `None` / staging/prod: `Lax` (기본값)

### Swagger 비활성화 (전 모듈)
- staging/prod: `springdoc.swagger-ui.enabled: false`, `api-docs.enabled: false`
- local/dev: 기존대로 활성화

### OAuth redirectUri 검증 (Auth-Guard)
- `kakao.allowed-redirect-uris` 화이트리스트 추가
- 허용되지 않은 redirectUri 요청 시 `OAUTH_REDIRECT_URI_MISMATCH` 에러 + 경고 로그
- staging/prod: `playball.one`, `staging.playball.one`만 허용
- local/dev: `localhost:3000` 추가 허용

### 에러 응답 개선 (common-core)
- `NoResourceFoundException` 500 → 404 수정 (존재하지 않는 경로 스캔 공격 대응)
- dev 환경 에러 코드 `CLIENT_ERROR` → `BAD_REQUEST` 등 HttpStatus 상세 노출
- `ErrorResponseStrategy`에 `resolveCode(HttpStatus)` default 메서드 추가

### 로깅 개선
- `EmailService` 이메일 PII 마스킹 (`gr***@gmail.com`)
- 유저 차단/해제 시 `[User Block]`, `[User Unblock]` 로그 추가

### 📌 관련 Jira Issue
- GRGB-333 (침투 테스트 대응 긴급 패치)

## 🧪 테스트 방법 
- staging 배포 후 Swagger UI 접근 불가 확인 (`/swagger-ui.html` → 404)
- 존재하지 않는 경로 요청 시 404 응답 확인 (기존 500)
- 카카오 로그인 시 `redirectUri=https://evil-site.com` → 에러 응답 확인
- 응답 헤더에 `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security` 포함 확인

## ❗ 참고 사항
- `ALLOWED_ORIGINS` 환경변수가 staging/prod에 반드시 설정되어 있어야 함 (미설정 시 앱 시작 실패)
- Cookie SameSite 정책 변경으로 프론트와 백엔드 동일 도메인 필수 (staging: `staging.playball.one`)
- `/loadtest/*` 엔드포인트는 부하테스트를 위해 staging 프로필 유지

---

<html><head></head><body><h3>dev 환경에서 달라진 것</h3>

항목 | 변경 전 | 변경 후
-- | -- | --
Swagger | 접근 가능 | 접근 가능 (변화 없음)
에러 코드 | CLIENT_ERROR | BAD_REQUEST 등 상세 HttpStatus
에러 메시지 | 상세 메시지 | 상세 메시지 (변화 없음)

<html><head></head><body><h3>staging 환경에서 달라진 것</h3>

항목 | 변경 전 | 변경 후
-- | -- | --
Swagger | 누구나 접근 가능 | 완전 비활성화
CORS | ALLOWED_ORIGINS 없으면 * (전체 허용) | 환경변수 필수, 없으면 앱 시작 실패
CORS Headers | * (전체 허용) | Authorization, Content-Type 등 명시적 목록만
JWT 검증 | 서명만 검증 | issuer + audience 추가 검증
보안 헤더 | 없음 | HSTS, X-Frame-Options: DENY, nosniff 추가
Cookie | SameSite=None | SameSite=Lax
OAuth redirectUri | 아무 URL 허용 | 화이트리스트 검증 (playball.one만)
404 처리 | 존재하지 않는 경로 → 500 | 404로 정상 응답
이메일 로그 | 평문 노출 | 마스킹 (gr***@gmail.com)
유저 차단 로그 | 없음 | 차단/해제 시 로그 기록

</body></html>
