### PR TITLE
feat(myPage): 내 문의 전체 조회 API [GRGB-342]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/repository/InquiryRepository.java
@@ -1,5 +1,6 @@
 package com.goormgb.be.ordercore.inquiry.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -11,6 +12,8 @@ import com.goormgb.be.ordercore.inquiry.entity.Inquiry;
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
 	Page<Inquiry> findByUserId(Long userId, Pageable pageable);
+
+	List<Inquiry> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
 	Optional<Inquiry> findByIdAndUserId(Long inquiryId, Long userId);
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -271,7 +271,8 @@ public class MyPageController {
 	)
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
-			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
+			@ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content)
 	})
 	@GetMapping("/inquiries")
 	@ResponseStatus(HttpStatus.OK)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -22,6 +22,7 @@ import com.goormgb.be.ordercore.mypage.dto.response.InquiryFilePresignedResponse
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -261,6 +262,23 @@ public class MyPageController {
 			@Valid @RequestBody MyPageInquiryCreateRequest request
 	) {
 		return ApiResult.created("문의가 등록되었습니다.", myPageInquiryService.createInquiry(userId, request));
+	}
+
+	@Operation(
+			summary = "1:1 문의 목록 조회",
+			description = "사용자가 작성한 1:1 문의 목록을 최신순으로 조회합니다.",
+			security = @SecurityRequirement(name = "BearerAuth")
+	)
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "조회 성공"),
+			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content)
+	})
+	@GetMapping("/inquiries")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<MyPageInquiryListResponse> getInquiries(
+			@AuthenticationPrincipal Long userId
+	) {
+		return ApiResult.ok("조회 성공", myPageInquiryService.getInquiries(userId));
 	}
 
 	@Operation(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageInquiryListResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageInquiryListResponse.java
@@ -1,0 +1,36 @@
+package com.goormgb.be.ordercore.mypage.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.goormgb.be.ordercore.inquiry.entity.Inquiry;
+
+public record MyPageInquiryListResponse(
+	List<InquiryItem> inquiries
+) {
+	public record InquiryItem(
+		Long inquiryId,
+		String category,
+		String title,
+		String status,
+		Instant createdAt
+	) {
+		public static InquiryItem of(Inquiry inquiry) {
+			return new InquiryItem(
+				inquiry.getId(),
+				inquiry.getCategory().name(),
+				inquiry.getTitle(),
+				inquiry.getStatus().name(),
+				inquiry.getCreatedAt()
+			);
+		}
+	}
+
+	public static MyPageInquiryListResponse of(List<Inquiry> inquiries) {
+		return new MyPageInquiryListResponse(
+			inquiries.stream()
+				.map(InquiryItem::of)
+				.toList()
+		);
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
@@ -47,6 +47,7 @@ public class MyPageInquiryService {
 	}
 
 	public MyPageInquiryListResponse getInquiries(Long userId) {
+		userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		List<Inquiry> inquiries = inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
 		return MyPageInquiryListResponse.of(inquiries);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.ordercore.mypage.service;
 
 import java.util.Locale;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +15,7 @@ import com.goormgb.be.ordercore.inquiry.repository.InquiryRepository;
 import com.goormgb.be.ordercore.mypage.dto.request.MyPageInquiryCreateRequest;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.repository.UserRepository;
 
@@ -42,6 +44,11 @@ public class MyPageInquiryService {
 
 		Inquiry saved = inquiryRepository.save(inquiry);
 		return MyPageInquiryCreateResponse.of(saved.getId());
+	}
+
+	public MyPageInquiryListResponse getInquiries(Long userId) {
+		List<Inquiry> inquiries = inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+		return MyPageInquiryListResponse.of(inquiries);
 	}
 
 	public MyPageInquiryDetailResponse getInquiryDetail(Long userId, Long inquiryId) {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -510,6 +510,17 @@ class MyPageControllerTest extends WebMvcTestSupport {
 				.andExpect(jsonPath("$.data.inquiries").isArray())
 				.andExpect(jsonPath("$.data.inquiries.length()").value(0));
 		}
+
+		@Test
+		@DisplayName("사용자가 없으면 404를 반환한다")
+		void getInquiries_사용자없음_404() throws Exception {
+			given(myPageInquiryService.getInquiries(1L))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			mockMvc.perform(get("/mypage/inquiries"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
+		}
 	}
 
 	@Nested

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -27,6 +27,7 @@ import com.goormgb.be.ordercore.mypage.dto.response.MyPageAccountResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.InquiryFilePresignedResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketCancelResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageTicketDetailResponse;
@@ -458,6 +459,56 @@ class MyPageControllerTest extends WebMvcTestSupport {
 			mockMvc.perform(post("/mypage/tickets/101/cancel"))
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.message").value("취소 가능한 기간이 아닙니다."));
+		}
+	}
+
+	@Nested
+	@DisplayName("GET /mypage/inquiries — 1:1 문의 목록 조회")
+	class GetInquiries {
+
+		@BeforeEach
+		void setAuth() {
+			setAuthentication(1L);
+		}
+
+		@Test
+		@DisplayName("유효한 요청이면 200과 문의 목록을 반환한다")
+		void getInquiries_성공() throws Exception {
+			given(myPageInquiryService.getInquiries(1L))
+				.willReturn(new MyPageInquiryListResponse(
+					List.of(
+						new MyPageInquiryListResponse.InquiryItem(
+							11L,
+							"BOOKING",
+							"문의 제목",
+							"REGISTERED",
+							Instant.parse("2026-03-31T08:00:00Z")
+						)
+					)
+				));
+
+			mockMvc.perform(get("/mypage/inquiries"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("OK"))
+				.andExpect(jsonPath("$.message").value("조회 성공"))
+				.andExpect(jsonPath("$.data.inquiries").isArray())
+				.andExpect(jsonPath("$.data.inquiries.length()").value(1))
+				.andExpect(jsonPath("$.data.inquiries[0].inquiryId").value(11))
+				.andExpect(jsonPath("$.data.inquiries[0].category").value("BOOKING"))
+				.andExpect(jsonPath("$.data.inquiries[0].title").value("문의 제목"))
+				.andExpect(jsonPath("$.data.inquiries[0].status").value("REGISTERED"));
+		}
+
+		@Test
+		@DisplayName("문의가 없으면 빈 배열을 반환한다")
+		void getInquiries_빈목록_반환() throws Exception {
+			given(myPageInquiryService.getInquiries(1L))
+				.willReturn(new MyPageInquiryListResponse(List.of()));
+
+			mockMvc.perform(get("/mypage/inquiries"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.inquiries").isArray())
+				.andExpect(jsonPath("$.data.inquiries.length()").value(0));
 		}
 	}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.Instant;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,10 +21,12 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.inquiry.entity.Inquiry;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryCategory;
+import com.goormgb.be.ordercore.inquiry.enums.InquiryStatus;
 import com.goormgb.be.ordercore.inquiry.repository.InquiryRepository;
 import com.goormgb.be.ordercore.mypage.dto.request.MyPageInquiryCreateRequest;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
+import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.repository.UserRepository;
 
@@ -83,6 +88,56 @@ class MyPageInquiryServiceTest {
 				.isInstanceOf(CustomException.class)
 				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
 					.isEqualTo(ErrorCode.INVALID_INQUIRY_CATEGORY));
+		}
+	}
+
+	@Nested
+	@DisplayName("getInquiries")
+	class GetInquiries {
+
+		@Test
+		@DisplayName("문의 목록을 최신순으로 매핑해서 반환한다")
+		void getInquiries_성공() {
+			User user = OrderFixture.createUserWithId(1L);
+			Inquiry first = createInquiry(user, 20L, "가장 최근 문의");
+			first.updateStatus(InquiryStatus.ANSWERED);
+			ReflectionTestUtils.setField(first, "createdAt", Instant.parse("2026-04-07T01:00:00Z"));
+
+			Inquiry second = createInquiry(user, 10L, "이전 문의");
+			ReflectionTestUtils.setField(second, "createdAt", Instant.parse("2026-04-06T01:00:00Z"));
+
+			given(inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+				.willReturn(List.of(first, second));
+
+			MyPageInquiryListResponse response = myPageInquiryService.getInquiries(1L);
+
+			assertThat(response.inquiries()).hasSize(2);
+			assertThat(response.inquiries().get(0).inquiryId()).isEqualTo(20L);
+			assertThat(response.inquiries().get(0).status()).isEqualTo("ANSWERED");
+			assertThat(response.inquiries().get(1).inquiryId()).isEqualTo(10L);
+		}
+
+		@Test
+		@DisplayName("문의가 없으면 빈 목록을 반환한다")
+		void getInquiries_빈목록() {
+			given(inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
+				.willReturn(List.of());
+
+			MyPageInquiryListResponse response = myPageInquiryService.getInquiries(1L);
+
+			assertThat(response.inquiries()).isEmpty();
+		}
+
+		private Inquiry createInquiry(User user, Long inquiryId, String title) {
+			Inquiry inquiry = Inquiry.create(
+				user,
+				InquiryCategory.BOOKING,
+				title,
+				"내용",
+				"010-1234-5678"
+			);
+			ReflectionTestUtils.setField(inquiry, "id", inquiryId);
+			return inquiry;
 		}
 	}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
@@ -99,6 +99,7 @@ class MyPageInquiryServiceTest {
 		@DisplayName("문의 목록을 최신순으로 매핑해서 반환한다")
 		void getInquiries_성공() {
 			User user = OrderFixture.createUserWithId(1L);
+			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			Inquiry first = createInquiry(user, 20L, "가장 최근 문의");
 			first.updateStatus(InquiryStatus.ANSWERED);
 			ReflectionTestUtils.setField(first, "createdAt", Instant.parse("2026-04-07T01:00:00Z"));
@@ -120,12 +121,26 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("문의가 없으면 빈 목록을 반환한다")
 		void getInquiries_빈목록() {
+			User user = OrderFixture.createUserWithId(1L);
+			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
 				.willReturn(List.of());
 
 			MyPageInquiryListResponse response = myPageInquiryService.getInquiries(1L);
 
 			assertThat(response.inquiries()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("사용자가 없으면 예외가 발생한다")
+		void getInquiries_사용자없음_예외() {
+			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND))
+				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
+
+			assertThatThrownBy(() -> myPageInquiryService.getInquiries(1L))
+				.isInstanceOf(CustomException.class)
+				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
+					.isEqualTo(ErrorCode.USER_NOT_FOUND));
 		}
 
 		private Inquiry createInquiry(User user, Long inquiryId, String title) {


### PR DESCRIPTION
## 🔧 작업 내용

- `GET /mypage/inquiries` API를 신규 추가했습니다.
- 현재 디자인에 맞춰 페이지네이션 없이 사용자 문의 목록을 최신순으로 조회하도록 구현했습니다.

## 🧩 구현 상세 (선택)

- `MyPageInquiryService#getInquiries`에서 사용자 ID 기준 문의 목록을 조회해 응답 DTO로 매핑합니다.
- `InquiryRepository`에 `findAllByUserIdOrderByCreatedAtDesc(Long userId)` 메서드를 추가해 최신순 정렬을 보장합니다.
- 신규 DTO `MyPageInquiryListResponse` / `InquiryItem`으로 목록 응답 스키마를 정의했습니다.

### 📌 관련 Jira Issue

- GRGB-342

## 🧪 테스트 방법(선택)

<img width="918" height="392" alt="image" src="https://github.com/user-attachments/assets/7cb25ded-6d1e-4862-bf4b-80001823122b" />

<img width="876" height="407" alt="image" src="https://github.com/user-attachments/assets/75c04748-9297-4fd5-990d-536626522565" />



## ❗ 참고 사항
