### PR TITLE
fix(order-core): 예매 내역 UNDER_REVIEW 누락 수정 및 취소 시 즉시 완료 처리 [GRGB-355]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/enums/TicketTab.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/enums/TicketTab.java
@@ -16,6 +16,7 @@ public enum TicketTab {
 	BOOKED(List.of(
 		OrderStatus.PAYMENT_PENDING,
 		OrderStatus.PAID,
+		OrderStatus.UNDER_REVIEW,
 		OrderStatus.CANCEL_REQUESTED,
 		OrderStatus.REFUND_PROCESSING
 	)),

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
@@ -30,7 +30,8 @@ public class MyPageProfileService {
 
 	private static final List<OrderStatus> UPCOMING_STATUSES = List.of(
 		OrderStatus.PAYMENT_PENDING,
-		OrderStatus.PAID
+		OrderStatus.PAID,
+		OrderStatus.UNDER_REVIEW
 	);
 
 	private static final List<OrderStatus> CANCEL_REFUND_STATUSES = List.of(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -39,6 +39,9 @@ import com.goormgb.be.ordercore.order.event.OrderEventPublisher;
 import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
 import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
 import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 
@@ -57,7 +60,8 @@ public class MyPageTicketService {
 
 	private static final List<OrderStatus> UPCOMING_STATUSES = List.of(
 			OrderStatus.PAYMENT_PENDING,
-			OrderStatus.PAID
+			OrderStatus.PAID,
+			OrderStatus.UNDER_REVIEW
 	);
 
 	private static final List<String> UPCOMING_TICKET_STATUSES = List.of(
@@ -74,6 +78,7 @@ public class MyPageTicketService {
 	private final OrderRepository orderRepository;
 	private final OrderSeatRepository orderSeatRepository;
 	private final QrTokenRepository qrTokenRepository;
+	private final PaymentRepository paymentRepository;
 	private final MyPageQueryService myPageQueryService;
 	private final CancellationFeePolicyRepository cancellationFeePolicyRepository;
 	private final OrderEventPublisher orderEventPublisher;
@@ -241,7 +246,17 @@ public class MyPageTicketService {
 
 		int cancellationFee = MyPageTicketCancellationCalculator.calculateCancellationFee(order, policy, now);
 		int refundedAmount = order.getTotalAmount() - cancellationFee;
-		order.cancel(cancellationFee, refundedAmount);
+
+		Payment payment = paymentRepository.findByOrderId(ticketId)
+				.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
+
+		if (payment.getPaymentMethod() == PaymentMethod.BANK_TRANSFER) {
+			order.refundComplete(cancellationFee, refundedAmount);
+			payment.refund();
+		} else {
+			order.cancelComplete(cancellationFee, refundedAmount);
+			payment.cancel();
+		}
 
 		// 주문 취소 이벤트 발행 → Seat 서비스에서 좌석 SOLD → AVAILABLE 복원
 		List<Long> matchSeatIds = orderSeatRepository.findMatchSeatIdsByOrderId(ticketId);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -251,10 +251,10 @@ public class MyPageTicketService {
 				.orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_NOT_FOUND));
 
 		if (payment.getPaymentMethod() == PaymentMethod.BANK_TRANSFER) {
-			order.refundComplete(cancellationFee, refundedAmount);
+			order.refundComplete(cancellationFee, refundedAmount, now);
 			payment.refund();
 		} else {
-			order.cancelComplete(cancellationFee, refundedAmount);
+			order.cancelComplete(cancellationFee, refundedAmount, now);
 			payment.cancel();
 		}
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -111,29 +111,28 @@ public class Order extends BaseEntity {
 	}
 
 	public void cancel(Integer cancellationFee, Integer refundedAmount) {
-		this.status = OrderStatus.CANCEL_REQUESTED;
-		this.cancellationFee = cancellationFee;
-		this.refundedAmount = refundedAmount;
-		this.cancelledAt = Instant.now();
+		updateCancellationInfo(OrderStatus.CANCEL_REQUESTED, cancellationFee, refundedAmount, Instant.now());
 	}
 
 	/**
 	 * 토스페이/카카오페이 결제 취소 — 즉시 CANCELLED 처리
 	 */
-	public void cancelComplete(Integer cancellationFee, Integer refundedAmount) {
-		this.status = OrderStatus.CANCELLED;
-		this.cancellationFee = cancellationFee;
-		this.refundedAmount = refundedAmount;
-		this.cancelledAt = Instant.now();
+	public void cancelComplete(Integer cancellationFee, Integer refundedAmount, Instant cancelledAt) {
+		updateCancellationInfo(OrderStatus.CANCELLED, cancellationFee, refundedAmount, cancelledAt);
 	}
 
 	/**
 	 * 무통장 입금 환불 완료 — 즉시 REFUND_COMPLETED 처리
 	 */
-	public void refundComplete(Integer cancellationFee, Integer refundedAmount) {
-		this.status = OrderStatus.REFUND_COMPLETED;
+	public void refundComplete(Integer cancellationFee, Integer refundedAmount, Instant cancelledAt) {
+		updateCancellationInfo(OrderStatus.REFUND_COMPLETED, cancellationFee, refundedAmount, cancelledAt);
+	}
+
+	private void updateCancellationInfo(OrderStatus status, Integer cancellationFee, Integer refundedAmount,
+		Instant cancelledAt) {
+		this.status = status;
 		this.cancellationFee = cancellationFee;
 		this.refundedAmount = refundedAmount;
-		this.cancelledAt = Instant.now();
+		this.cancelledAt = cancelledAt;
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -116,4 +116,24 @@ public class Order extends BaseEntity {
 		this.refundedAmount = refundedAmount;
 		this.cancelledAt = Instant.now();
 	}
+
+	/**
+	 * 토스페이/카카오페이 결제 취소 — 즉시 CANCELLED 처리
+	 */
+	public void cancelComplete(Integer cancellationFee, Integer refundedAmount) {
+		this.status = OrderStatus.CANCELLED;
+		this.cancellationFee = cancellationFee;
+		this.refundedAmount = refundedAmount;
+		this.cancelledAt = Instant.now();
+	}
+
+	/**
+	 * 무통장 입금 환불 완료 — 즉시 REFUND_COMPLETED 처리
+	 */
+	public void refundComplete(Integer cancellationFee, Integer refundedAmount) {
+		this.status = OrderStatus.REFUND_COMPLETED;
+		this.cancellationFee = cancellationFee;
+		this.refundedAmount = refundedAmount;
+		this.cancelledAt = Instant.now();
+	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -47,6 +47,7 @@ import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
 import com.goormgb.be.ordercore.payment.entity.Payment;
 import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
 import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
 import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
 import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
@@ -574,6 +575,79 @@ class MyPageTicketServiceTest {
 
 			assertThat(response.cancellationFee()).isEqualTo(2000);
 			assertThat(response.refundedAmount()).isEqualTo(40000);
+		}
+
+		@Test
+		@DisplayName("토스페이 결제 취소 시 Order는 CANCELLED, Payment는 CANCELLED 상태가 된다")
+		void requestTicketCancel_tossPay_즉시_취소완료() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.TOSS_PAY).build();
+			payment.complete();
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+					.daysBeforeMatchMin(1).daysBeforeMatchMax(6)
+					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
+					.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
+
+			myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("카카오페이 결제 취소 시 Order는 CANCELLED, Payment는 CANCELLED 상태가 된다")
+		void requestTicketCancel_kakaoPay_즉시_취소완료() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.KAKAO_PAY).build();
+			payment.complete();
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+					.daysBeforeMatchMin(1).daysBeforeMatchMax(6)
+					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
+					.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
+
+			myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("무통장입금 취소 시 Order는 REFUND_COMPLETED, Payment는 REFUNDED 상태가 된다")
+		void requestTicketCancel_bankTransfer_즉시_환불완료() {
+			Long userId = 1L;
+			Long ticketId = 101L;
+			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.BANK_TRANSFER).build();
+			payment.complete();
+			CancellationFeePolicy policy = CancellationFeePolicy.builder()
+					.daysBeforeMatchMin(1).daysBeforeMatchMax(6)
+					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
+					.build();
+
+			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
+			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
+			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
+
+			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
+
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_COMPLETED);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+			assertThat(response.status()).isEqualTo(OrderStatus.REFUND_COMPLETED);
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -578,7 +578,7 @@ class MyPageTicketServiceTest {
 		}
 
 		@Test
-		@DisplayName("토스페이 결제 취소 시 Order는 CANCELLED, Payment는 CANCELLED 상태가 된다")
+		@DisplayName("토스페이 결제 취소 시 Order는 CANCELLED, Payment는 CANCELLED, cancelledAt은 Clock 기반 시간이다")
 		void requestTicketCancel_tossPay_즉시_취소완료() {
 			Long userId = 1L;
 			Long ticketId = 101L;
@@ -599,6 +599,7 @@ class MyPageTicketServiceTest {
 
 			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+			assertThat(order.getCancelledAt()).isEqualTo(Instant.now(clock));
 		}
 
 		@Test
@@ -623,6 +624,7 @@ class MyPageTicketServiceTest {
 
 			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELLED);
+			assertThat(order.getCancelledAt()).isEqualTo(Instant.now(clock));
 		}
 
 		@Test
@@ -647,6 +649,7 @@ class MyPageTicketServiceTest {
 
 			assertThat(order.getStatus()).isEqualTo(OrderStatus.REFUND_COMPLETED);
 			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+			assertThat(order.getCancelledAt()).isEqualTo(Instant.now(clock));
 			assertThat(response.status()).isEqualTo(OrderStatus.REFUND_COMPLETED);
 		}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -45,6 +45,9 @@ import com.goormgb.be.ordercore.order.event.OrderEventPublisher;
 import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
+import com.goormgb.be.ordercore.payment.entity.Payment;
+import com.goormgb.be.ordercore.payment.enums.PaymentMethod;
+import com.goormgb.be.ordercore.payment.repository.PaymentRepository;
 import com.goormgb.be.ordercore.qrtoken.entity.QrToken;
 import com.goormgb.be.ordercore.qrtoken.repository.QrTokenRepository;
 import com.goormgb.be.user.entity.User;
@@ -64,6 +67,8 @@ class MyPageTicketServiceTest {
 	@Mock
 	private QrTokenRepository qrTokenRepository;
 	@Mock
+	private PaymentRepository paymentRepository;
+	@Mock
 	private OrderEventPublisher orderEventPublisher;
 
 	private MyPageTicketService myPageService;
@@ -76,6 +81,7 @@ class MyPageTicketServiceTest {
 				orderRepository,
 				orderSeatRepository,
 				qrTokenRepository,
+				paymentRepository,
 				myPageQueryService,
 				cancellationFeePolicyRepository,
 				orderEventPublisher,
@@ -485,11 +491,12 @@ class MyPageTicketServiceTest {
 		}
 
 		@Test
-		@DisplayName("D-1~D-6 정책이면 취소수수료는 bookingFee + 티켓금액 10% 이다")
+		@DisplayName("D-1~D-6 정책이면 취소수수료는 bookingFee + 티켓금액 10% 이다 (토스페이)")
 		void requestTicketCancel_d1to6_성공() {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.TOSS_PAY).build();
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 					.daysBeforeMatchMin(1)
 					.daysBeforeMatchMax(6)
@@ -499,17 +506,18 @@ class MyPageTicketServiceTest {
 					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
 			MyPageTicketCancelResponse response = myPageService.requestTicketCancel(userId, ticketId);
 
 			assertThat(response.ticketId()).isEqualTo(ticketId);
-			assertThat(response.status()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+			assertThat(response.status()).isEqualTo(OrderStatus.CANCELLED);
 			assertThat(response.totalAmount()).isEqualTo(42000);
 			assertThat(response.cancellationFee()).isEqualTo(6000);
 			assertThat(response.refundedAmount()).isEqualTo(36000);
-			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 			assertThat(order.getCancellationFee()).isEqualTo(6000);
 			assertThat(order.getRefundedAmount()).isEqualTo(36000);
 		}
@@ -520,6 +528,7 @@ class MyPageTicketServiceTest {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(10, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.TOSS_PAY).build();
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 					.daysBeforeMatchMin(7)
 					.daysBeforeMatchMax(null)
@@ -529,6 +538,7 @@ class MyPageTicketServiceTest {
 					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
@@ -545,6 +555,7 @@ class MyPageTicketServiceTest {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(10, ChronoUnit.DAYS));
 			ReflectionTestUtils.setField(order, "createdAt", Instant.now(clock).minus(1, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.TOSS_PAY).build();
 
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 					.daysBeforeMatchMin(7)
@@ -555,6 +566,7 @@ class MyPageTicketServiceTest {
 					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
 
@@ -615,6 +627,7 @@ class MyPageTicketServiceTest {
 			Long userId = 1L;
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, userId, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
+			Payment payment = Payment.builder().order(order).paymentMethod(PaymentMethod.TOSS_PAY).build();
 			List<Long> matchSeatIds = List.of(101L, 102L);
 			CancellationFeePolicy policy = CancellationFeePolicy.builder()
 					.daysBeforeMatchMin(1)
@@ -625,6 +638,7 @@ class MyPageTicketServiceTest {
 					.build();
 
 			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(matchSeatIds);
 


### PR DESCRIPTION
## 🔧 작업 내용
- 예매 내역(/mypage/tickets) BOOKED 탭에서 UNDER_REVIEW(정밀 확인 중) 상태 주문이 누락되던 문제 수정
- 경기 예정 티켓 Summary 카운트(upcomingCount)에 UNDER_REVIEW 미반영 문제 수정
- 티켓 취소 요청 시 중간 상태(CANCEL_REQUESTED)에서 멈추지 않고, 결제 수단에 따라 즉시 완료 상태로 전환되도록 개선
  - 토스페이 / 카카오페이 → CANCELLED(취소 완료)
  - 무통장 입금 → REFUND_COMPLETED(환불 완료)

##  🧩 구현 상세
- TicketTab.BOOKED에 UNDER_REVIEW 추가하여 예매 내역에서 정밀 확인 중 주문 정상 조회
- UPCOMING_STATUSES에 UNDER_REVIEW 추가하여 Summary 카운트 정확도 보정
- Order 엔티티에 cancelComplete(), refundComplete() 메서드 추가
  - 기존 cancel() 메서드(→ CANCEL_REQUESTED)는 하위 호환을 위해 유지
- requestTicketCancel()에서 PaymentRepository로 결제 정보 조회 후 PaymentMethod 기준 분기 처리
  - BANK_TRANSFER → order.refundComplete() + payment.refund()
  - 그 외(TOSS_PAY, KAKAO_PAY) → order.cancelComplete() + payment.cancel()

### 📌 관련 Jira Issue
- GRGB-355

##  🧪 테스트 방법
- GET /mypage/tickets?tab=BOOKED → UNDER_REVIEW 상태 주문 포함 확인
- GET /mypage/tickets/upcoming → Summary upcomingCount에 UNDER_REVIEW 반영 확인
- POST /mypage/tickets/{id}/cancel
  - 토스페이/카카오페이 결제 주문 → Order CANCELLED, Payment CANCELLED 확인
  - 무통장입금 결제 주문 → Order REFUND_COMPLETED, Payment REFUNDED 확인
- GET /mypage/tickets?tab=CANCEL_REFUND → 취소/환불 완료 주문 즉시 노출 확인
<img width="1255" height="631" alt="스크린샷 2026-04-09 오후 5 30 31" src="https://github.com/user-attachments/assets/e86fccf0-8bce-42b6-b604-9cc68d4b35b1" />
