### PR TITLE
refactor(monitoring): staging, prod debug log 삭제 [GRGB-332]

### DIFF
--- a/API-Gateway/src/main/resources/application-dev.yaml
+++ b/API-Gateway/src/main/resources/application-dev.yaml
@@ -78,3 +78,4 @@ logging:
   level:
     root: INFO
     com.goormgb.be: DEBUG
+    org.springframework.web: DEBUG

--- a/API-Gateway/src/main/resources/application.yaml
+++ b/API-Gateway/src/main/resources/application.yaml
@@ -67,5 +67,3 @@ management:
 
 logging:
   config: classpath:logback-spring.xml
-  level:
-    org.springframework.web: DEBUG

--- a/Auth-Guard/src/main/resources/application-dev.yaml
+++ b/Auth-Guard/src/main/resources/application-dev.yaml
@@ -90,3 +90,4 @@ logging:
   level:
     root: INFO
     com.goormgb.be: DEBUG
+    org.springframework.web: DEBUG

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -93,5 +93,3 @@ springdoc:
 
 logging:
   config: classpath:logback-spring.xml
-  level:
-    org.springframework.web: DEBUG

--- a/Order-Core/src/main/resources/application-dev.yaml
+++ b/Order-Core/src/main/resources/application-dev.yaml
@@ -103,3 +103,4 @@ logging:
   level:
     root: INFO
     com.goormgb.be: DEBUG
+    org.springframework.web: DEBUG

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -108,5 +108,3 @@ springdoc:
 
 logging:
   config: classpath:logback-spring.xml
-  level:
-    org.springframework.web: DEBUG

--- a/Queue/src/main/resources/application-dev.yaml
+++ b/Queue/src/main/resources/application-dev.yaml
@@ -79,3 +79,4 @@ logging:
   level:
     root: INFO
     com.goormgb.be: DEBUG
+    org.springframework.web: DEBUG

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -84,5 +84,3 @@ springdoc:
 
 logging:
   config: classpath:logback-spring.xml
-  level:
-    org.springframework.web: DEBUG

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -72,3 +72,4 @@ logging:
   level:
     root: INFO
     com.goormgb.be: DEBUG
+    org.springframework.web: DEBUG

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -77,5 +77,3 @@ springdoc:
 
 logging:
   config: classpath:logback-spring.xml
-  level:
-    org.springframework.web: DEBUG

--- a/common-core/src/main/resources/logging/logback-base.xml
+++ b/common-core/src/main/resources/logging/logback-base.xml
@@ -76,7 +76,7 @@
         <logger name="org.springframework.web" level="DEBUG"/>
     </springProfile>
 
-    <springProfile name="staging">
+    <springProfile name="staging | prod">
         <appender name="FILE_STAGING_ORIGIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>/var/log/backend/application.log</file>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -97,19 +97,6 @@
         <root level="INFO">
             <appender-ref ref="STDOUT_JSON"/>
             <appender-ref ref="ASYNC_FILE_STAGING"/>
-        </root>
-        <logger name="com.goormgb.be" level="INFO"/>
-        <logger name="org.springframework" level="WARN"/>
-        <logger name="org.hibernate" level="WARN"/>
-        <logger name="io.opentelemetry" level="WARN"/>
-        <logger name="org.springframework.security" level="INFO"/>
-    </springProfile>
-
-
-    <!--    임시 prod 추가-->
-    <springProfile name="prod">
-        <root level="INFO">
-            <appender-ref ref="STDOUT_JSON"/>
         </root>
         <logger name="com.goormgb.be" level="INFO"/>
         <logger name="org.springframework" level="WARN"/>

--- a/common-core/src/main/resources/logging/logback-base.xml
+++ b/common-core/src/main/resources/logging/logback-base.xml
@@ -77,7 +77,7 @@
     </springProfile>
 
     <springProfile name="staging | prod">
-        <appender name="FILE_STAGING_ORIGIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <appender name="FILE_RUNTIME_ORIGIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>/var/log/backend/application.log</file>
             <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                 <fileNamePattern>/var/log/backend/app-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
@@ -88,15 +88,15 @@
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>
 
-        <appender name="ASYNC_FILE_STAGING" class="ch.qos.logback.classic.AsyncAppender">
-            <appender-ref ref="FILE_STAGING_ORIGIN"/>
+        <appender name="ASYNC_FILE_RUNTIME" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE_RUNTIME_ORIGIN"/>
             <queueSize>1024</queueSize>
             <discardingThreshold>0</discardingThreshold>
         </appender>
 
         <root level="INFO">
             <appender-ref ref="STDOUT_JSON"/>
-            <appender-ref ref="ASYNC_FILE_STAGING"/>
+            <appender-ref ref="ASYNC_FILE_RUNTIME"/>
         </root>
         <logger name="com.goormgb.be" level="INFO"/>
         <logger name="org.springframework" level="WARN"/>


### PR DESCRIPTION
## 🔧 작업 내용

- `staging` 이상 환경에서 `org.springframework.web` DEBUG 로그가 출력되지 않도록 로깅 레벨 적용 범위를 정리했습니다.
- 각 서비스의 공통 `application.yaml`에 있던 `logging.level.org.springframework.web: DEBUG`를 제거하고, `application-dev.yaml`에만 유지하도록 분리했습니다.
- 공통 로그백 설정에서 운영 환경 공통 블록을 `staging | prod`로 통합해 동일 기준이 적용되도록 정리했습니다.

### 📌 관련 Jira Issue

- GRGB-332

## ❗ 참고 사항

- DEBUG 로그 삭제하는걸 까먹고 있었네요..
