### PR TITLE
fix(order-core): 온보딩 수정 시 viewpoint priority unique constraint 위반 수정

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingPreferredBlockRepository.java
@@ -18,7 +18,7 @@ public interface OnboardingPreferredBlockRepository extends JpaRepository<Onboar
 
 	long countByUserId(Long userId);
 
-	@Modifying(clearAutomatically = true)
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
 	@Query("DELETE FROM OnboardingPreferredBlock opb WHERE opb.user.id = :userId")
 	void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingViewpointPriorityRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/onboarding/repository/OnboardingViewpointPriorityRepository.java
@@ -3,6 +3,9 @@ package com.goormgb.be.domain.onboarding.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
 
@@ -10,5 +13,7 @@ public interface OnboardingViewpointPriorityRepository extends JpaRepository<Onb
 
 	List<OnboardingViewpointPriority> findAllByUserIdOrderByPriorityAsc(Long userId);
 
-	void deleteAllByUserId(Long userId);
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query("DELETE FROM OnboardingViewpointPriority v WHERE v.user.id = :userId")
+	void deleteAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 🔧 작업 내용
- ViewpointPriorityRepository의 deleteAllByUserId를 @Modifying @Query JPQL 벌크 삭제로 변경
- flushAutomatically=true 추가하여 DELETE가 INSERT보다 먼저 실행되도록 보장
- PreferredBlockRepository에도 동일하게 flushAutomatically=true 추가
