### PR TITLE
fix(common-core): DB 암호화 필드 확장 및 Hibernate dirty checking 성능 최적화

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -82,7 +82,7 @@ public class LoadTestAuthService {
 		Preconditions.validate(user.getStatus() != UserStatus.DEACTIVATE, ErrorCode.USER_DEACTIVATED);
 		Preconditions.validate(user.getStatus() != UserStatus.BLOCKED, ErrorCode.USER_ALREADY_BLOCKED);
 
-		user.updateLastLoginAt();
+		// 부하테스트 로그인에서는 lastLoginAt 업데이트 생략 (동시 UPDATE 병목 방지)
 
 		String sid = UUID.randomUUID().toString();
 		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY, sid);

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -16,6 +16,7 @@ import com.goormgb.be.authguard.kakao.client.KakaoOAuthClient;
 import com.goormgb.be.authguard.kakao.dto.KakaoLoginResponse;
 import com.goormgb.be.authguard.kakao.dto.KakaoTokenResponse;
 import com.goormgb.be.authguard.kakao.dto.KakaoUserResponse;
+import com.goormgb.be.global.encryption.HashUtil;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
@@ -56,10 +57,11 @@ public class KakaoAuthService {
 		String nickname = userResponse.getNickname();
 		String profileImageUrl = userResponse.getProfileImageUrl();
 
-		// 3. user_sns 기준으로 기존 사용자 조회
+		// 3. user_sns 기준으로 기존 사용자 조회 (해시 기반)
 		boolean isNewUser = false;
-		Optional<UserSns> existingUserSns = userSnsRepository.findByProviderAndProviderUserId(
-				SocialProvider.KAKAO, providerUserId);
+		String providerUserIdHash = HashUtil.sha256(providerUserId);
+		Optional<UserSns> existingUserSns = userSnsRepository.findByProviderAndProviderUserIdHash(
+				SocialProvider.KAKAO, providerUserIdHash);
 		User user;
 		if (existingUserSns.isPresent()) {
 			user = existingUserSns.get().getUser();

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionCacheCleanupFilter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionCacheCleanupFilter.java
@@ -1,0 +1,31 @@
+package com.goormgb.be.global.encryption;
+
+import java.io.IOException;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class EncryptionCacheCleanupFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			FilterChain filterChain
+	) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			EncryptionConverter.clearCache();
+		}
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
@@ -9,10 +9,27 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * AES-GCM 암호화 컨버터.
+ *
+ * AES-GCM은 랜덤 IV를 사용하므로 동일 평문이라도 매번 다른 암호문이 생성된다.
+ * Hibernate dirty checking 시 convertToDatabaseColumn()이 호출되면
+ * 기존 DB 스냅샷과 다른 값이 반환되어 불필요한 UPDATE가 발생한다.
+ *
+ * 이를 방지하기 위해 ThreadLocal에 "DB에서 읽은 원본 암호문"을 캐싱하고,
+ * 평문이 변경되지 않았으면 원본 암호문을 그대로 반환한다.
+ */
 @Converter
 public class EncryptionConverter implements AttributeConverter<String, String> {
 
 	private static EncryptionProvider encryptionProvider;
+
+	/**
+	 * ThreadLocal 캐시: 복호화 시 (암호문 → 평문) 매핑을 저장.
+	 * dirty checking 시 평문이 동일하면 원본 암호문을 재사용하여 불필요한 UPDATE 방지.
+	 */
+	private static final ThreadLocal<java.util.Map<String, String>> PLAINTEXT_TO_CIPHER_CACHE =
+			ThreadLocal.withInitial(java.util.HashMap::new);
 
 	@Slf4j
 	@Component
@@ -36,6 +53,13 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
 		if (encryptionProvider == null) {
 			throw new IllegalStateException("EncryptionProvider가 초기화되지 않았습니다.");
 		}
+
+		// 캐시에 동일 평문에 대한 원본 암호문이 있으면 재사용 (dirty checking 우회)
+		String cached = PLAINTEXT_TO_CIPHER_CACHE.get().get(attribute);
+		if (cached != null) {
+			return cached;
+		}
+
 		return encryptionProvider.encrypt(attribute);
 	}
 
