### PR TITLE
ci(github): GitHub Release 생성 시 디스코드 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/release-discord-notify.yml
+++ b/.github/workflows/release-discord-notify.yml
@@ -1,0 +1,45 @@
+name: Release Discord Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set environment label
+        id: env
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "label=Staging" >> $GITHUB_OUTPUT
+          else
+            echo "label=Production" >> $GITHUB_OUTPUT
+          fi
+          echo "color=65280" >> $GITHUB_OUTPUT
+
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+        run: |
+          # 릴리즈 노트 본문 (2000자 제한, JSON escape)
+          BODY=$(echo '${{ github.event.release.body }}' | head -c 1800 | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"${{ github.event.release.tag_name }}\",
+                \"description\": $BODY,
+                \"url\": \"${{ github.event.release.html_url }}\",
+                \"color\": ${{ steps.env.outputs.color }},
+                \"author\": {
+                  \"name\": \"${{ github.event.release.author.login }}\"
+                },
+                \"footer\": {
+                  \"text\": \"${{ steps.env.outputs.label }} Release\"
+                },
+                \"timestamp\": \"${{ github.event.release.published_at }}\"
+              }]
+            }" \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## 🔧 작업 내용
- GitHub Release 생성 시 디스코드 채널에 자동 알림 발송하는 워크플로우 추가
- staging/prod 배포는 PR 없이 push로 진행되어 팀 공유가 안 되던 문제 해결

## 🧩 구현 상세
- `release-discord-notify.yml` 워크플로우 추가
- staging(pre-release) / prod(release) 구분하여 footer에 환경 표시
- 릴리즈 노트 본문, 태그명, 작성자, 링크 포함된 임베드 메시지 발송