### PR TITLE
feat(auth-guard): Refresh Token 만료시간 시간 단위 변경 및 부하테스트 토큰 15분 제한 [GRGB-346]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
  * <p>
  * Key: {@code refresh_token:{jti}}
  * <p>
- * TTL: 7일 (application.yaml의 jwt.refresh-token.expiration-days 참조)
+ * TTL: 4시간 (application.yaml의 jwt.refresh-token.expiration-hours 참조, 부하테스트: 15분)
  * <p>
  * 중복 로그인 허용: 유저당 여러 개의 Refresh Token 저장 가능
  */

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/dto/RefreshTokenInfo.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
  * <p>
  * Key: {@code refresh_token:{jti}}
  * <p>
- * TTL: 4시간 (application.yaml의 jwt.refresh-token.expiration-hours 참조, 부하테스트: 15분)
+ * TTL: 3시간 (application.yaml의 jwt.refresh-token.expiration-hours 참조, 부하테스트: 15분)
  * <p>
  * 중복 로그인 허용: 유저당 여러 개의 Refresh Token 저장 가능
  */

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
 		refreshTokenRepository.deleteByJti(jti);
 
 		Instant now = Instant.now();
-		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
+		int expirationHours = jwtProperties.getRefreshToken().getExpirationHours();
 
 		RefreshTokenInfo newTokenInfo = RefreshTokenInfo.builder()
 				.userId(userId)
@@ -106,7 +106,7 @@ public class AuthService {
 				.jti(newJti)
 				.sid(sid)
 				.issuedAt(now)
-				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
+				.expiresAt(now.plus(Duration.ofHours(expirationHours)))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))
 				.build();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
@@ -85,7 +85,7 @@ public class DevAuthService {
 		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
 
 		Instant now = Instant.now();
-		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
+		int expirationHours = jwtProperties.getRefreshToken().getExpirationHours();
 
 		RefreshTokenInfo tokenInfo = RefreshTokenInfo.builder()
 				.userId(user.getId())
@@ -93,7 +93,7 @@ public class DevAuthService {
 				.jti(jti)
 				.sid(sid)
 				.issuedAt(now)
-				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
+				.expiresAt(now.plus(Duration.ofHours(expirationHours)))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))
 				.build();

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/LoadTestAuthService.java
@@ -85,12 +85,14 @@ public class LoadTestAuthService {
 		// 부하테스트 로그인에서는 lastLoginAt 업데이트 생략 (동시 UPDATE 병목 방지)
 
 		String sid = UUID.randomUUID().toString();
-		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY, sid);
-		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), sid);
+		int loadTestMinutes = jwtProperties.getLoadTest().getTokenExpirationMinutes();
+
+		String accessToken = jwtTokenProvider.createAccessToken(user.getId(), DEFAULT_AUTHORITY, sid, loadTestMinutes);
+		String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), sid, loadTestMinutes);
 		String jti = jwtTokenProvider.getJtiFromToken(refreshToken);
 
 		Instant now = Instant.now();
-		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
+		Duration loadTestTtl = Duration.ofMinutes(loadTestMinutes);
 
 		RefreshTokenInfo tokenInfo = RefreshTokenInfo.builder()
 				.userId(user.getId())
@@ -98,12 +100,12 @@ public class LoadTestAuthService {
 				.jti(jti)
 				.sid(sid)
 				.issuedAt(now)
-				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
+				.expiresAt(now.plus(loadTestTtl))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))
 				.build();
 
-		refreshTokenRepository.save(tokenInfo);
+		refreshTokenRepository.save(tokenInfo, loadTestTtl);
 
 		return new LoadTestLoginResult(accessToken, refreshToken);
 	}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/config/JwtProperties.java
