### PR TITLE
feat(order-core): 마이페이지 경기 예정 티켓 전용 조회 API 추가 [GRGB-343]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -14,9 +14,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.goormgb.be.global.response.ApiResult;
-import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
 import com.goormgb.be.ordercore.mypage.dto.request.InquiryFileConfirmRequest;
 import com.goormgb.be.ordercore.mypage.dto.request.InquiryFilePresignedRequest;
+import com.goormgb.be.ordercore.mypage.dto.request.MyPageAccountUpdateRequest;
 import com.goormgb.be.ordercore.mypage.dto.request.MyPageInquiryCreateRequest;
 import com.goormgb.be.ordercore.mypage.dto.response.InquiryFilePresignedResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
@@ -27,6 +27,7 @@ import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.UpcomingTicketListResponse;
 import com.goormgb.be.ordercore.mypage.service.InquiryFileService;
 import com.goormgb.be.ordercore.mypage.service.MyPageInquiryService;
 import com.goormgb.be.ordercore.mypage.service.MyPageProfileService;
@@ -54,231 +55,278 @@ public class MyPageController {
 	private final InquiryFileService inquiryFileService;
 
 	@Operation(
-		summary = "개인정보 조회",
-		description = "로그인한 사용자의 계정 기본 정보를 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "개인정보 조회",
+			description = "로그인한 사용자의 계정 기본 정보를 조회합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
 	})
 	@GetMapping("/account")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageAccountResponse> getAccount(
-		@AuthenticationPrincipal Long userId
+			@AuthenticationPrincipal Long userId
 	) {
 		return ApiResult.ok("조회 성공", myPageProfileService.getAccount(userId));
 	}
 
 	@Operation(
-		summary = "개인정보 수정",
-		description = "로그인한 사용자의 닉네임을 수정합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "개인정보 수정",
+			description = "로그인한 사용자의 닉네임을 수정합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "수정 성공"),
-		@ApiResponse(responseCode = "400", description = "닉네임 입력값 오류", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "수정 성공"),
+			@ApiResponse(responseCode = "400", description = "닉네임 입력값 오류", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
 	})
 	@PutMapping("/account")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageAccountResponse> updateAccount(
-		@AuthenticationPrincipal Long userId,
-		@Valid @RequestBody MyPageAccountUpdateRequest request
+			@AuthenticationPrincipal Long userId,
+			@Valid @RequestBody MyPageAccountUpdateRequest request
 	) {
 		return ApiResult.ok("수정 성공", myPageProfileService.updateAccount(userId, request));
 	}
 
 	@Operation(
-		summary = "마이페이지 프로필 요약 조회",
-		description = "사용자 프로필 기본 정보 및 티켓 현황 요약을 반환합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "마이페이지 프로필 요약 조회",
+			description = "사용자 프로필 기본 정보 및 티켓 현황 요약을 반환합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
 	})
 	@GetMapping("/profile")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageProfileResponse> getProfile(
-		@AuthenticationPrincipal Long userId
+			@AuthenticationPrincipal Long userId
 	) {
 		return ApiResult.ok("조회 성공", myPageProfileService.getProfile(userId));
 	}
 
 	@Operation(
-		summary = "예매 내역 목록 조회",
-		description = "사용자의 예매 내역을 탭별로 조회합니다. 상단 요약 정보는 탭과 무관하게 항상 포함됩니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "예매 내역 목록 조회",
+			description = "사용자의 예매 내역을 탭별로 조회합니다. 상단 요약 정보는 탭과 무관하게 항상 포함됩니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "400", description = "파라미터 오류 (size > 10 등)", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "400", description = "파라미터 오류 (size > 10 등)", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
 	})
 	@GetMapping("/tickets")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageTicketListResponse> getTickets(
-		@AuthenticationPrincipal Long userId,
-		@Parameter(description = "탭 (BOOKED | CANCEL_REFUND)", example = "BOOKED")
-		@RequestParam(defaultValue = "BOOKED") String tab,
-		@Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-		@RequestParam(defaultValue = "0") int page,
-		@Parameter(description = "페이지 크기 (최대 10)", example = "10")
-		@RequestParam(defaultValue = "10") int size
+			@AuthenticationPrincipal Long userId,
+			@Parameter(description = "탭 (BOOKED | CANCEL_REFUND)", example = "BOOKED")
+			@RequestParam(defaultValue = "BOOKED") String tab,
+			@Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+			@RequestParam(defaultValue = "0") int page,
+			@Parameter(description = "페이지 크기 (최대 10)", example = "10")
+			@RequestParam(defaultValue = "10") int size
 	) {
 		return ApiResult.ok("조회 성공", myPageTicketService.getTickets(userId, tab, page, size));
 	}
 
 	@Operation(
-		summary = "예매 상세 조회",
-		description = "사용자의 특정 예매(ticketId=orders.id) 상세 정보를 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "경기 예정 티켓 조회",
+			description = """
+					오늘 이후 경기 중 유효한 예매만 경기 날짜가 가까운 순서로 조회합니다.
+					
+					**조회 대상 주문 상태(환불이나 취소는 안나옴):**
+					- `PAYMENT_PENDING` (입금 대기)
+					- `PAID` (결제 완료)
+					- `UNDER_REVIEW` (정밀 확인 중)
+					
+					**페이지네이션:**
+					- page, size 파라미터를 생략하면 기본값(page=0, size=10)이 적용됩니다.
+					- 별도 설정 없이 호출하면 첫 페이지 10건이 반환됩니다.
+					
+					**응답 필드 설명:**
+					- `dDay`: 경기까지 남은 일수 (0이면 당일 경기, 3이면 3일 후 경기)
+					- `statusLabel`: 주문 상태의 한글 라벨 (예: "결제 완료", "입금 대기")
+					- `seatCount`: 해당 주문의 좌석 수 (매수)
+					- `seats`: 좌석 상세 목록 (구역명, 블럭 코드, 열 번호, 좌석 번호)
+					- `actions.canDeposit`: 입금하기 버튼 표시 여부 (입금 대기 상태일 때 true)
+					- `actions.canCancel`: 취소하기 버튼 표시 여부 (결제 완료 상태일 때 true)
+					""",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "400", description = "파라미터 오류 (size > 10 등)", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요 — Authorization 헤더에 Bearer 토큰을 포함해주세요", content = @Content)
+	})
+	@GetMapping("/tickets/upcoming")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<UpcomingTicketListResponse> getUpcomingTickets(
+			@AuthenticationPrincipal Long userId,
+			@Parameter(
+					description = "페이지 번호 (0부터 시작). 생략하면 0이 기본값으로 적용됩니다. 첫 페이지는 0, 두 번째 페이지는 1입니다.",
+					example = "0"
+			)
+			@RequestParam(defaultValue = "0") int page,
+			@Parameter(
+					description = "한 페이지에 보여줄 티켓 수 (최대 10). 생략하면 10이 기본값으로 적용됩니다.",
+					example = "10"
+			)
+			@RequestParam(defaultValue = "10") int size
+	) {
+		return ApiResult.ok("조회 성공", myPageTicketService.getUpcomingTickets(userId, page, size));
+	}
+
+	@Operation(
+			summary = "예매 상세 조회",
+			description = "사용자의 특정 예매(ticketId=orders.id) 상세 정보를 조회합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
 	})
 	@GetMapping("/tickets/{ticketId}")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageTicketDetailResponse> getTicketDetail(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long ticketId
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long ticketId
 	) {
 		return ApiResult.ok("조회 성공", myPageTicketService.getTicketDetail(userId, ticketId));
 	}
 
 	@Operation(
-		summary = "입장용 QR 조회",
-		description = "사용자의 특정 예매(ticketId=orders.id)에 대한 입장용 QR 토큰을 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "입장용 QR 조회",
+			description = "사용자의 특정 예매(ticketId=orders.id)에 대한 입장용 QR 토큰을 조회합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "QR 발급 성공"),
-		@ApiResponse(responseCode = "400", description = "발급 불가 상태", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "QR 발급 성공"),
+			@ApiResponse(responseCode = "400", description = "발급 불가 상태", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
 	})
 	@GetMapping("/tickets/{ticketId}/qr")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageTicketQrResponse> getTicketEntryQr(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long ticketId
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long ticketId
 	) {
 		return ApiResult.ok("QR 발급 성공", myPageTicketService.getTicketEntryQr(userId, ticketId));
 	}
 
 	@Operation(
-		summary = "티켓 취소 요청",
-		description = "사용자의 특정 예매(ticketId=orders.id)에 대한 취소 요청을 처리합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "티켓 취소 요청",
+			description = "사용자의 특정 예매(ticketId=orders.id)에 대한 취소 요청을 처리합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "취소 요청 완료"),
-		@ApiResponse(responseCode = "400", description = "취소 불가 상태", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "취소 요청 완료"),
+			@ApiResponse(responseCode = "400", description = "취소 불가 상태", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
 	})
 	@PostMapping("/tickets/{ticketId}/cancel")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageTicketCancelResponse> requestTicketCancel(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long ticketId
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long ticketId
 	) {
 		return ApiResult.ok("취소 요청이 완료되었습니다.", myPageTicketService.requestTicketCancel(userId, ticketId));
 	}
 
 	@Operation(
-		summary = "1:1 문의 작성",
-		description = "문의 내용을 등록합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "1:1 문의 작성",
+			description = "문의 내용을 등록합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "201", description = "문의 등록 성공"),
-		@ApiResponse(responseCode = "400", description = "요청 값 오류", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
+			@ApiResponse(responseCode = "201", description = "문의 등록 성공"),
+			@ApiResponse(responseCode = "400", description = "요청 값 오류", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
 	})
 	@PostMapping("/inquiries")
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResult<MyPageInquiryCreateResponse> createInquiry(
-		@AuthenticationPrincipal Long userId,
-		@Valid @RequestBody MyPageInquiryCreateRequest request
+			@AuthenticationPrincipal Long userId,
+			@Valid @RequestBody MyPageInquiryCreateRequest request
 	) {
 		return ApiResult.created("문의가 등록되었습니다.", myPageInquiryService.createInquiry(userId, request));
 	}
 
 	@Operation(
-		summary = "문의 첨부파일 Presigned URL 발급",
-		description = "문의 첨부파일 업로드를 위한 S3 Presigned URL을 발급합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "문의 첨부파일 Presigned URL 발급",
+			description = "문의 첨부파일 업로드를 위한 S3 Presigned URL을 발급합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공"),
-		@ApiResponse(responseCode = "400", description = "파일 형식 오류", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "문의 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공"),
+			@ApiResponse(responseCode = "400", description = "파일 형식 오류", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "문의 없음", content = @Content)
 	})
 	@PostMapping("/inquiries/{inquiryId}/presigned-url")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<InquiryFilePresignedResponse> getInquiryFilePresignedUrl(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long inquiryId,
-		@Valid @RequestBody InquiryFilePresignedRequest request
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long inquiryId,
+			@Valid @RequestBody InquiryFilePresignedRequest request
 	) {
 		InquiryFilePresignedResponse response =
-			inquiryFileService.generatePresignedUrl(userId, inquiryId, request.fileName());
+				inquiryFileService.generatePresignedUrl(userId, inquiryId, request.fileName());
 		return ApiResult.ok("Presigned URL 발급 성공", response);
 	}
 
 	@Operation(
-		summary = "문의 첨부파일 확정",
-		description = "S3 업로드된 첨부파일을 검증 후 문의에 확정 저장합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "문의 첨부파일 확정",
+			description = "S3 업로드된 첨부파일을 검증 후 문의에 확정 저장합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "파일 등록 완료"),
-		@ApiResponse(responseCode = "400", description = "파일 검증 실패", content = @Content),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "문의 또는 파일 없음", content = @Content),
-		@ApiResponse(responseCode = "413", description = "파일 크기 제한 초과", content = @Content)
+			@ApiResponse(responseCode = "200", description = "파일 등록 완료"),
+			@ApiResponse(responseCode = "400", description = "파일 검증 실패", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "문의 또는 파일 없음", content = @Content),
+			@ApiResponse(responseCode = "413", description = "파일 크기 제한 초과", content = @Content)
 	})
 	@PatchMapping("/inquiries/{inquiryId}/file")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<Void> confirmInquiryFile(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long inquiryId,
-		@Valid @RequestBody InquiryFileConfirmRequest request
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long inquiryId,
+			@Valid @RequestBody InquiryFileConfirmRequest request
 	) {
 		inquiryFileService.confirmFile(userId, inquiryId, request.fileKey());
 		return ApiResult.ok("파일 등록 완료", null);
 	}
 
 	@Operation(
-		summary = "문의 상세 조회",
-		description = "본인 문의 상세와 첨부파일 다운로드 URL을 조회합니다.",
-		security = @SecurityRequirement(name = "BearerAuth")
+			summary = "문의 상세 조회",
+			description = "본인 문의 상세와 첨부파일 다운로드 URL을 조회합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
 	)
 	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "조회 성공"),
