### PR TITLE
feat(order-core): 경기 판매상태 개편 — 매진/판매종료 상태 추가

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/scheduler/MatchStatusScheduler.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/scheduler/MatchStatusScheduler.java
@@ -51,6 +51,23 @@ public class MatchStatusScheduler {
 	}
 
 	/**
+	 * 매 정시: 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 CLOSED(판매종료)로 전환한다.
+	 * 경기 시작 이후에는 티켓 판매가 불가능해야 한다.
+	 */
+	@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+	@Transactional
+	public void closeSales() {
+		Instant now = Instant.now();
+		int count = matchRepository.bulkUpdateSaleClosed(
+			now, SaleStatus.CLOSED, SaleStatus.ON_SALE, SaleStatus.SOLD_OUT
+		);
+
+		if (count > 0) {
+			log.info("[MatchStatusScheduler] ON_SALE/SOLD_OUT → CLOSED 전환 완료: {}건", count);
+		}
+	}
+
+	/**
 	 * 매일 자정 00:00: 전날까지 경기가 있던 건을 ENDED로 전환한다.
 	 * 예) 3월 10일 경기 → 3월 11일 00:00에 ENDED 처리
 	 */

--- a/common-core/src/main/java/com/goormgb/be/domain/match/enums/SaleStatus.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/enums/SaleStatus.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum SaleStatus {
 	ON_SALE("예매중"),
 	UPCOMING("오픈예정"),
-	SOLD_OUT("예매 마감"),
+	SOLD_OUT("매진"),
+	CLOSED("판매종료"),
 	ENDED("경기 종료");
 
 	private final String description;

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -68,4 +68,21 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		Instant start,
 		Instant end
 	);
+
+	/**
+	 * 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 CLOSED(판매종료)로 일괄 전환한다.
+	 */
+	@Modifying
+	@Query("""
+		UPDATE Match m
+		SET m.saleStatus = :newStatus
+		WHERE m.matchAt <= :now
+		  AND m.saleStatus IN (:onSale, :soldOut)
+		""")
+	int bulkUpdateSaleClosed(
+		@Param("now") Instant now,
+		@Param("newStatus") SaleStatus newStatus,
+		@Param("onSale") SaleStatus onSale,
+		@Param("soldOut") SaleStatus soldOut
+	);
 }


### PR DESCRIPTION
## 🔧 작업 내용
- SaleStatus enum에 CLOSED(판매종료) 상태 신규 추가
- SOLD_OUT description을 "예매 마감"에서 "매진"으로 변경
- 경기 시작 시간이 지나면 ON_SALE/SOLD_OUT → CLOSED로 자동 전환하는 스케줄러 추가

## 🧩 구현 상세
- `SaleStatus.java`: SOLD_OUT("매진")으로 description 변경, CLOSED("판매종료") 추가
- `MatchRepository.java`: `bulkUpdateSaleClosed()` 벌크 업데이트 쿼리 추가 — 경기 시작 시간이 지난 ON_SALE/SOLD_OUT 경기를 CLOSED로 일괄 전환
- `MatchStatusScheduler.java`: `closeSales()` 스케줄러 추가 — 매 정시 실행
- 기존 QueueService, MatchDisplayUtils는 ON_SALE만 허용하므로 CLOSED 상태에서 자동으로 티켓 판매/대기열 진입이 차단됨 (변경 불필요)

### 상태 전환 흐름
UPCOMING → ON_SALE → SOLD_OUT(매진)
                ↘          ↓
             CLOSED(판매종료) ← 경기 시작 시간 도래 (매 정시 스케줄러)
                   ↓
              ENDED(경기 종료) ← 당일 자정 (기존 스케줄러)

### 📌 관련 Jira Issue
- GRGB-349

## ❗ 참고 사항
- 프론트에서 새로운 `CLOSED` 상태값 처리 필요 (표시 텍스트: "판매종료")
- DB 마이그레이션 불필요 (VARCHAR(20) + EnumType.STRING, CLOSED는 6자)
- 기존 seed data에 CLOSED 상태 경기가 없으므로 배포 시 별도 데이터 작업 불필요