@@ -18,6 +18,7 @@ public class JwtProperties {
 	private AccessToken accessToken = new AccessToken();
 	private RefreshToken refreshToken = new RefreshToken();
 	private Cookie cookie = new Cookie();
+	private LoadTest loadTest = new LoadTest();
 
 	@Getter
 	@Setter
@@ -30,7 +31,13 @@ public class JwtProperties {
 	@Setter
 	public static class RefreshToken {
 		private String audience;
-		private int expirationDays;
+		private int expirationHours;
+	}
+
+	@Getter
+	@Setter
+	public static class LoadTest {
+		private int tokenExpirationMinutes = 15;
 	}
 
 	@Getter

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -43,48 +43,11 @@ public class JwtTokenProvider {
 	}
 
 	public String createAccessToken(Long userId, String authority, String sid) {
-		Instant now = Instant.now();
-		Instant expiration = now.plus(jwtProperties.getAccessToken().getExpirationMinutes(), ChronoUnit.MINUTES);
-
-		return Jwts.builder()
-				.header()
-				.type("JWT")
-				.and()
-				.issuer(jwtProperties.getIssuer())
-				.subject(String.valueOf(userId))
-				.audience()
-				.add(jwtProperties.getAccessToken().getAudience())
-				.and()
-				.issuedAt(Date.from(now))
-				.expiration(Date.from(expiration))
-				.id(UUID.randomUUID().toString())
-				.claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
-				.claim(CLAIM_AUTH, authority)
-				.claim(CLAIM_SID, sid)
-				.signWith(privateKey, Jwts.SIG.RS256)
-				.compact();
+		return createAccessToken(userId, authority, sid, jwtProperties.getAccessToken().getExpirationMinutes());
 	}
 
 	public String createRefreshToken(Long userId, String sid) {
-		Instant now = Instant.now();
-		Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationHours(), ChronoUnit.HOURS);
-
-		return Jwts.builder()
-				.header()
-				.type("JWT")
-				.and()
-				.issuer(jwtProperties.getIssuer())
-				.subject(String.valueOf(userId))
-				.audience()
-				.add(jwtProperties.getRefreshToken().getAudience())
-				.and()
-				.issuedAt(Date.from(now))
-				.expiration(Date.from(expiration))
-				.id(UUID.randomUUID().toString())
-				.claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
-				.claim(CLAIM_SID, sid)
-				.signWith(privateKey, Jwts.SIG.RS256)
-				.compact();
+		return createRefreshToken(userId, sid, jwtProperties.getRefreshToken().getExpirationHours() * 60);
 	}
 
 	/**

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProvider.java
@@ -67,7 +67,58 @@ public class JwtTokenProvider {
 
 	public String createRefreshToken(Long userId, String sid) {
 		Instant now = Instant.now();
-		Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationDays(), ChronoUnit.DAYS);
+		Instant expiration = now.plus(jwtProperties.getRefreshToken().getExpirationHours(), ChronoUnit.HOURS);
+
+		return Jwts.builder()
+				.header()
+				.type("JWT")
+				.and()
+				.issuer(jwtProperties.getIssuer())
+				.subject(String.valueOf(userId))
+				.audience()
+				.add(jwtProperties.getRefreshToken().getAudience())
+				.and()
+				.issuedAt(Date.from(now))
+				.expiration(Date.from(expiration))
+				.id(UUID.randomUUID().toString())
+				.claim(CLAIM_TOKEN_TYPE, TokenType.REFRESH.getValue())
+				.claim(CLAIM_SID, sid)
+				.signWith(privateKey, Jwts.SIG.RS256)
+				.compact();
+	}
+
+	/**
+	 * 만료 시간을 직접 지정하여 Access Token을 생성한다. (부하테스트용)
+	 */
+	public String createAccessToken(Long userId, String authority, String sid, int expirationMinutes) {
+		Instant now = Instant.now();
+		Instant expiration = now.plus(expirationMinutes, ChronoUnit.MINUTES);
+
+		return Jwts.builder()
+				.header()
+				.type("JWT")
+				.and()
+				.issuer(jwtProperties.getIssuer())
+				.subject(String.valueOf(userId))
+				.audience()
+				.add(jwtProperties.getAccessToken().getAudience())
+				.and()
+				.issuedAt(Date.from(now))
+				.expiration(Date.from(expiration))
+				.id(UUID.randomUUID().toString())
+				.claim(CLAIM_TOKEN_TYPE, TokenType.ACCESS.getValue())
+				.claim(CLAIM_AUTH, authority)
+				.claim(CLAIM_SID, sid)
+				.signWith(privateKey, Jwts.SIG.RS256)
+				.compact();
+	}
+
+	/**
+	 * 만료 시간을 직접 지정하여 Refresh Token을 생성한다. (부하테스트용)
+	 */
+	public String createRefreshToken(Long userId, String sid, int expirationMinutes) {
+		Instant now = Instant.now();
+		Instant expiration = now.plus(expirationMinutes, ChronoUnit.MINUTES);
 
 		return Jwts.builder()
 				.header()

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
@@ -30,14 +30,14 @@ public class RefreshTokenRepository {
 
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
-	private final long ttlDays;
+	private final long ttlHours;
 
 	public RefreshTokenRepository(StringRedisTemplate redisTemplate,
 			ObjectMapper redisObjectMapper,
 			JwtProperties jwtProperties) {
 		this.redisTemplate = redisTemplate;
 		this.objectMapper = redisObjectMapper;
-		this.ttlDays = jwtProperties.getRefreshToken().getExpirationDays();
+		this.ttlHours = jwtProperties.getRefreshToken().getExpirationHours();
 	}
 
 	/**
@@ -49,8 +49,27 @@ public class RefreshTokenRepository {
 		String key = generateKey(tokenInfo.getJti());
 		try {
 			String json = objectMapper.writeValueAsString(tokenInfo);
-			redisTemplate.opsForValue().set(key, json, Duration.ofDays(ttlDays));
+			redisTemplate.opsForValue().set(key, json, Duration.ofHours(ttlHours));
 			log.debug("Refresh token saved - jti: {}, userId: {}", tokenInfo.getJti(), tokenInfo.getUserId());
+		} catch (JsonProcessingException e) {
+			log.error("Failed to serialize RefreshTokenInfo - jti: {}", tokenInfo.getJti(), e);
+			throw new RuntimeException("Failed to save refresh token", e);
+		}
+	}
+
+	/**
+	 * Refresh Token 정보를 Redis에 저장한다. (커스텀 TTL 지정)
+	 *
+	 * @param tokenInfo 저장할 토큰 정보 (jti 필수)
+	 * @param customTtl Redis TTL (부하테스트 등 기본 TTL과 다른 경우 사용)
+	 */
+	public void save(RefreshTokenInfo tokenInfo, Duration customTtl) {
+		String key = generateKey(tokenInfo.getJti());
+		try {
+			String json = objectMapper.writeValueAsString(tokenInfo);
+			redisTemplate.opsForValue().set(key, json, customTtl);
+			log.debug("Refresh token saved with custom TTL - jti: {}, userId: {}, ttl: {}",
+					tokenInfo.getJti(), tokenInfo.getUserId(), customTtl);
 		} catch (JsonProcessingException e) {
 			log.error("Failed to serialize RefreshTokenInfo - jti: {}", tokenInfo.getJti(), e);
 			throw new RuntimeException("Failed to save refresh token", e);

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/repository/RefreshTokenRepository.java
@@ -46,15 +46,7 @@ public class RefreshTokenRepository {
 	 * @param tokenInfo 저장할 토큰 정보 (jti 필수)
 	 */
 	public void save(RefreshTokenInfo tokenInfo) {
-		String key = generateKey(tokenInfo.getJti());
-		try {
-			String json = objectMapper.writeValueAsString(tokenInfo);
-			redisTemplate.opsForValue().set(key, json, Duration.ofHours(ttlHours));
-			log.debug("Refresh token saved - jti: {}, userId: {}", tokenInfo.getJti(), tokenInfo.getUserId());
-		} catch (JsonProcessingException e) {
-			log.error("Failed to serialize RefreshTokenInfo - jti: {}", tokenInfo.getJti(), e);
-			throw new RuntimeException("Failed to save refresh token", e);
-		}
+		save(tokenInfo, Duration.ofHours(ttlHours));
 	}
 
 	/**

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/jwt/util/CookieUtils.java
@@ -24,7 +24,7 @@ public class CookieUtils {
 	 * Refresh Token용 HttpOnly Cookie 생성 (로그인/토큰 재발급 시)
 	 * */
 	public ResponseCookie createRefreshTokenCookie(String refreshToken) {
-		long maxAgeSeconds = TimeUnit.DAYS.toSeconds(jwtProperties.getRefreshToken().getExpirationDays());
+		long maxAgeSeconds = TimeUnit.HOURS.toSeconds(jwtProperties.getRefreshToken().getExpirationHours());
 
 		return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
 				.httpOnly(true)

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/kakao/service/KakaoAuthService.java
@@ -96,7 +96,7 @@ public class KakaoAuthService {
 		// 7. refreshToken redis 에 저장
 		Instant now = Instant.now();
 
-		int expirationDays = jwtProperties.getRefreshToken().getExpirationDays();
+		int expirationHours = jwtProperties.getRefreshToken().getExpirationHours();
 
 		RefreshTokenInfo tokenInfo = RefreshTokenInfo.builder()
 				.userId(user.getId())
@@ -104,7 +104,7 @@ public class KakaoAuthService {
 				.jti(jti)
 				.sid(sid)
 				.issuedAt(now)
-				.expiresAt(now.plus(Duration.ofDays(expirationDays)))
+				.expiresAt(now.plus(Duration.ofHours(expirationHours)))
 				.userAgent(request.getHeader("User-Agent"))
 				.ipAddress(getClientIp(request))
 				.build();

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -46,7 +46,9 @@ jwt:
     expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
   refresh-token:
     audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+    expiration-hours: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  load-test:
+    token-expiration-minutes: ${JWT_LOADTEST_TOKEN_EXPIRATION:15}
   cookie:
     secure: true
     same-site: None

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -46,7 +46,9 @@ jwt:
     expiration-minutes: ${JWT_ACCESS_TOKEN_EXPIRATION}
   refresh-token:
     audience: ${JWT_REFRESH_TOKEN_AUDIENCE}
-    expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION}
+    expiration-hours: ${JWT_REFRESH_TOKEN_EXPIRATION}
+  load-test:
+    token-expiration-minutes: ${JWT_LOADTEST_TOKEN_EXPIRATION:15}
   cookie:
     secure: false
 

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProviderTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/jwt/provider/JwtTokenProviderTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.*;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +40,7 @@ class JwtTokenProviderTest {
 
 	private static final Long USER_ID = 42L;
 	private static final String ROLE = "ROLE_USER";
+	private static final String SID = "test-session-id";
 
 	private JwtTokenProvider jwtTokenProvider;
 
@@ -58,7 +58,7 @@ class JwtTokenProviderTest {
 
 		JwtProperties.RefreshToken refreshToken = new JwtProperties.RefreshToken();
 		refreshToken.setAudience("test-refresh-audience");
-		refreshToken.setExpirationDays(7);
+		refreshToken.setExpirationHours(3);
 		properties.setRefreshToken(refreshToken);
 
 		jwtTokenProvider = new JwtTokenProvider(properties);
@@ -72,7 +72,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰을 생성하면 서명이 유효하다")
 		void createsValidToken() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(token).isNotBlank();
 			assertThat(jwtTokenProvider.validateToken(token)).isTrue();
@@ -81,7 +81,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰의 userId를 정확히 담는다")
 		void containsCorrectUserId() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(jwtTokenProvider.getUserIdFromToken(token)).isEqualTo(USER_ID);
 		}
@@ -89,7 +89,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰의 authority를 정확히 담는다")
 		void containsCorrectAuthority() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(jwtTokenProvider.getAuthorityFromToken(token)).isEqualTo(ROLE);
 		}
@@ -97,7 +97,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰의 tokenType이 ACCESS다")
 		void tokenTypeIsAccess() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(jwtTokenProvider.getTokenTypeFromToken(token)).isEqualTo(TokenType.ACCESS);
 		}
@@ -105,7 +105,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰은 JTI를 포함한다")
 		void containsJti() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(jwtTokenProvider.getJtiFromToken(token)).isNotBlank();
 		}
@@ -113,10 +113,10 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("ACCESS 토큰의 만료 시각은 현재보다 미래다")
 		void expirationIsInFuture() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			assertThat(jwtTokenProvider.getExpirationFromToken(token))
-				.isAfter(new java.util.Date());
+					.isAfter(new java.util.Date());
 		}
 	}
 
@@ -127,7 +127,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("REFRESH 토큰을 생성하면 서명이 유효하다")
 		void createsValidToken() {
-			String token = jwtTokenProvider.createRefreshToken(USER_ID);
+			String token = jwtTokenProvider.createRefreshToken(USER_ID, SID);
 
 			assertThat(token).isNotBlank();
 			assertThat(jwtTokenProvider.validateToken(token)).isTrue();
@@ -136,7 +136,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("REFRESH 토큰의 tokenType이 REFRESH다")
 		void tokenTypeIsRefresh() {
-			String token = jwtTokenProvider.createRefreshToken(USER_ID);
+			String token = jwtTokenProvider.createRefreshToken(USER_ID, SID);
 
 			assertThat(jwtTokenProvider.getTokenTypeFromToken(token)).isEqualTo(TokenType.REFRESH);
 		}
@@ -144,7 +144,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("REFRESH 토큰은 userId를 포함한다")
 		void containsUserId() {
-			String token = jwtTokenProvider.createRefreshToken(USER_ID);
+			String token = jwtTokenProvider.createRefreshToken(USER_ID, SID);
 
 			assertThat(jwtTokenProvider.getUserIdFromToken(token)).isEqualTo(USER_ID);
 		}
@@ -160,9 +160,9 @@ class JwtTokenProviderTest {
 			String expiredToken = buildExpiredToken();
 
 			assertThatThrownBy(() -> jwtTokenProvider.validateToken(expiredToken))
-				.isInstanceOf(CustomException.class)
-				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
-					.isEqualTo(ErrorCode.EXPIRED_TOKEN));
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
+							.isEqualTo(ErrorCode.EXPIRED_TOKEN));
 		}
 
 		@Test
@@ -171,18 +171,18 @@ class JwtTokenProviderTest {
 			String wrongToken = buildWrongSignatureToken();
 
 			assertThatThrownBy(() -> jwtTokenProvider.validateToken(wrongToken))
-				.isInstanceOf(CustomException.class)
-				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
-					.isEqualTo(ErrorCode.INVALID_TOKEN));
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
+							.isEqualTo(ErrorCode.INVALID_TOKEN));
 		}
 
 		@Test
 		@DisplayName("형식이 잘못된 토큰이면 INVALID_TOKEN 예외를 던진다")
 		void malformedToken_throwsInvalidTokenException() {
 			assertThatThrownBy(() -> jwtTokenProvider.validateToken("not.a.jwt"))
-				.isInstanceOf(CustomException.class)
-				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
-					.isEqualTo(ErrorCode.INVALID_TOKEN));
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
+							.isEqualTo(ErrorCode.INVALID_TOKEN));
 		}
 	}
 
