### PR TITLE
feat(metrics): add X-Test-Id header as test_id metric label

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/config/ObservationConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/ObservationConfig.java
@@ -1,32 +1,50 @@
 package com.goormgb.be.global.config;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.observation.ObservationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 
 /**
  * Observation configuration for adding custom metrics tags.
  * Adds X-Test-Id header value as 'test_id' label to HTTP server metrics.
+ *
+ * - Uses ObservationFilter for broader compatibility (MVC + WebFlux future support)
+ * - Limits cardinality to prevent metric explosion in Prometheus
  */
 @Configuration
 public class ObservationConfig {
 
+    /**
+     * Adds test_id tag from X-Test-Id header to HTTP server metrics.
+     * Works with Spring MVC ServerRequestObservationContext.
+     */
     @Bean
-    public DefaultServerRequestObservationConvention serverRequestObservationConvention() {
-        return new DefaultServerRequestObservationConvention() {
-            @Override
-            public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
-                return super.getLowCardinalityKeyValues(context)
-                    .and(testIdTag(context));
+    public ObservationFilter testIdObservationFilter() {
+        return context -> {
+            if (context instanceof ServerRequestObservationContext serverContext) {
+                String testId = serverContext.getCarrier() != null
+                    ? serverContext.getCarrier().getHeader("X-Test-Id")
+                    : null;
+                context.addLowCardinalityKeyValue(KeyValue.of("test_id", testId != null ? testId : "none"));
             }
-
-            private KeyValue testIdTag(ServerRequestObservationContext context) {
-                String testId = context.getCarrier().getHeader("X-Test-Id");
-                return KeyValue.of("test_id", testId != null ? testId : "none");
-            }
+            return context;
         };
+    }
+
+    /**
+     * Limits test_id tag cardinality to prevent Prometheus index bloat.
+     * Denies new metrics after 100 unique test_id values.
+     */
+    @Bean
+    public MeterFilter testIdCardinalityFilter() {
+        return MeterFilter.maximumAllowableTags(
+            "http.server.requests",
+            "test_id",
+            100,
+            MeterFilter.deny()
+        );
     }
 }

--- a/common-core/src/main/java/com/goormgb/be/global/config/ObservationConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/ObservationConfig.java
@@ -1,0 +1,32 @@
+package com.goormgb.be.global.config;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+
+/**
+ * Observation configuration for adding custom metrics tags.
+ * Adds X-Test-Id header value as 'test_id' label to HTTP server metrics.
+ */
+@Configuration
+public class ObservationConfig {
+
+    @Bean
+    public DefaultServerRequestObservationConvention serverRequestObservationConvention() {
+        return new DefaultServerRequestObservationConvention() {
+            @Override
+            public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
+                return super.getLowCardinalityKeyValues(context)
+                    .and(testIdTag(context));
+            }
+
+            private KeyValue testIdTag(ServerRequestObservationContext context) {
+                String testId = context.getCarrier().getHeader("X-Test-Id");
+                return KeyValue.of("test_id", testId != null ? testId : "none");
+            }
+        };
+    }
+}


### PR DESCRIPTION
🔧 작업 내용

  - k6 부하테스트 시 X-Test-Id 헤더를 Spring Boot 메트릭에 test_id label로 추가
  - Grafana 대시보드에서 테스트 ID별로 메트릭 필터링 가능하도록 개선
  - common-core에 추가하여 모든 서비스(Auth-Guard, Queue, Seat 등)에 자동 적용

  🧩 구현 상세

  - DefaultServerRequestObservationConvention을 확장하여 X-Test-Id 헤더 값을 메트릭 태그로 추가
  - 헤더가 없는 일반 요청은 test_id=none으로 기록되어 부하테스트 트래픽과 구분 가능
  - Spring Boot 4.x Micrometer Observation API 사용

  🧪 테스트 방법

  - k6 부하테스트 실행 후 Prometheus에서 확인:
  http_server_request_duration_seconds_count{test_id!="none"}
  - Grafana "k6 부하테스트 - 수신" 대시보드에서 테스트 ID 필터 확인

  ❗ 참고 사항

  - k6-controller에서 X-Test-Id 헤더 추가 작업 완료
  - 대시보드 variable 쿼리도 test_id label 사용하도록 수정 완료