-		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
-		@ApiResponse(responseCode = "404", description = "문의 없음", content = @Content)
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "403", description = "본인 문의 아님", content = @Content),
+			@ApiResponse(responseCode = "404", description = "문의 없음", content = @Content)
 	})
 	@GetMapping("/inquiries/{inquiryId}")
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResult<MyPageInquiryDetailResponse> getInquiryDetail(
-		@AuthenticationPrincipal Long userId,
-		@PathVariable Long inquiryId
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long inquiryId
 	) {
 		return ApiResult.ok("조회 성공", myPageInquiryService.getInquiryDetail(userId, inquiryId));
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/UpcomingTicketListResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/UpcomingTicketListResponse.java
@@ -1,0 +1,132 @@
+package com.goormgb.be.ordercore.mypage.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 경기 예정 티켓 목록 조회 응답 DTO.
+ */
+@Schema(description = "경기 예정 티켓 목록 응답")
+public record UpcomingTicketListResponse(
+
+		@Schema(description = "경기 예정 티켓 총 개수", example = "3")
+		int totalCount,
+
+		PaginationInfo pagination,
+
+		@Schema(description = "경기 예정 티켓 목록 (경기 날짜가 가까운 순)")
+		List<UpcomingTicketItem> tickets
+) {
+
+	@Schema(description = "페이지네이션 정보")
+	public record PaginationInfo(
+			@Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+			int page,
+			@Schema(description = "한 페이지 크기", example = "10")
+			int size,
+			@Schema(description = "전체 티켓 수", example = "3")
+			long totalElements,
+			@Schema(description = "전체 페이지 수", example = "1")
+			int totalPages,
+			@Schema(description = "다음 페이지 존재 여부", example = "false")
+			boolean hasNext
+	) {
+	}
+
+	@Schema(description = "경기 예정 티켓 카드 1건")
+	public record UpcomingTicketItem(
+			@Schema(description = "티켓(주문) ID — 상세 조회 시 이 값을 ticketId로 사용", example = "58")
+			Long ticketId,
+
+			@Schema(description = "경기까지 남은 일수. 0이면 당일(D-Day), 3이면 3일 후(D-3)", example = "3")
+			long dDay,
+
+			@Schema(description = "주문 상태 코드", example = "PAID")
+			OrderStatus status,
+
+			@Schema(description = "주문 상태 한글 라벨 (화면에 그대로 표시 가능)", example = "결제 완료")
+			String statusLabel,
+
+			@Schema(description = "매수 (예매한 좌석 수)", example = "2")
+			int seatCount,
+
+			MatchInfo match,
+
+			@Schema(description = "좌석 상세 목록")
+			List<SeatInfo> seats,
+
+			TicketActions actions
+	) {
+	}
+
+	@Schema(description = "경기 정보")
+	public record MatchInfo(
+			@Schema(description = "경기 ID", example = "181")
+			Long matchId,
+
+			@Schema(description = "경기 시작 시간 (UTC)", example = "2026-04-10T05:00:00Z")
+			Instant matchAt,
+
+			ClubInfo homeClub,
+			ClubInfo awayClub,
+			StadiumInfo stadium
+	) {
+	}
+
+	@Schema(description = "구단 정보")
+	public record ClubInfo(
+			@Schema(description = "구단 ID", example = "1")
+			Long clubId,
+
+			@Schema(description = "구단 한글명", example = "LG 트윈스")
+			String koName
+	) {
+	}
+
+	@Schema(description = "경기장 정보")
+	public record StadiumInfo(
+			@Schema(description = "경기장 ID", example = "1")
+			Long stadiumId,
+
+			@Schema(description = "경기장 한글명", example = "잠실야구장")
+			String koName
+	) {
+	}
+
+	@Schema(description = "좌석 정보 — 구역/블럭/열/번호")
+	public record SeatInfo(
+			@Schema(description = "구역명 (예: 오렌지석, 블루석)", example = "오렌지석")
+			String sectionName,
+
+			@Schema(description = "블럭 코드 (예: 206, 103)", example = "206")
+			String blockCode,
+
+			@Schema(description = "열 번호", example = "3")
+			int rowNo,
+
+			@Schema(description = "좌석 번호", example = "15")
+			int seatNo
+	) {
+	}
+
+	@Schema(description = "버튼 표시 여부")
+	public record TicketActions(
+			@Schema(description = "입금하기 버튼 표시 여부 (입금 대기 상태일 때 true)", example = "false")
+			boolean canDeposit,
+
+			@Schema(description = "취소하기 버튼 표시 여부 (결제 완료 상태일 때 true)", example = "true")
+			boolean canCancel
+	) {
+		public static TicketActions of(OrderStatus status, Instant matchAt) {
+			boolean isUpcoming = matchAt.isAfter(Instant.now());
+			return new TicketActions(
+					status == OrderStatus.PAYMENT_PENDING && isUpcoming,
+					status == OrderStatus.PAID && isUpcoming
+			);
+		}
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/UpcomingTicketListResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/UpcomingTicketListResponse.java
@@ -121,8 +121,8 @@ public record UpcomingTicketListResponse(
 			@Schema(description = "취소하기 버튼 표시 여부 (결제 완료 상태일 때 true)", example = "true")
 			boolean canCancel
 	) {
-		public static TicketActions of(OrderStatus status, Instant matchAt) {
-			boolean isUpcoming = matchAt.isAfter(Instant.now());
+		public static TicketActions of(OrderStatus status, Instant matchAt, Instant now) {
+			boolean isUpcoming = matchAt.isAfter(now);
 			return new TicketActions(
 					status == OrderStatus.PAYMENT_PENDING && isUpcoming,
 					status == OrderStatus.PAID && isUpcoming

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -31,15 +31,15 @@ public class MyPageQueryService {
 	 */
 	public long countTickets(Long userId, List<String> statuses) {
 		String sql = """
-			SELECT COUNT(*)
-			FROM orders
-			WHERE user_id = :userId
-			  AND status IN (:statuses)
-			""";
+				SELECT COUNT(*)
+				FROM orders
+				WHERE user_id = :userId
+				  AND status IN (:statuses)
+				""";
 
 		var params = new MapSqlParameterSource()
-			.addValue("userId", userId)
-			.addValue("statuses", statuses);
+				.addValue("userId", userId)
+				.addValue("statuses", statuses);
 
 		Long count = namedJdbc.queryForObject(sql, params, Long.class);
 		return count != null ? count : 0L;
@@ -50,43 +50,43 @@ public class MyPageQueryService {
 	 */
 	public List<TicketRow> findTickets(Long userId, List<String> statuses, int page, int size) {
 		String sql = """
-			SELECT
-			    o.id           AS order_id,
-			    o.status,
-			    m.match_at,
-			    hc.id          AS home_club_id,
-			    hc.ko_name     AS home_club_name,
-			    ac.id          AS away_club_id,
-			    ac.ko_name     AS away_club_name,
-			    st.ko_name     AS stadium_name,
-			    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
-			FROM orders o
-			JOIN matches m  ON o.match_id    = m.id
-			JOIN clubs hc   ON m.home_club_id = hc.id
-			JOIN clubs ac   ON m.away_club_id = ac.id
-			JOIN stadiums st ON m.stadium_id  = st.id
-			WHERE o.user_id = :userId
-			  AND o.status IN (:statuses)
-			ORDER BY o.created_at DESC
-			LIMIT :size OFFSET :offset
-			""";
+				SELECT
+				    o.id           AS order_id,
+				    o.status,
+				    m.match_at,
+				    hc.id          AS home_club_id,
+				    hc.ko_name     AS home_club_name,
+				    ac.id          AS away_club_id,
+				    ac.ko_name     AS away_club_name,
+				    st.ko_name     AS stadium_name,
+				    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
+				FROM orders o
+				JOIN matches m  ON o.match_id    = m.id
+				JOIN clubs hc   ON m.home_club_id = hc.id
+				JOIN clubs ac   ON m.away_club_id = ac.id
+				JOIN stadiums st ON m.stadium_id  = st.id
+				WHERE o.user_id = :userId
+				  AND o.status IN (:statuses)
+				ORDER BY o.created_at DESC
+				LIMIT :size OFFSET :offset
+				""";
 
 		var params = new MapSqlParameterSource()
-			.addValue("userId", userId)
-			.addValue("statuses", statuses)
-			.addValue("size", size)
-			.addValue("offset", (long)page * size);
+				.addValue("userId", userId)
+				.addValue("statuses", statuses)
+				.addValue("size", size)
+				.addValue("offset", (long)page * size);
 
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new TicketRow(
-			rs.getLong("order_id"),
-			OrderStatus.valueOf(rs.getString("status")),
-			rs.getObject("match_at", Timestamp.class).toInstant(),
-			rs.getLong("home_club_id"),
-			rs.getString("home_club_name"),
-			rs.getLong("away_club_id"),
-			rs.getString("away_club_name"),
-			rs.getString("stadium_name"),
-			rs.getInt("seat_count")
+				rs.getLong("order_id"),
+				OrderStatus.valueOf(rs.getString("status")),
+				rs.getObject("match_at", Timestamp.class).toInstant(),
+				rs.getLong("home_club_id"),
+				rs.getString("home_club_name"),
+				rs.getLong("away_club_id"),
+				rs.getString("away_club_name"),
+				rs.getString("stadium_name"),
+				rs.getInt("seat_count")
 		));
 	}
 
@@ -99,28 +99,28 @@ public class MyPageQueryService {
 		}
 
 		String sql = """
-			SELECT
-			    os.order_id,
-			    sec.name    AS section_name,
-			    b.block_code,
-			    os.row_no,
-			    os.seat_no
-			FROM order_seats os
-			JOIN sections sec ON os.section_id = sec.id
-			JOIN blocks b     ON os.block_id   = b.id
-			WHERE os.order_id IN (:orderIds)
-			ORDER BY os.order_id, os.id
-			""";
+				SELECT
+				    os.order_id,
+				    sec.name    AS section_name,
+				    b.block_code,
+				    os.row_no,
+				    os.seat_no
+				FROM order_seats os
+				JOIN sections sec ON os.section_id = sec.id
+				JOIN blocks b     ON os.block_id   = b.id
+				WHERE os.order_id IN (:orderIds)
+				ORDER BY os.order_id, os.id
+				""";
 
 		var params = new MapSqlParameterSource()
-			.addValue("orderIds", orderIds);
+				.addValue("orderIds", orderIds);
 
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new OrderSeatRow(
-			rs.getLong("order_id"),
-			rs.getString("section_name"),
-			rs.getString("block_code"),
-			rs.getInt("row_no"),
-			rs.getInt("seat_no")
+				rs.getLong("order_id"),
+				rs.getString("section_name"),
+				rs.getString("block_code"),
+				rs.getInt("row_no"),
+				rs.getInt("seat_no")
 		));
 	}
 
@@ -129,78 +129,78 @@ public class MyPageQueryService {
 	 */
 	public Optional<TicketDetailBaseRow> findTicketDetailBaseByOrderId(Long orderId) {
 		String sql = """
-			SELECT
-			    o.id             AS order_id,
-			    o.user_id        AS user_id,
-			    o.status         AS order_status,
-			    o.total_amount,
-			    o.booking_fee,
-			    o.cancelled_at,
-			    o.cancellation_fee,
-			    o.refunded_amount,
-			    m.id             AS match_id,
-			    m.match_at,
-			    hc.id            AS home_club_id,
-			    hc.ko_name       AS home_club_name,
-			    ac.id            AS away_club_id,
-			    ac.ko_name       AS away_club_name,
-			    st.id            AS stadium_id,
-			    st.ko_name       AS stadium_name,
-			    st.address       AS stadium_address,
-			    p.payment_method,
-			    p.paid_at,
-			    p.account_bank,
-			    p.account_number,
-			    p.account_holder,
-			    p.deposit_deadline,
-			    cr.purpose       AS cash_receipt_purpose,
-			    cr.number        AS cash_receipt_number
-			FROM orders o
-			JOIN matches m      ON o.match_id = m.id
-			JOIN clubs hc       ON m.home_club_id = hc.id
-			JOIN clubs ac       ON m.away_club_id = ac.id
-			JOIN stadiums st    ON m.stadium_id = st.id
-			LEFT JOIN payments p ON p.order_id = o.id
-			LEFT JOIN cash_receipts cr ON cr.payment_id = p.id
-			WHERE o.id = :orderId
-			""";
+				SELECT
+				    o.id             AS order_id,
+				    o.user_id        AS user_id,
+				    o.status         AS order_status,
+				    o.total_amount,
+				    o.booking_fee,
+				    o.cancelled_at,
+				    o.cancellation_fee,
+				    o.refunded_amount,
+				    m.id             AS match_id,
+				    m.match_at,
+				    hc.id            AS home_club_id,
+				    hc.ko_name       AS home_club_name,
+				    ac.id            AS away_club_id,
+				    ac.ko_name       AS away_club_name,
+				    st.id            AS stadium_id,
+				    st.ko_name       AS stadium_name,
+				    st.address       AS stadium_address,
+				    p.payment_method,
+				    p.paid_at,
+				    p.account_bank,
+				    p.account_number,
+				    p.account_holder,
+				    p.deposit_deadline,
+				    cr.purpose       AS cash_receipt_purpose,
+				    cr.number        AS cash_receipt_number
+				FROM orders o
+				JOIN matches m      ON o.match_id = m.id
+				JOIN clubs hc       ON m.home_club_id = hc.id
+				JOIN clubs ac       ON m.away_club_id = ac.id
+				JOIN stadiums st    ON m.stadium_id = st.id
+				LEFT JOIN payments p ON p.order_id = o.id
+				LEFT JOIN cash_receipts cr ON cr.payment_id = p.id
+				WHERE o.id = :orderId
+				""";
 
 		var params = new MapSqlParameterSource()
-			.addValue("orderId", orderId);
+				.addValue("orderId", orderId);
 
 		List<TicketDetailBaseRow> rows = namedJdbc.query(sql, params, (rs, rowNum) -> {
 			String paymentMethod = rs.getString("payment_method");
 			String cashReceiptPurpose = rs.getString("cash_receipt_purpose");
 
 			return new TicketDetailBaseRow(
-				rs.getLong("order_id"),
-				rs.getLong("user_id"),
-				OrderStatus.valueOf(rs.getString("order_status")),
-				rs.getInt("total_amount"),
-				rs.getInt("booking_fee"),
-				rs.getObject("cancelled_at", Timestamp.class) == null ? null
-					: rs.getObject("cancelled_at", Timestamp.class).toInstant(),
-				rs.getInt("cancellation_fee"),
-				rs.getObject("refunded_amount", Integer.class),
-				rs.getLong("match_id"),
-				rs.getObject("match_at", Timestamp.class).toInstant(),
-				rs.getLong("home_club_id"),
-				rs.getString("home_club_name"),
-				rs.getLong("away_club_id"),
-				rs.getString("away_club_name"),
-				rs.getLong("stadium_id"),
-				rs.getString("stadium_name"),
-				rs.getString("stadium_address"),
-				paymentMethod == null ? null : PaymentMethod.valueOf(paymentMethod),
-				rs.getObject("paid_at", Timestamp.class) == null ? null
-					: rs.getObject("paid_at", Timestamp.class).toInstant(),
-				rs.getString("account_bank"),
-				decrypt(rs.getString("account_number")),
-				decrypt(rs.getString("account_holder")),
-				rs.getObject("deposit_deadline", Timestamp.class) == null ? null
-					: rs.getObject("deposit_deadline", Timestamp.class).toInstant(),
-				cashReceiptPurpose == null ? null : CashReceiptPurpose.valueOf(cashReceiptPurpose),
-				decrypt(rs.getString("cash_receipt_number"))
+					rs.getLong("order_id"),
+					rs.getLong("user_id"),
+					OrderStatus.valueOf(rs.getString("order_status")),
+					rs.getInt("total_amount"),
+					rs.getInt("booking_fee"),
+					rs.getObject("cancelled_at", Timestamp.class) == null ? null
+							: rs.getObject("cancelled_at", Timestamp.class).toInstant(),
+					rs.getInt("cancellation_fee"),
+					rs.getObject("refunded_amount", Integer.class),
+					rs.getLong("match_id"),
+					rs.getObject("match_at", Timestamp.class).toInstant(),
+					rs.getLong("home_club_id"),
+					rs.getString("home_club_name"),
+					rs.getLong("away_club_id"),
+					rs.getString("away_club_name"),
+					rs.getLong("stadium_id"),
+					rs.getString("stadium_name"),
+					rs.getString("stadium_address"),
+					paymentMethod == null ? null : PaymentMethod.valueOf(paymentMethod),
+					rs.getObject("paid_at", Timestamp.class) == null ? null
+							: rs.getObject("paid_at", Timestamp.class).toInstant(),
+					rs.getString("account_bank"),
+					decrypt(rs.getString("account_number")),
+					decrypt(rs.getString("account_holder")),
+					rs.getObject("deposit_deadline", Timestamp.class) == null ? null
+							: rs.getObject("deposit_deadline", Timestamp.class).toInstant(),
+					cashReceiptPurpose == null ? null : CashReceiptPurpose.valueOf(cashReceiptPurpose),
+					decrypt(rs.getString("cash_receipt_number"))
 			);
 		});
 
@@ -212,43 +212,132 @@ public class MyPageQueryService {
 	 */
 	public List<TicketSeatDetailRow> findTicketSeatRowsByOrderId(Long orderId) {
 		String sql = """
-			SELECT
-			    sec.name      AS section_name,
-			    b.block_code,
-			    os.row_no,
-			    os.seat_no,
-			    os.price,
-			    os.ticket_type
-			FROM order_seats os
-			JOIN sections sec ON os.section_id = sec.id
-			JOIN blocks b     ON os.block_id = b.id
-			WHERE os.order_id = :orderId
-			ORDER BY os.id
-			""";
+				SELECT
+				    sec.name      AS section_name,
+				    b.block_code,
+				    os.row_no,
+				    os.seat_no,
+				    os.price,
+				    os.ticket_type
+				FROM order_seats os
+				JOIN sections sec ON os.section_id = sec.id
+				JOIN blocks b     ON os.block_id = b.id
+				WHERE os.order_id = :orderId
+				ORDER BY os.id
+				""";
 
 		var params = new MapSqlParameterSource()
-			.addValue("orderId", orderId);
+				.addValue("orderId", orderId);
 
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new TicketSeatDetailRow(
-			rs.getString("section_name"),
-			rs.getString("block_code"),
-			rs.getInt("row_no"),
-			rs.getInt("seat_no"),
-			rs.getInt("price"),
-			TicketType.valueOf(rs.getString("ticket_type"))
+				rs.getString("section_name"),
+				rs.getString("block_code"),
+				rs.getInt("row_no"),
+				rs.getInt("seat_no"),
+				rs.getInt("price"),
+				TicketType.valueOf(rs.getString("ticket_type"))
 		));
 	}
 
+	/**
+	 * 경기 예정 티켓 수를 반환한다. (오늘 이후 경기 + 유효 상태)
+	 */
+	public long countUpcomingTickets(Long userId, List<String> statuses, java.time.Instant now) {
+		String sql = """
+				SELECT COUNT(*)
+				FROM orders o
+				JOIN matches m ON o.match_id = m.id
+				WHERE o.user_id = :userId
+				  AND o.status IN (:statuses)
+				  AND m.match_at > :now
+				""";
+
+		var params = new MapSqlParameterSource()
+				.addValue("userId", userId)
+				.addValue("statuses", statuses)
+				.addValue("now", Timestamp.from(now));
+
+		Long count = namedJdbc.queryForObject(sql, params, Long.class);
+		return count != null ? count : 0L;
+	}
+
+	/**
+	 * 경기 예정 티켓 목록을 matchAt ASC로 페이지네이션하여 반환한다.
+	 */
+	public List<UpcomingTicketRow> findUpcomingTickets(Long userId, List<String> statuses,
+			java.time.Instant now, int page, int size) {
+		String sql = """
+				SELECT
+				    o.id           AS order_id,
+				    o.status,
+				    m.id           AS match_id,
+				    m.match_at,
+				    hc.id          AS home_club_id,
+				    hc.ko_name     AS home_club_name,
+				    ac.id          AS away_club_id,
+				    ac.ko_name     AS away_club_name,
+				    st.id          AS stadium_id,
+				    st.ko_name     AS stadium_name,
+				    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
+				FROM orders o
+				JOIN matches m   ON o.match_id    = m.id
+				JOIN clubs hc    ON m.home_club_id = hc.id
+				JOIN clubs ac    ON m.away_club_id = ac.id
+				JOIN stadiums st ON m.stadium_id  = st.id
+				WHERE o.user_id = :userId
+				  AND o.status IN (:statuses)
+				  AND m.match_at > :now
+				ORDER BY m.match_at ASC
+				LIMIT :size OFFSET :offset
+				""";
+
+		var params = new MapSqlParameterSource()
+				.addValue("userId", userId)
+				.addValue("statuses", statuses)
+				.addValue("now", Timestamp.from(now))
+				.addValue("size", size)
+				.addValue("offset", (long)page * size);
+
+		return namedJdbc.query(sql, params, (rs, rowNum) -> new UpcomingTicketRow(
+				rs.getLong("order_id"),
+				OrderStatus.valueOf(rs.getString("status")),
+				rs.getLong("match_id"),
+				rs.getObject("match_at", Timestamp.class).toInstant(),
+				rs.getLong("home_club_id"),
+				rs.getString("home_club_name"),
+				rs.getLong("away_club_id"),
+				rs.getString("away_club_name"),
+				rs.getLong("stadium_id"),
+				rs.getString("stadium_name"),
+				rs.getInt("seat_count")
+		));
+	}
+
+	public record UpcomingTicketRow(
+			Long orderId,
+			OrderStatus status,
+			Long matchId,
+			java.time.Instant matchAt,
+			Long homeClubId,
+			String homeClubName,
+			Long awayClubId,
+			String awayClubName,
+			Long stadiumId,
+			String stadiumName,
+			int seatCount
+	) {
+	}
+
 	public record TicketRow(
-		Long orderId,
-		OrderStatus status,
-		java.time.Instant matchAt,
-		Long homeClubId,
-		String homeClubName,
-		Long awayClubId,
-		String awayClubName,
-		String stadiumName,
-		int seatCount
+			Long orderId,
+			OrderStatus status,
+			java.time.Instant matchAt,
+			Long homeClubId,
+			String homeClubName,
+			Long awayClubId,
+			String awayClubName,
+			String stadiumName,
+			int seatCount
 	) {
 	}
 
@@ -260,11 +349,11 @@ public class MyPageQueryService {
 	}
 
 	public record OrderSeatRow(
-		Long orderId,
-		String sectionName,
-		String blockCode,
-		int rowNo,
-		int seatNo
+			Long orderId,
+			String sectionName,
+			String blockCode,
+			int rowNo,
+			int seatNo
 	) {
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -2,8 +2,12 @@ package com.goormgb.be.ordercore.mypage.service;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,10 +23,12 @@ import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketQrResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.UpcomingTicketListResponse;
 import com.goormgb.be.ordercore.mypage.enums.TicketTab;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.OrderSeatRow;
 import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.TicketRow;
+import com.goormgb.be.ordercore.mypage.query.MyPageQueryService.UpcomingTicketRow;
 import com.goormgb.be.ordercore.mypage.service.support.MyPageTicketCancellationCalculator;
 import com.goormgb.be.ordercore.mypage.service.support.MyPageTicketDetailAssembler;
 import com.goormgb.be.ordercore.mypage.service.support.MyPageTicketListAssembler;
@@ -47,9 +53,17 @@ public class MyPageTicketService {
 
 	private static final int MAX_PAGE_SIZE = 10;
 
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
 	private static final List<OrderStatus> UPCOMING_STATUSES = List.of(
 			OrderStatus.PAYMENT_PENDING,
 			OrderStatus.PAID
+	);
+
+	private static final List<String> UPCOMING_TICKET_STATUSES = List.of(
+			OrderStatus.PAYMENT_PENDING.name(),
+			OrderStatus.PAID.name(),
+			OrderStatus.UNDER_REVIEW.name()
 	);
 
 	private static final List<OrderStatus> CANCEL_PROCESSING_STATUSES = List.of(
@@ -108,6 +122,64 @@ public class MyPageTicketService {
 				totalCount, upcomingCount, cancelProcessingCount, completedCount,
 				ticketTab.name(), page, size, totalElements, totalPages, hasNext, tickets
 		);
+	}
+
+	/**
+	 * 경기 예정 티켓 목록을 조회한다. (오늘 이후 경기 + 유효 상태만)
+	 */
+	public UpcomingTicketListResponse getUpcomingTickets(Long userId, int page, int size) {
+		Preconditions.validate(size <= MAX_PAGE_SIZE, ErrorCode.INVALID_PAGE_SIZE);
+
+		Instant now = Instant.now(clock);
+		LocalDate today = LocalDate.now(KST);
+
+		long totalElements = myPageQueryService.countUpcomingTickets(userId, UPCOMING_TICKET_STATUSES, now);
+		List<UpcomingTicketRow> rows = myPageQueryService.findUpcomingTickets(
+				userId, UPCOMING_TICKET_STATUSES, now, page, size);
+
+		List<UpcomingTicketListResponse.UpcomingTicketItem> tickets;
+		if (rows.isEmpty()) {
+			tickets = List.of();
+		} else {
+			List<Long> orderIds = rows.stream().map(UpcomingTicketRow::orderId).toList();
+			List<OrderSeatRow> seatRows = myPageQueryService.findOrderSeatRowsByOrderIds(orderIds);
+			Map<Long, List<UpcomingTicketListResponse.SeatInfo>> seatMap = seatRows.stream()
+					.collect(Collectors.groupingBy(
+							OrderSeatRow::orderId,
+							Collectors.mapping(
+									row -> new UpcomingTicketListResponse.SeatInfo(
+											row.sectionName(), row.blockCode(), row.rowNo(), row.seatNo()),
+									Collectors.toList())));
+
+			tickets = rows.stream()
+					.map(row -> {
+						long dDay = ChronoUnit.DAYS.between(today,
+								row.matchAt().atZone(KST).toLocalDate());
+						return new UpcomingTicketListResponse.UpcomingTicketItem(
+								row.orderId(),
+								dDay,
+								row.status(),
+								row.status().getDescription(),
+								row.seatCount(),
+								new UpcomingTicketListResponse.MatchInfo(
+										row.matchId(),
+										row.matchAt(),
+										new UpcomingTicketListResponse.ClubInfo(row.homeClubId(), row.homeClubName()),
+										new UpcomingTicketListResponse.ClubInfo(row.awayClubId(), row.awayClubName()),
+										new UpcomingTicketListResponse.StadiumInfo(row.stadiumId(), row.stadiumName())),
+								seatMap.getOrDefault(row.orderId(), List.of()),
+								UpcomingTicketListResponse.TicketActions.of(row.status(), row.matchAt()));
+					})
+					.toList();
+		}
+
+		int totalPages = totalElements == 0 ? 0 : (int)Math.ceil((double)totalElements / size);
+		boolean hasNext = (long)(page + 1) * size < totalElements;
+
+		return new UpcomingTicketListResponse(
+				(int)totalElements,
+				new UpcomingTicketListResponse.PaginationInfo(page, size, totalElements, totalPages, hasNext),
+				tickets);
 	}
 
 	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -128,7 +128,7 @@ public class MyPageTicketService {
 	 * 경기 예정 티켓 목록을 조회한다. (오늘 이후 경기 + 유효 상태만)
 	 */
 	public UpcomingTicketListResponse getUpcomingTickets(Long userId, int page, int size) {
-		Preconditions.validate(size <= MAX_PAGE_SIZE, ErrorCode.INVALID_PAGE_SIZE);
+		Preconditions.validate(page >= 0 && size > 0 && size <= MAX_PAGE_SIZE, ErrorCode.INVALID_PAGE_SIZE);
 
 		Instant now = Instant.now(clock);
 		LocalDate today = LocalDate.now(KST);
@@ -168,7 +168,7 @@ public class MyPageTicketService {
 										new UpcomingTicketListResponse.ClubInfo(row.awayClubId(), row.awayClubName()),
 										new UpcomingTicketListResponse.StadiumInfo(row.stadiumId(), row.stadiumName())),
 								seatMap.getOrDefault(row.orderId(), List.of()),
-								UpcomingTicketListResponse.TicketActions.of(row.status(), row.matchAt()));
+								UpcomingTicketListResponse.TicketActions.of(row.status(), row.matchAt(), now));
 					})
 					.toList();
 		}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/enums/OrderStatus.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/enums/OrderStatus.java
@@ -12,7 +12,8 @@ public enum OrderStatus {
 	CANCEL_REQUESTED("취소 요청"),
 	CANCELLED("취소 완료"),
 	REFUND_PROCESSING("환불 처리 중"),
-	REFUND_COMPLETED("환불 완료");
+	REFUND_COMPLETED("환불 완료"),
+	UNDER_REVIEW("정밀 확인 중");
 
 	private final String description;
 }


### PR DESCRIPTION
## 🔧 작업 내용
- 마이페이지 경기 예정 티켓 전용 조회 API 추가 (`GET /mypage/tickets/upcoming`)
- 오늘 이후 경기의 유효한 예매(입금 대기, 결제 완료, 정밀 확인 중)를 경기 날짜순으로 조회
- OrderStatus에 `UNDER_REVIEW`(정밀 확인 중) enum 추가
- 프론트 개발 편의를 위한 Swagger 문서 상세화 (@Schema 전 필드 적용)

## 🧩 구현 상세
- 기존 `GET /mypage/tickets?tab=BOOKED`와 분리하여 경기 예정 전용 API 신설
- D-day 계산 (KST 기준), statusLabel(한글 라벨) 응답에 포함
- matchAt ASC 정렬 (가까운 경기 먼저), 기존 API는 created_at DESC
- 좌석 상세(구역/블럭/열/번호) 기존 `findOrderSeatRowsByOrderIds()` 재사용
- 필터 대상 상태: PAYMENT_PENDING, PAID, UNDER_REVIEW

### 📌 관련 Jira Issue
- GRGB-343