### PR TITLE
fix(auth-guard): BLOCKED 유저 로그인 차단 — LoadTest/카카오 로그인 상태 검증 추가

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -15,8 +15,10 @@ import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.user.entity.LoadTestUser;
 import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.enums.UserStatus;
 import com.goormgb.be.user.repository.LoadTestUserRepository;
 import com.goormgb.be.user.repository.UserRepository;
 
@@ -76,6 +78,9 @@ public class LoadTestAuthService {
 		}
 
 		User user = loadTestUser.getUser();
+
+		Preconditions.validate(user.getStatus() != UserStatus.BLOCKED, ErrorCode.USER_ALREADY_BLOCKED);
+
 		user.updateLastLoginAt();
 
 		String sid = UUID.randomUUID().toString();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -79,6 +79,7 @@ public class LoadTestAuthService {
 
 		User user = loadTestUser.getUser();
 
+		Preconditions.validate(user.getStatus() != UserStatus.DEACTIVATE, ErrorCode.USER_DEACTIVATED);
 		Preconditions.validate(user.getStatus() != UserStatus.BLOCKED, ErrorCode.USER_ALREADY_BLOCKED);
 
 		user.updateLastLoginAt();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -73,6 +73,10 @@ public class KakaoAuthService {
 				user.getStatus() != UserStatus.DEACTIVATE,
 				ErrorCode.USER_DEACTIVATED
 		);
+		Preconditions.validate(
+				user.getStatus() != UserStatus.BLOCKED,
+				ErrorCode.USER_ALREADY_BLOCKED
+		);
 
 		// 5. 로그인 처리
 		user.updateLastLoginAt();

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
 	USER_DEACTIVATED(HttpStatus.FORBIDDEN, "비활성화된 사용자입니다."),
-	USER_ALREADY_BLOCKED(HttpStatus.CONFLICT, "이미 차단된 사용자입니다."),
+	USER_ALREADY_BLOCKED(HttpStatus.CONFLICT, "차단된 사용자입니다."),
 	USER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "이미 활성 상태인 사용자입니다."),
 
 	// Onboarding

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
 	USER_DEACTIVATED(HttpStatus.FORBIDDEN, "비활성화된 사용자입니다."),
-	USER_ALREADY_BLOCKED(HttpStatus.CONFLICT, "차단된 사용자입니다."),
+	USER_ALREADY_BLOCKED(HttpStatus.FORBIDDEN, "차단된 사용자입니다."),
 	USER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "이미 활성 상태인 사용자입니다."),
 
 	// Onboarding


### PR DESCRIPTION
## 🔧 작업 내용
- BLOCKED 상태 유저가 LoadTest 로그인, 카카오 로그인으로 토큰 발급받을 수 있던 문제 수정
- 로그인 가능한 보안 허점발견하여 대응

## 🧩 구현 상세
- `LoadTestAuthService.login()`: BLOCKED 상태 체크 추가 
- `KakaoAuthService.kakaoLogin()`: 기존 DEACTIVATE만 체크 → BLOCKED 체크추가

## ❗ 참고 사항
4/3 부터 침투테스트 보안 및 앱 보안 관련은 @siyeon13 님이 작업 봐주시면 감사하겠습니다!