### PR TITLE
fix: add separate actuator SecurityFilterChain for management port

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/AuthGuardSecurityConfig.java
@@ -2,6 +2,7 @@ package com.goormgb.be.authguard.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -26,7 +27,21 @@ public class AuthGuardSecurityConfig {
 	private final InternalApiKeyProperties internalApiKeyProperties;
 	private final ObjectMapper objectMapper;
 
+	/**
+	 * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
+	 * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+	 */
 	@Bean
+	@Order(0)
+	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+	@Bean
+	@Order(1)
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.goormgb.be.ordercore.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,7 +21,21 @@ public class SecurityConfig {
 
 	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
+	/**
+	 * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
+	 * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+	 */
 	@Bean
+	@Order(0)
+	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+	@Bean
+	@Order(1)
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)

--- a/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.goormgb.be.queue.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,7 +21,21 @@ public class SecurityConfig {
 
 	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
+	/**
+	 * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
+	 * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+	 */
 	@Bean
+	@Order(0)
+	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+	@Bean
+	@Order(1)
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)

--- a/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.goormgb.be.seat.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,7 +21,21 @@ public class SecurityConfig {
 
 	private final XUserIdAuthenticationFilter xUserIdAuthenticationFilter;
 
+	/**
+	 * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
+	 * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+	 */
 	@Bean
+	@Order(0)
+	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+	@Bean
+	@Order(1)
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 				.csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
### 작업 내용
Spring Boot 서비스의 management 포트를 9090으로 분리하여 Prometheus 메트릭 수집과 mTLS를 양립할 수 있도록 설정.

### 변경 사항
deployment.yaml: management 포트(9090) containerPort 추가, 환경변수 설정
values-*.yaml (dev/staging): metrics.port: 9090 추가, path에서 context path 제거


### 구현 상세
아키텍처 변경
Before:
Pod :8080 ─── 서비스 + actuator (같은 포트)
└── mTLS 비활성화 시 IngressGateway도 plain HTTP → 503

After:
Pod :8080 ─── 서비스 (mTLS 유지)
Pod :9090 ─── actuator (mTLS 비활성화, Prometheus 전용)

metrics.path 변경 이유
management.server.port를 설정하면 actuator는 context path 없이 제공됨
/auth/actuator/prometheus → /actuator/prometheus