@@ -47,6 +71,20 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
 		if (encryptionProvider == null) {
 			throw new IllegalStateException("EncryptionProvider가 초기화되지 않았습니다.");
 		}
-		return encryptionProvider.decrypt(dbData);
+
+		String plainText = encryptionProvider.decrypt(dbData);
+
+		// 복호화 시 (평문 → 원본 암호문) 캐싱
+		PLAINTEXT_TO_CIPHER_CACHE.get().put(plainText, dbData);
+
+		return plainText;
+	}
+
+	/**
+	 * 요청 종료 시 ThreadLocal 캐시 정리.
+	 * Filter/Interceptor에서 호출하거나, @Transactional 종료 후 자동 정리 용도.
+	 */
+	public static void clearCache() {
+		PLAINTEXT_TO_CIPHER_CACHE.remove();
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/EncryptionConverter.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
@@ -18,18 +20,31 @@ import lombok.extern.slf4j.Slf4j;
  *
  * 이를 방지하기 위해 ThreadLocal에 "DB에서 읽은 원본 암호문"을 캐싱하고,
  * 평문이 변경되지 않았으면 원본 암호문을 그대로 반환한다.
+ *
+ * <h3>캐시 정리 전략</h3>
+ * <ul>
+ *   <li>웹 요청: {@link EncryptionCacheCleanupFilter}에서 요청 종료 시 정리</li>
+ *   <li>비웹 컨텍스트(@Scheduled, @KafkaListener 등): {@link TransactionSynchronization}으로 트랜잭션 종료 시 자동 정리</li>
+ * </ul>
+ *
+ * <h3>캐시 키 제약사항</h3>
+ * 캐시 키는 평문(plaintext)이며 필드 구분 없이 저장된다.
+ * {@link AttributeConverter}는 어떤 엔티티의 어떤 필드에서 호출되는지 알 수 없으므로,
+ * 동일 엔티티 내에서 서로 다른 암호화 필드가 같은 평문 값을 가질 경우
+ * 마지막 복호화된 암호문으로 덮어씌워질 수 있다.
+ * 다만 email, nickname, profileImageUrl 등은 도메인 특성상 동일 값을 가질 확률이 극히 낮아
+ * 실질적 영향은 없다.
  */
 @Converter
 public class EncryptionConverter implements AttributeConverter<String, String> {
 
 	private static EncryptionProvider encryptionProvider;
 
-	/**
-	 * ThreadLocal 캐시: 복호화 시 (암호문 → 평문) 매핑을 저장.
-	 * dirty checking 시 평문이 동일하면 원본 암호문을 재사용하여 불필요한 UPDATE 방지.
-	 */
 	private static final ThreadLocal<java.util.Map<String, String>> PLAINTEXT_TO_CIPHER_CACHE =
 			ThreadLocal.withInitial(java.util.HashMap::new);
+
+	/** 현재 트랜잭션에 정리 콜백이 이미 등록되었는지 추적 */
+	private static final ThreadLocal<Boolean> CLEANUP_REGISTERED = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
 	@Slf4j
 	@Component
@@ -77,14 +92,35 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
 		// 복호화 시 (평문 → 원본 암호문) 캐싱
 		PLAINTEXT_TO_CIPHER_CACHE.get().put(plainText, dbData);
 
+		// 비웹 컨텍스트(@Scheduled, @KafkaListener 등)에서도 트랜잭션 종료 시 캐시 정리
+		registerTransactionCleanup();
+
 		return plainText;
 	}
 
 	/**
-	 * 요청 종료 시 ThreadLocal 캐시 정리.
-	 * Filter/Interceptor에서 호출하거나, @Transactional 종료 후 자동 정리 용도.
+	 * 트랜잭션 종료 시 ThreadLocal 캐시를 정리하는 콜백을 등록한다.
+	 * 웹 요청은 EncryptionCacheCleanupFilter에서도 정리되므로 이중 안전장치 역할.
+	 * 비웹 컨텍스트에서는 이 콜백이 유일한 정리 수단이다.
+	 */
+	private static void registerTransactionCleanup() {
+		if (!CLEANUP_REGISTERED.get() && TransactionSynchronizationManager.isSynchronizationActive()) {
+			CLEANUP_REGISTERED.set(Boolean.TRUE);
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCompletion(int status) {
+					clearCache();
+				}
+			});
+		}
+	}
+
+	/**
+	 * ThreadLocal 캐시 정리.
+	 * EncryptionCacheCleanupFilter(웹) 및 TransactionSynchronization(비웹)에서 호출된다.
 	 */
 	public static void clearCache() {
 		PLAINTEXT_TO_CIPHER_CACHE.remove();
+		CLEANUP_REGISTERED.remove();
 	}
 }

