### PR TITLE
feat(order): totalPrice 검증 로직 추가 [GRGB-341]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/controller/OrderController.java
@@ -73,7 +73,7 @@ public class OrderController {
 		description = """
 			예매자 정보, 좌석 ID 목록, 총 결제 금액을 받아 주문을 생성합니다.
 			- matchSeatIds: 주문서 조회에서 받은 매치 좌석 ID 목록
-			- totalPrice: 프론트에서 할인 적용 후 계산한 총 결제 금액 (수수료 2,000원 포함)
+			- totalPrice: 프론트에서 계산한 총 결제 금액 (서버에서 좌석 가격 기준으로 검증, 수수료 2,000원 포함)
 			- 결제는 목업(무조건 성공)으로 처리됩니다.
 			""",
 		security = @SecurityRequirement(name = "BearerAuth")

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderService {
 
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final int BOOKING_FEE = 2000;
 
 	private final MatchRepository matchRepository;
 	private final UserRepository userRepository;
@@ -100,6 +101,7 @@ public class OrderService {
 
 		// 유효성 검증 + 좌석별 성인 기본가 조회 (order_seats 저장용)
 		List<OrderSeat> orderSeats = new ArrayList<>();
+		int totalSeatPrice = 0;
 		for (SeatHoldInfo hold : holdInfos) {
 			Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
 			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
@@ -107,6 +109,7 @@ public class OrderService {
 
 			Integer adultPrice = seatInfoQueryService.findPrice(hold.sectionId(), dayType, "ADULT");
 			Preconditions.validate(adultPrice != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
+			totalSeatPrice += adultPrice;
 
 			orderSeats.add(OrderSeat.builder()
 				.matchSeatId(hold.matchSeatId())
@@ -118,11 +121,13 @@ public class OrderService {
 				.ticketType(TicketType.ADULT)
 				.build());
 		}
+		int serverCalculatedTotal = totalSeatPrice + BOOKING_FEE;
+		Preconditions.validate(serverCalculatedTotal == request.totalPrice(), ErrorCode.ORDER_TOTAL_PRICE_MISMATCH);
 
 		Order order = Order.builder()
 			.user(user)
 			.match(match)
-			.totalAmount(request.totalPrice())
+			.totalAmount(serverCalculatedTotal)
 			.ordererName(request.ordererName())
 			.ordererEmail(request.ordererEmail())
 			.ordererPhone(request.ordererPhone())

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/controller/OrderControllerTest.java
@@ -308,6 +308,21 @@ class OrderControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
+		@DisplayName("요청 totalPrice가 서버 계산값과 다르면 400을 반환한다")
+		void createOrder_totalPrice_불일치_400() throws Exception {
+			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
+
+			given(orderService.createOrder(any(), any()))
+				.willThrow(new CustomException(ErrorCode.ORDER_TOTAL_PRICE_MISMATCH));
+
+			mockMvc.perform(post("/mypage/orders")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message").value("주문 금액이 유효하지 않습니다. 다시 시도해주세요."));
+		}
+
+		@Test
 		@DisplayName("matchId가 없으면 400을 반환한다")
 		void createOrder_matchId_누락_400() throws Exception {
 			String invalidJson = """

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
@@ -264,7 +264,7 @@ class OrderServiceTest {
 			OrderCreateRequest request = new OrderCreateRequest(
 				1L,
 				List.of(101L, 102L),
-				31000,
+				46000,
 				"홍길동", "hong@test.com", "010-1234-5678", "990831"
 			);
 
@@ -281,7 +281,7 @@ class OrderServiceTest {
 			OrderCreateResponse response = orderService.createOrder(userId, request);
 
 			assertThat(response.seatCount()).isEqualTo(2);
-			assertThat(response.totalAmount()).isEqualTo(22000 + 7000 + 2000);
+			assertThat(response.totalAmount()).isEqualTo(22000 + 22000 + 2000);
 		}
 
 		@Test
@@ -331,6 +331,35 @@ class OrderServiceTest {
 			orderService.createOrder(userId, request);
 
 			then(orderSeatRepository).should().saveAll(any());
+		}
+
+		@Test
+		@DisplayName("요청 totalPrice가 서버 계산값과 다르면 ORDER_TOTAL_PRICE_MISMATCH 예외가 발생한다")
+		void createOrder_totalPrice_불일치_예외() {
+			Long userId = 1L;
+			User user = OrderFixture.createUser();
+			Match match = OrderFixture.createWeekdayMatch();
+			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
+			OrderCreateRequest request = new OrderCreateRequest(
+				1L,
+				List.of(101L),
+				0,
+				"홍길동", "hong@test.com", "010-1234-5678", "990831"
+			);
+
+			stubNoPendingOrders();
+			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
+			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
+			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+
+			assertThatThrownBy(() -> orderService.createOrder(userId, request))
+				.isInstanceOf(CustomException.class)
+				.hasMessage(ErrorCode.ORDER_TOTAL_PRICE_MISMATCH.getMessage());
+
+			then(orderRepository).should(never()).save(any(Order.class));
+			then(orderSeatRepository).should(never()).saveAll(any());
 		}
 
 		@Test

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
 	ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 주문에 접근할 권한이 없습니다."),
 	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
 	ORDER_SEAT_EMPTY(HttpStatus.BAD_REQUEST, "주문 좌석 정보가 없습니다."),
+	ORDER_TOTAL_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "주문 금액이 유효하지 않습니다. 다시 시도해주세요."),
 
 	// Section
 	SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "섹션을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔧 작업 내용

- `OrderService.createOrder`에서 서버 기준 총액 재계산 로직 추가
- `request.totalPrice`와 서버 계산 총액 불일치 시 `ORDER_TOTAL_PRICE_MISMATCH` 예외 반환
- `orders.total_amount`는 클라이언트 값이 아닌 서버 계산값으로 저장하도록 변경
- 주문 생성 Swagger 설명을 "`totalPrice`는 서버 검증 대상 값"으로 정정
- 주문 생성 관련 서비스/컨트롤러 테스트 보강


### 📌 관련 Jira Issue

- GRGB-341

## 🧪 테스트 방법(선택)

<img width="1325" height="25" alt="image" src="https://github.com/user-attachments/assets/c1cc6fc0-8eb5-44b2-8c7b-bb71dce19fe2" />

<img width="1021" height="38" alt="image" src="https://github.com/user-attachments/assets/75c90649-744c-4604-938b-9c39dede4e67" />


## ❗ 참고 사항

- 이제 주문은 일반으로만 가능합니다
