### PR TITLE
feat(order-core): 경기당 1인 최대 8매 예매 제한 검증 추가 [GRGB-345]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderSeatRepository.java
@@ -8,8 +8,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.ordercore.order.entity.OrderSeat;
+import com.goormgb.be.ordercore.order.enums.OrderStatus;
 
 public interface OrderSeatRepository extends JpaRepository<OrderSeat, Long> {
+
+	/**
+	 * 특정 유저의 특정 경기에 대한 유효 주문 좌석 수를 카운트한다.
+	 */
+	@Query("""
+			SELECT COUNT(os)
+			FROM OrderSeat os
+			JOIN os.order o
+			WHERE o.user.id = :userId
+			  AND o.match.id = :matchId
+			  AND o.status IN :statuses
+			""")
+	long countByUserIdAndMatchIdAndStatuses(
+			@Param("userId") Long userId,
+			@Param("matchId") Long matchId,
+			@Param("statuses") List<OrderStatus> statuses
+	);
 
 	List<OrderSeat> findByOrderId(Long orderId);
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -41,6 +41,9 @@ public class OrderService {
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private static final int BOOKING_FEE = 2000;
 	private static final int MAX_TICKETS_PER_MATCH = 8;
+	private static final List<OrderStatus> COUNTABLE_ORDER_STATUSES = List.of(
+			OrderStatus.PAYMENT_PENDING, OrderStatus.PAID, OrderStatus.UNDER_REVIEW
+	);
 
 	private final MatchRepository matchRepository;
 	private final UserRepository userRepository;
@@ -89,8 +92,8 @@ public class OrderService {
 	public OrderCreateResponse createOrder(Long userId, OrderCreateRequest request) {
 		Preconditions.validate(!request.matchSeatIds().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
 
-		validateMaxTicketsPerMatch(userId, request.matchId(), request.matchSeatIds().size());
 		cancelExistingPendingOrders(userId, request.matchId());
+		validateMaxTicketsPerMatch(userId, request.matchId(), request.matchSeatIds().size());
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Match match = matchRepository.findDetailByIdOrThrow(request.matchId());
@@ -173,11 +176,8 @@ public class OrderService {
 	 * 유효 주문(PAYMENT_PENDING, PAID, UNDER_REVIEW) 좌석 수 + 신규 좌석 수가 8을 초과하면 예외를 발생시킨다.
 	 */
 	private void validateMaxTicketsPerMatch(Long userId, Long matchId, int newSeatCount) {
-		List<OrderStatus> countableStatuses = List.of(
-				OrderStatus.PAYMENT_PENDING, OrderStatus.PAID, OrderStatus.UNDER_REVIEW);
-
 		long existingSeatCount = orderSeatRepository.countByUserIdAndMatchIdAndStatuses(
-				userId, matchId, countableStatuses);
+				userId, matchId, COUNTABLE_ORDER_STATUSES);
 
 		Preconditions.validate(
 				existingSeatCount + newSeatCount <= MAX_TICKETS_PER_MATCH,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -40,6 +40,7 @@ public class OrderService {
 
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private static final int BOOKING_FEE = 2000;
+	private static final int MAX_TICKETS_PER_MATCH = 8;
 
 	private final MatchRepository matchRepository;
 	private final UserRepository userRepository;
@@ -88,6 +89,7 @@ public class OrderService {
 	public OrderCreateResponse createOrder(Long userId, OrderCreateRequest request) {
 		Preconditions.validate(!request.matchSeatIds().isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
 
+		validateMaxTicketsPerMatch(userId, request.matchId(), request.matchSeatIds().size());
 		cancelExistingPendingOrders(userId, request.matchId());
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
@@ -125,14 +127,14 @@ public class OrderService {
 		Preconditions.validate(serverCalculatedTotal == request.totalPrice(), ErrorCode.ORDER_TOTAL_PRICE_MISMATCH);
 
 		Order order = Order.builder()
-			.user(user)
-			.match(match)
-			.totalAmount(serverCalculatedTotal)
-			.ordererName(request.ordererName())
-			.ordererEmail(request.ordererEmail())
-			.ordererPhone(request.ordererPhone())
-			.ordererBirthDate(request.ordererBirthDate())
-			.build();
+				.user(user)
+				.match(match)
+				.totalAmount(serverCalculatedTotal)
+				.ordererName(request.ordererName())
+				.ordererEmail(request.ordererEmail())
+				.ordererPhone(request.ordererPhone())
+				.ordererBirthDate(request.ordererBirthDate())
+				.build();
 
 		orderRepository.save(order);
 		orderSeats.forEach(seat -> seat.assignOrder(order));
@@ -164,6 +166,23 @@ public class OrderService {
 				userId, updatedCount);
 
 		return updatedCount;
+	}
+
+	/**
+	 * 경기당 1인 최대 예매 수량(8매)을 초과하는지 검증한다.
+	 * 유효 주문(PAYMENT_PENDING, PAID, UNDER_REVIEW) 좌석 수 + 신규 좌석 수가 8을 초과하면 예외를 발생시킨다.
+	 */
+	private void validateMaxTicketsPerMatch(Long userId, Long matchId, int newSeatCount) {
+		List<OrderStatus> countableStatuses = List.of(
+				OrderStatus.PAYMENT_PENDING, OrderStatus.PAID, OrderStatus.UNDER_REVIEW);
+
+		long existingSeatCount = orderSeatRepository.countByUserIdAndMatchIdAndStatuses(
+				userId, matchId, countableStatuses);
+
+		Preconditions.validate(
+				existingSeatCount + newSeatCount <= MAX_TICKETS_PER_MATCH,
+				ErrorCode.EXCEEDED_MAX_TICKETS_PER_MATCH
+		);
 	}
 
 	private void cancelExistingPendingOrders(Long userId, Long matchId) {

--- a/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
+++ b/common-core/src/main/java/com/goormgb/be/global/exception/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
 	INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
 	ORDER_SEAT_EMPTY(HttpStatus.BAD_REQUEST, "주문 좌석 정보가 없습니다."),
 	ORDER_TOTAL_PRICE_MISMATCH(HttpStatus.BAD_REQUEST, "주문 금액이 유효하지 않습니다. 다시 시도해주세요."),
+	EXCEEDED_MAX_TICKETS_PER_MATCH(HttpStatus.CONFLICT, "경기당 최대 8매까지만 예매 가능합니다."),
 
 	// Section
 	SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "섹션을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔧 작업 내용
- 동일 경기에 대해 1인당 최대 8매까지만 예매 가능하도록 주문 생성 시 검증 추가
- 부정 예매 방지 및 티켓 공정 배분을 위한 수량 제한
- 대기열/좌석 선점/주문서 조회 단계는 제한 없이 허용하고, 주문 확정 시점에서만 차단

## 🧩 구현 상세
- `OrderSeatRepository`에 유저+경기+주문상태 조건의 좌석 수 카운트 쿼리 추가
- `OrderService.createOrder()` 진입 시 `validateMaxTicketsPerMatch()` 검증 수행
- 카운트 대상 주문 상태: `PAYMENT_PENDING`(무통장 입금 대기), `PAID`, `UNDER_REVIEW`
- 취소/환불 완료 주문은 카운트에서 제외하여 재예매 가능
- `ErrorCode.EXCEEDED_MAX_TICKETS_PER_MATCH` (409 CONFLICT) 추가

### 📌 관련 Jira Issue
- GRGB-345

## 🧪 테스트 방법
- `POST /order/mypage/orders`로 주문 생성
- 동일 경기에 PAID 상태 주문 8석 존재 시, 추가 주문 → 409 에러 확인
- CANCELLED 상태 8석 존재 시, 신규 주문 → 정상 생성 확인
- 다른 경기 주문은 카운트에 미포함 확인

## ❗ 참고 사항
- 최대 수량 상수 `MAX_TICKETS_PER_MATCH = 8`은 `OrderService`에 정의
- 검증은 `cancelExistingPendingOrders()` 이전에 수행 (무통장 입금 대기 건도 카운트에 포함되어야 해서!!)
