### PR TITLE
refactor(order-core): CLOSED 상태 제거 및 판매종료 시 ENDED로 통합 (#GRGB-349)

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/scheduler/MatchStatusScheduler.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/scheduler/MatchStatusScheduler.java
@@ -51,19 +51,19 @@ public class MatchStatusScheduler {
 	}
 
 	/**
-	 * 매 정시: 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 CLOSED(판매종료)로 전환한다.
+	 * 매 정시: 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 ENDED(예매 마감)로 전환한다.
 	 * 경기 시작 이후에는 티켓 판매가 불가능해야 한다.
 	 */
 	@Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void closeSales() {
 		Instant now = Instant.now();
-		int count = matchRepository.bulkUpdateSaleClosed(
-			now, SaleStatus.CLOSED, SaleStatus.ON_SALE, SaleStatus.SOLD_OUT
+		int count = matchRepository.bulkUpdateSaleEnded(
+			now, SaleStatus.ENDED, SaleStatus.ON_SALE, SaleStatus.SOLD_OUT
 		);
 
 		if (count > 0) {
-			log.info("[MatchStatusScheduler] ON_SALE/SOLD_OUT → CLOSED 전환 완료: {}건", count);
+			log.info("[MatchStatusScheduler] ON_SALE/SOLD_OUT → ENDED 전환 완료: {}건", count);
 		}
 	}
 

--- a/common-core/src/main/java/com/goormgb/be/domain/match/enums/SaleStatus.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/enums/SaleStatus.java
@@ -6,11 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SaleStatus {
-	ON_SALE("예매중"),
-	UPCOMING("오픈예정"),
+	ON_SALE("예매 가능"),
+	UPCOMING("판매 예정"),
 	SOLD_OUT("매진"),
-	CLOSED("판매종료"),
-	ENDED("경기 종료");
+	ENDED("예매 마감");
 
 	private final String description;
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -70,7 +70,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 	);
 
 	/**
-	 * 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 CLOSED(판매종료)로 일괄 전환한다.
+	 * 경기 시작 시간이 지난 ON_SALE / SOLD_OUT 경기를 ENDED(예매 마감)로 일괄 전환한다.
 	 */
 	@Modifying
 	@Query("""
@@ -79,7 +79,7 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		WHERE m.matchAt <= :now
 		  AND m.saleStatus IN (:onSale, :soldOut)
 		""")
-	int bulkUpdateSaleClosed(
+	int bulkUpdateSaleEnded(
 		@Param("now") Instant now,
 		@Param("newStatus") SaleStatus newStatus,
 		@Param("onSale") SaleStatus onSale,


### PR DESCRIPTION
## 🔧 작업 내용
- 기획 변경에 따라 SaleStatus에서 CLOSED 상태를 제거
- 경기 시작 시간 도래 시 ON_SALE/SOLD_OUT → ENDED(예매 마감)로 직접 전환하도록 변경
- SaleStatus description 정리: ON_SALE("예매 가능"), UPCOMING("판매 예정"), SOLD_OUT("매진"), ENDED("예매 마감")

## 🧩 구현 상세
- `SaleStatus.java`: CLOSED 제거, description 문구 통일
- `MatchRepository.java`: `bulkUpdateSaleClosed()` → `bulkUpdateSaleEnded()`로 메서드명 변경, Javadoc 수정
- `MatchStatusScheduler.java`: `closeSales()`에서 CLOSED 대신 ENDED로 전환하도록 변경, 로그 메시지 반영
- 기존 자정 `closeEndedMatches()` 스케줄러는 안전망으로 그대로 유지

### 상태 전환 흐름 (변경 후)
UPCOMING → ON_SALE → SOLD_OUT(매진)
                                ↓                     ↓
                              ENDED(예매 마감) ← 경기 시작 시간 도래 (매 정시 스케줄러)

### 📌 관련 Jira Issue
- GRGB-349

## ❗ 참고 사항
- DB 마이그레이션 불필요 (VARCHAR + EnumType.STRING 방식, CLOSED 데이터 없음)