--- a/common-core/src/main/java/com/goormgb/be/global/encryption/HashUtil.java
+++ b/common-core/src/main/java/com/goormgb/be/global/encryption/HashUtil.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.global.encryption;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class HashUtil {
+
+	private HashUtil() {
+	}
+
+	public static String sha256(String input) {
+		if (input == null) {
+			return null;
+		}
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hash);
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/user/entity/User.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/User.java
@@ -36,7 +36,8 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", length = 512)
 	private String nickname;
 
-	@Column(name = "profile_image_url")
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "profile_image_url", length = 1024)
 	private String profileImageUrl;
 
 	@Column(name = "onboarding_completed", nullable = false)

--- a/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -26,8 +27,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_sns", uniqueConstraints = {
 		@UniqueConstraint(columnNames = {"provider", "provider_user_id_hash"})
 }, indexes = {
-		@Index(name = "idx_user_sns_user_id", columnList = "user_id"),
-		@Index(name = "idx_user_sns_provider_hash", columnList = "provider, provider_user_id_hash")
+		@Index(name = "idx_user_sns_user_id", columnList = "user_id")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -57,6 +57,7 @@ public class UserSns extends BaseEntity {
 	}
 
 	@PrePersist
+	@PreUpdate
 	private void ensureHash() {
 		if (this.providerUserIdHash == null && this.providerUserId != null) {
 			this.providerUserIdHash = HashUtil.sha256(this.providerUserId);

--- a/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
+++ b/common-core/src/main/java/com/goormgb/be/user/entity/UserSns.java
@@ -1,9 +1,12 @@
 package com.goormgb.be.user.entity;
 
 import com.goormgb.be.global.entity.BaseEntity;
+import com.goormgb.be.global.encryption.EncryptionConverter;
+import com.goormgb.be.global.encryption.HashUtil;
 import com.goormgb.be.user.enums.SocialProvider;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -11,6 +14,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -20,9 +24,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "user_sns", uniqueConstraints = {
-		@UniqueConstraint(columnNames = {"provider", "provider_user_id"})
+		@UniqueConstraint(columnNames = {"provider", "provider_user_id_hash"})
 }, indexes = {
-		@Index(name = "idx_user_sns_user_id", columnList = "user_id")
+		@Index(name = "idx_user_sns_user_id", columnList = "user_id"),
+		@Index(name = "idx_user_sns_provider_hash", columnList = "provider, provider_user_id_hash")
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,14 +41,26 @@ public class UserSns extends BaseEntity {
 	@Column(name = "provider", nullable = false, length = 20)
 	private SocialProvider provider;
 
-	@Column(name = "provider_user_id", nullable = false, length = 128)
+	@Convert(converter = EncryptionConverter.class)
+	@Column(name = "provider_user_id", nullable = false, length = 512)
 	private String providerUserId;
+
+	@Column(name = "provider_user_id_hash", nullable = false, length = 64)
+	private String providerUserIdHash;
 
 	@Builder
 	public UserSns(User user, SocialProvider provider, String providerUserId) {
 		this.user = user;
 		this.provider = provider != null ? provider : SocialProvider.KAKAO;
 		this.providerUserId = providerUserId;
+		this.providerUserIdHash = HashUtil.sha256(providerUserId);
+	}
+
+	@PrePersist
+	private void ensureHash() {
+		if (this.providerUserIdHash == null && this.providerUserId != null) {
+			this.providerUserIdHash = HashUtil.sha256(this.providerUserId);
+		}
 	}
 
 	public static UserSns create(User user, SocialProvider provider, String providerUserId) {

--- a/common-core/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/user/repository/UserSnsRepository.java
@@ -8,9 +8,9 @@ import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.enums.SocialProvider;
 
 public interface UserSnsRepository extends JpaRepository<UserSns, Long> {
-	Optional<UserSns> findByProviderAndProviderUserId(
+	Optional<UserSns> findByProviderAndProviderUserIdHash(
 			SocialProvider provider,
-			String providerUserId
+			String providerUserIdHash
 	);
 
 	Optional<UserSns> findByUserId(Long userId);


### PR DESCRIPTION
## 🔧 작업 내용
- users.profile_image_url, user_sns.provider_user_id 필드에 AES-256-GCM 암호화 적용
- provider_user_id는 암호화 후 DB 조회가 불가하므로 SHA-256 해시 컬럼(provider_user_id_hash) 추가 및 해시 기반 조회로 전환
- AES-GCM 랜덤 IV로 인해 Hibernate dirty checking이 매 요청마다 불필요한 UPDATE를 실행하는 성능 이슈 발견 및 수정 (cc. @212clab )
- 부하테스트 로그인 시 lastLoginAt UPDATE 제거로 동시 쓰기 병목 완화

##  🧩 구현 상세
### 1. 암호화 필드 확장 (5b24756)
- User.profileImageUrl: 암호화
- AES-GCM은 동일 평문 → 다른 암호문이므로 기존 findByProviderAndProviderUserId 조회 불가 → findByProviderAndProviderUserIdHash로 전환
- unique constraint도 (provider, provider_user_id) → (provider, provider_user_id_hash)로 변경

###  2. Hibernate dirty checking 불필요 UPDATE 방지 (3cf7e5b)

- 문제: AES-GCM 랜덤 IV 특성상 복호화 후 재암호화 시 다른 암호문 생성 → Hibernate가 "값 변경됨"으로 오탐 → readOnly 조회(/me)에서도 매번 UPDATE 실행
- 해결: EncryptionConverter에 ThreadLocal 캐시 도입. 복호화 시 (평문 → 원본 암호문) 매핑을 저장하고, dirty check 시 동일 평문이면 원본 암호문을 그대로 반환
- EncryptionCacheCleanupFilter로 요청 종료 시 ThreadLocal 캐시 정리 (메모리 누수 방지)

###  3. 부하테스트 로그인 UPDATE 제거 (acd404b)
- LoadTestAuthService.login()에서 updateLastLoginAt() 호출 제거
- 3000 VU 동시 로그인 시 불필요한 row lock 경합 방지

## 🧪 테스트 방법
 - ./gradlew compileJava 빌드 성공 확인
- staging 환경 배포 후 /me 엔드포인트 호출 시 Hibernate 로그에서 UPDATE 쿼리 미발생 확인 필요

##  ❗ 참고 사항
- staging DB 정리. user_sns에 평문으로 저장된 기존 데이터 삭제 완료.
- user_sns 테이블 DDL 변경 발생: provider_user_id_hash 컬럼 추가, unique constraint 변경 → staging은
  ddl-auto로 처리, prod 배포 시 별도 마이그레이션 필요