@@ -204,7 +204,7 @@ class JwtTokenProviderTest {
 		@Test
 		@DisplayName("유효한 토큰이면 정상적으로 Claims를 반환한다")
 		void validToken_returnsClaims() {
-			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE);
+			String token = jwtTokenProvider.createAccessToken(USER_ID, ROLE, SID);
 
 			Claims claims = jwtTokenProvider.parseClaimsAllowExpired(token);
 
@@ -217,9 +217,9 @@ class JwtTokenProviderTest {
 			String wrongToken = buildWrongSignatureToken();
 
 			assertThatThrownBy(() -> jwtTokenProvider.parseClaimsAllowExpired(wrongToken))
-				.isInstanceOf(CustomException.class)
-				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
-					.isEqualTo(ErrorCode.INVALID_TOKEN));
+					.isInstanceOf(CustomException.class)
+					.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
+							.isEqualTo(ErrorCode.INVALID_TOKEN));
 		}
 	}
 
@@ -227,13 +227,13 @@ class JwtTokenProviderTest {
 
 	private String buildExpiredToken() {
 		return Jwts.builder()
-			.subject(String.valueOf(USER_ID))
-			.claim("tokenType", TokenType.ACCESS.getValue())
-			.claim("auth", ROLE)
-			.issuedAt(new java.util.Date(System.currentTimeMillis() - 7200_000))
-			.expiration(new java.util.Date(System.currentTimeMillis() - 3600_000))
-			.signWith((RSAPrivateKey)KEY_PAIR.getPrivate(), Jwts.SIG.RS256)
-			.compact();
+				.subject(String.valueOf(USER_ID))
+				.claim("tokenType", TokenType.ACCESS.getValue())
+				.claim("auth", ROLE)
+				.issuedAt(new java.util.Date(System.currentTimeMillis() - 7200_000))
+				.expiration(new java.util.Date(System.currentTimeMillis() - 3600_000))
+				.signWith((RSAPrivateKey)KEY_PAIR.getPrivate(), Jwts.SIG.RS256)
+				.compact();
 	}
 
 	private String buildWrongSignatureToken() {
@@ -242,13 +242,13 @@ class JwtTokenProviderTest {
 			kpg.initialize(2048);
 			KeyPair wrongPair = kpg.generateKeyPair();
 			return Jwts.builder()
-				.subject(String.valueOf(USER_ID))
-				.claim("tokenType", TokenType.ACCESS.getValue())
-				.claim("auth", ROLE)
-				.issuedAt(new java.util.Date())
-				.expiration(new java.util.Date(System.currentTimeMillis() + 3600_000))
-				.signWith((RSAPrivateKey)wrongPair.getPrivate(), Jwts.SIG.RS256)
-				.compact();
+					.subject(String.valueOf(USER_ID))
+					.claim("tokenType", TokenType.ACCESS.getValue())
+					.claim("auth", ROLE)
+					.issuedAt(new java.util.Date())
+					.expiration(new java.util.Date(System.currentTimeMillis() + 3600_000))
+					.signWith((RSAPrivateKey)wrongPair.getPrivate(), Jwts.SIG.RS256)
+					.compact();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/common-core/src/main/java/com/goormgb/be/global/config/ActuatorSecurityConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/ActuatorSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
+ * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+ */
+@Configuration
+public class ActuatorSecurityConfig {
+
+	@Bean
+	@Order(0)
+	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용
- Refresh Token 만료 단위를 일(day)에서 시간(hour)으로 변경하여 보안 강화
- 환경변수 `JWT_REFRESH_TOKEN_EXPIRATION` 단위가 일 → 시간으로 변경됨 (기존 7일 → 3시간)
- 부하테스트 계정의 Access/Refresh Token 만료시간을 15분으로 제한하여 Redis 메모리 누적 방지

## 🧩 구현 상세
- `JwtProperties.RefreshToken.expirationDays` → `expirationHours`로 프로퍼티 변경
- `JwtTokenProvider`, `AuthService`, `KakaoAuthService`, `DevAuthService`에서 `ChronoUnit.DAYS` / `Duration.ofDays()` → `HOURS` /  `ofHours()`로 일괄 변경
- `RefreshTokenRepository` Redis TTL도 동일하게 `Duration.ofDays` → `Duration.ofHours`로 변경
- `CookieUtils`의 Refresh Token 쿠키 maxAge도 시간 단위로 변경
- `JwtProperties.LoadTest` 설정 클래스 신규 추가 (기본값 15분)
- `JwtTokenProvider`에 만료시간 직접 지정 가능한 오버로드 메서드 2개 추가 (`createAccessToken`, `createRefreshToken`)
- `RefreshTokenRepository`에 커스텀 TTL `save()` 오버로드 추가 (부하테스트 토큰 15분 TTL 저장)
- `LoadTestAuthService`에서 위 오버로드 메서드들을 사용하여 15분짜리 토큰 발급 및 Redis 저장
- `application.yaml`, `application-dev.yaml`에 `expiration-hours`, `load-test.token-expiration-minutes` 설정 추가
- 테스트 코드 시그니처 반영 (`sid` 파라미터 추가, `setExpirationHours(3)`)

### 📌 관련 Jira Issue
- GRGB-346

## 🧪 테스트 방법
- 일반 유저 로그인 → Refresh Token 만료시간이 3시간(env 값)인지 확인
- 부하테스트 로그인(`POST /auth/loadtest/login`) → Access/Refresh Token 만료시간이 15분인지 확인
- Redis에서 `refresh_token:{jti}` 키의 TTL이 일반: 3시간, 부하테스트: 15분인지 확인
- Refresh Token 쿠키의 maxAge가 10800초(3시간)인지 확인

## ❗ 참고 사항
- **배포 시 환경변수 값 변경 필수**: `JWT_REFRESH_TOKEN_EXPIRATION`의 의미가 일 → 시간으로 변경되었으므로 반드시 `7` → `3`으로 수정해야 합니다 (값을 그대로 두면 7시간으로 동작)
- 신규 환경변수 `JWT_LOADTEST_TOKEN_EXPIRATION`: 미설정 시 기본값 15분 자동 적용 (설정 불필요)
- 기존 발급된 Refresh Token은 JWT `exp` claim에 만료 시각이 박혀있으므로 배포 후에도 기존 토큰은 원래 만료시간까지 유효함