### PR TITLE
feat(kafka): Consumer DLT 에러 처리 및 안정화 (Seat + Order-Core) [GRGB-348]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/KafkaConsumerConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/KafkaConsumerConfig.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.ordercore.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+	@Bean
+	public CommonErrorHandler commonErrorHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+			kafkaTemplate,
+			(record, ex) -> new TopicPartition(record.topic() + ".DLT", record.partition())
+		);
+
+		// 1초 간격 3회 재시도 후 DLT 전송
+		return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
@@ -32,10 +32,13 @@ public class EmailEventConsumer {
 			.orElse(null);
 
 		if (context == null) {
-			log.warn("[Kafka-Email] 주문 없음, 이메일 발송 스킵: orderId={}", event.getOrderId());
+			log.warn("[Kafka-Email] 주문없음 이메일스킵 - orderId={}, eventTopic={}, action=skip, reason=order_not_found",
+				event.getOrderId(), EventTopic.PAYMENT_COMPLETED);
 			return;
 		}
 
+		log.info("[Kafka-Email] 결제완료 이메일발송 - orderId={}, eventTopic={}, action=send", event.getOrderId(),
+			EventTopic.PAYMENT_COMPLETED);
 		emailService.sendPaymentConfirmation(context);
 	}
 
@@ -49,10 +52,13 @@ public class EmailEventConsumer {
 			.orElse(null);
 
 		if (context == null) {
-			log.warn("[Kafka-Email] 주문 없음, 이메일 발송 스킵: orderId={}", event.getOrderId());
+			log.warn("[Kafka-Email] 주문없음 이메일스킵 - orderId={}, eventTopic={}, action=skip, reason=order_not_found",
+				event.getOrderId(), EventTopic.ORDER_CANCELLED);
 			return;
 		}
 
+		log.info("[Kafka-Email] 주문취소 이메일발송 - orderId={}, eventTopic={}, action=send", event.getOrderId(),
+			EventTopic.ORDER_CANCELLED);
 		emailService.sendCancellationConfirmation(context);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/KafkaConsumerConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/KafkaConsumerConfig.java
@@ -1,0 +1,25 @@
+package com.goormgb.be.seat.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+	@Bean
+	public CommonErrorHandler commonErrorHandler(KafkaTemplate<String, Object> kafkaTemplate) {
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+			kafkaTemplate,
+			(record, ex) -> new TopicPartition(record.topic() + ".DLT", record.partition())
+		);
+
+		// 1초 간격 3회 재시도 후 DLT 전송
+		return new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -27,31 +27,37 @@ public class BankTransferExpiredEventConsumer {
 	public void handleBankTransferExpired(BankTransferExpiredEvent event) {
 		List<Long> requestedIds = event.getMatchSeatIds();
 		List<MatchSeat> seats = matchSeatRepository.findAllById(requestedIds);
+		int missingSeatCount = requestedIds.size() - seats.size();
+		int updatedCount = 0;
+		int alreadyTargetStateCount = 0;
+		int unexpectedStateCount = 0;
 
-		if (seats.size() != requestedIds.size()) {
-			log.warn("[Kafka] 좌석 조회 수 불일치: orderId={}, 요청={}건, 조회={}건",
-				event.getOrderId(), requestedIds.size(), seats.size());
-		}
-
-		int restoredCount = 0;
 		for (MatchSeat seat : seats) {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				seat.markAvailable();
-				restoredCount++;
+				updatedCount++;
+					log.debug("[Kafka] 무통장만료 좌석복원 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
+						event.getOrderId(), event.getPaymentId(), seat.getId(), MatchSeatSaleStatus.SOLD);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE) {
-				log.debug("[Kafka] 이미 AVAILABLE 상태, 스킵: matchSeatId={}", seat.getId());
+				alreadyTargetStateCount++;
+					log.debug("[Kafka] 무통장만료 처리스킵 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
+						event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
 			} else {
-				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}, orderId={}",
-					seat.getId(), seat.getSaleStatus(), event.getOrderId());
+				unexpectedStateCount++;
+					log.warn("[Kafka] 무통장만료 비정상상태 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+						event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 
-		if (restoredCount > 0) {
-			log.info("[Kafka] 무통장 만료 이벤트 처리 완료: orderId={}, paymentId={}, 좌석 AVAILABLE 복원={}건",
-				event.getOrderId(), event.getPaymentId(), restoredCount);
-		} else {
-			log.info("[Kafka] 무통장 만료 이벤트 수신: orderId={}, AVAILABLE 복원 대상 없음",
-				event.getOrderId());
-		}
+		log.info(
+			"[Kafka] 무통장 만료 이벤트 처리 요약: orderId={}, paymentId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
+			event.getOrderId(),
+			event.getPaymentId(),
+			requestedIds.size(),
+			updatedCount,
+			alreadyTargetStateCount,
+			unexpectedStateCount,
+			missingSeatCount
+		);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -36,16 +36,19 @@ public class BankTransferExpiredEventConsumer {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				seat.markAvailable();
 				updatedCount++;
-					log.debug("[Kafka] 무통장만료 좌석복원 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
-						event.getOrderId(), event.getPaymentId(), seat.getId(), MatchSeatSaleStatus.SOLD);
+				log.debug(
+					"[Kafka] 무통장만료 좌석복원 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
+					event.getOrderId(), event.getPaymentId(), seat.getId(), MatchSeatSaleStatus.SOLD);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE) {
 				alreadyTargetStateCount++;
-					log.debug("[Kafka] 무통장만료 처리스킵 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
-						event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
+				log.debug(
+					"[Kafka] 무통장만료 처리스킵 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
+					event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
 			} else {
 				unexpectedStateCount++;
-					log.warn("[Kafka] 무통장만료 비정상상태 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
-						event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
+				log.warn(
+					"[Kafka] 무통장만료 비정상상태 - orderId={}, paymentId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+					event.getOrderId(), event.getPaymentId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
@@ -27,31 +27,36 @@ public class OrderCancelledEventConsumer {
 	public void handleOrderCancelled(OrderCancelledEvent event) {
 		List<Long> requestedIds = event.getMatchSeatIds();
 		List<MatchSeat> seats = matchSeatRepository.findAllById(requestedIds);
+		int missingSeatCount = requestedIds.size() - seats.size();
+		int updatedCount = 0;
+		int alreadyTargetStateCount = 0;
+		int unexpectedStateCount = 0;
 
-		if (seats.size() != requestedIds.size()) {
-			log.warn("[Kafka] 좌석 조회 수 불일치: orderId={}, 요청={}건, 조회={}건",
-				event.getOrderId(), requestedIds.size(), seats.size());
-		}
-
-		int restoredCount = 0;
 		for (MatchSeat seat : seats) {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				seat.markAvailable();
-				restoredCount++;
+				updatedCount++;
+					log.debug("[Kafka] 주문취소 좌석복원 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
+						event.getOrderId(), seat.getId(), MatchSeatSaleStatus.SOLD);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE) {
-				log.debug("[Kafka] 이미 AVAILABLE 상태, 스킵: matchSeatId={}", seat.getId());
+				alreadyTargetStateCount++;
+					log.debug("[Kafka] 주문취소 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
+						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			} else {
-				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}, orderId={}",
-					seat.getId(), seat.getSaleStatus(), event.getOrderId());
+				unexpectedStateCount++;
+					log.warn("[Kafka] 주문취소 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 
-		if (restoredCount > 0) {
-			log.info("[Kafka] 주문 취소 이벤트 처리 완료: orderId={}, 좌석 AVAILABLE 복원={}건",
-				event.getOrderId(), restoredCount);
-		} else {
-			log.info("[Kafka] 주문 취소 이벤트 수신: orderId={}, AVAILABLE 복원 대상 없음",
-				event.getOrderId());
-		}
+		log.info(
+			"[Kafka] 주문 취소 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
+			event.getOrderId(),
+			requestedIds.size(),
+			updatedCount,
+			alreadyTargetStateCount,
+			unexpectedStateCount,
+			missingSeatCount
+		);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -27,32 +27,36 @@ public class PaymentCompletedEventConsumer {
 	public void handlePaymentCompleted(PaymentCompletedEvent event) {
 		List<Long> requestedIds = event.getMatchSeatIds();
 		List<MatchSeat> seats = matchSeatRepository.findAllById(requestedIds);
+		int missingSeatCount = requestedIds.size() - seats.size();
+		int updatedCount = 0;
+		int alreadyTargetStateCount = 0;
+		int unexpectedStateCount = 0;
 
-		if (seats.size() != requestedIds.size()) {
-			log.warn("[Kafka] 좌석 조회 수 불일치: orderId={}, 요청={}건, 조회={}건",
-				event.getOrderId(), requestedIds.size(), seats.size());
-		}
-
-		int soldCount = 0;
 		for (MatchSeat seat : seats) {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.BLOCKED) {
 				seat.markSold();
-				soldCount++;
+				updatedCount++;
+					log.debug("[Kafka] 결제완료 좌석상태변경 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=SOLD",
+						event.getOrderId(), seat.getId(), MatchSeatSaleStatus.BLOCKED);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
-				log.debug("[Kafka] 이미 SOLD 상태, 스킵: matchSeatId={}", seat.getId());
+				alreadyTargetStateCount++;
+					log.debug("[Kafka] 결제완료 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_sold",
+						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			} else {
-				log.warn("[Kafka] 예상하지 못한 좌석 상태: matchSeatId={}, status={}, orderId={} — "
-						+ "Consumer Lag으로 인해 SeatHoldCleanupScheduler가 먼저 AVAILABLE로 복원했을 가능성 있음",
-					seat.getId(), seat.getSaleStatus(), event.getOrderId());
+				unexpectedStateCount++;
+					log.warn("[Kafka] 결제완료 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 
-		if (soldCount > 0) {
-			log.info("[Kafka] 결제 이벤트 처리 완료: orderId={}, 좌석 SOLD 전환={}건",
-				event.getOrderId(), soldCount);
-		} else {
-			log.info("[Kafka] 결제 이벤트 수신: orderId={}, SOLD 전환 대상 없음",
-				event.getOrderId());
-		}
+		log.info(
+			"[Kafka] 결제 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
+			event.getOrderId(),
+			requestedIds.size(),
+			updatedCount,
+			alreadyTargetStateCount,
+			unexpectedStateCount,
+			missingSeatCount
+		);
 	}
 }

--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -27,6 +27,10 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: ${KAFKA_PRODUCER_KEY_SERIALIZER}
+      value-serializer: ${KAFKA_PRODUCER_VALUE_SERIALIZER}
+      acks: ${KAFKA_PRODUCER_ACKS}
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP_ID}
       key-deserializer: ${KAFKA_CONSUMER_KEY_DESERIALIZER}

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -27,6 +27,10 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: ${KAFKA_PRODUCER_KEY_SERIALIZER}
+      value-serializer: ${KAFKA_PRODUCER_VALUE_SERIALIZER}
+      acks: ${KAFKA_PRODUCER_ACKS}
     consumer:
       group-id: ${KAFKA_CONSUMER_GROUP_ID}
       key-deserializer: ${KAFKA_CONSUMER_KEY_DESERIALIZER}

--- a/common-core/src/main/java/com/goormgb/be/kafka/KafkaTopicConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/kafka/KafkaTopicConfig.java
@@ -19,6 +19,14 @@ public class KafkaTopicConfig {
 	}
 
 	@Bean
+	public NewTopic paymentCompletedDltTopic() {
+		return TopicBuilder.name(EventTopic.PAYMENT_COMPLETED + ".DLT")
+				.partitions(3)
+				.replicas(1)
+				.build();
+	}
+
+	@Bean
 	public NewTopic orderCancelledTopic() {
 		return TopicBuilder.name(EventTopic.ORDER_CANCELLED)
 				.partitions(3)
@@ -27,8 +35,24 @@ public class KafkaTopicConfig {
 	}
 
 	@Bean
+	public NewTopic orderCancelledDltTopic() {
+		return TopicBuilder.name(EventTopic.ORDER_CANCELLED + ".DLT")
+				.partitions(3)
+				.replicas(1)
+				.build();
+	}
+
+	@Bean
 	public NewTopic bankTransferExpiredTopic() {
 		return TopicBuilder.name(EventTopic.BANK_TRANSFER_EXPIRED)
+				.partitions(3)
+				.replicas(1)
+				.build();
+	}
+
+	@Bean
+	public NewTopic bankTransferExpiredDltTopic() {
+		return TopicBuilder.name(EventTopic.BANK_TRANSFER_EXPIRED + ".DLT")
 				.partitions(3)
 				.replicas(1)
 				.build();


### PR DESCRIPTION
## 🔧 작업 내용

- Kafka Consumer 공통 에러 처리 정책을 Seat, Order-Core에 적용했습니다.
- 예외 발생 시 1초 간격 3회 재시도 후 `<원본토픽>.DLT`로 전송되도록 구성했습니다.
- DLT 토픽(`payment-completed.DLT`, `order-cancelled.DLT`, `bank-transfer-expired.DLT`) 생성 설정을 추가했습니다.
- Seat 3개 Consumer와 Order-Core Email Consumer 로그를 구조화해 운영 추적성을 높였습니다.
- Seat 서비스에 Kafka producer 설정(serializer, acks)을 보강했습니다.

## 🧩 구현 상세 (선택)

- 공통 핸들러:
  - `DefaultErrorHandler`
  - `DeadLetterPublishingRecoverer`
  - `FixedBackOff(1000L, 3L)`
- DLT 라우팅:
  - `<원본토픽>.DLT`
  - 원본 partition 유지
- 로그 필드:
  - Seat: `orderId`, `matchSeatId`, `currentStatus`, `action`, `reason`, 요약 카운트
  - Email: `orderId`, `eventTopic`, `action`, `reason`

### 📌 관련 Jira Issue

- GRGB-348

## 🧪 테스트 방법(선택)

- 실패 발행 예시 (`payment-completed`):
  - key: `order-1001`
  - header: `{"__TypeId__":"com.goormgb.be.kafka.event.PaymentCompletedEvent"}`
  - value:
    ```json
    {
      "orderId": 1001,
      "userId": 3001,
      "matchId": 7001,
      "matchSeatIds": null,
      "paymentMethod": "TOSS_PAY",
      "totalAmount": 25000,
      "occurredAt": "2026-04-09T01:00:00Z"
    }
    ```

## ❗ 참고 사항

- dev에서 테스트 해보도록 하겠슴니다..
- seat의 apllication-local.yaml도 dev와 동일하게(producer) 변경되었습니다
