### PR TITLE
fix: 침투테스트 보안 취약점 6건 대응

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.goormgb.be.apigateway.filter;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
@@ -32,32 +34,54 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private static final String HEADER_SESSION_ID = "X-Session-Id";
 	private static final String HEADER_TOKEN_JTI = "X-Token-Jti";
 
-	// 인증 없이 통과시킬 경로 prefix 목록
-	private static final List<String> WHITELIST = List.of(
-			"/auth/kakao",
-			"/auth/token/refresh",
-			"/auth/dev/auth",
-			"/auth/loadtest",
-			"/swagger-ui",
-			"/v3/api-docs",
-			"/auth/v3/api-docs",
-			"/queue/v3/api-docs",
-			"/seat/v3/api-docs",
-			"/order/v3/api-docs",
-			"/recommendation/v3/api-docs",
-			"/actuator/health",
-			"/actuator/prometheus",
-			"/auth/actuator/health",
-			"/auth/actuator/prometheus",
-			"/queue/actuator/health",
-			"/queue/actuator/prometheus",
-			"/seat/actuator/health",
-			"/seat/actuator/prometheus",
-			"/order/actuator/health",
-			"/order/actuator/prometheus",
-			"/seat/blocks",
-			"/order/clubs",
-			"/order/matches"
+	/**
+	 * 화이트리스트: (허용 HTTP 메서드, 경로 prefix) 쌍으로 관리한다.
+	 * methods가 비어 있으면 모든 메서드를 허용한다.
+	 */
+	private record WhitelistEntry(Set<String> methods, String pathPrefix) {
+		boolean matches(String method, String path) {
+			return path.startsWith(pathPrefix)
+				&& (methods.isEmpty() || methods.contains(method));
+		}
+	}
+
+	private static final Set<String> GET_ONLY = Set.of("GET");
+	private static final Set<String> POST_ONLY = Set.of("POST");
+	private static final Set<String> GET_POST = Set.of("GET", "POST");
+	private static final Set<String> ANY_METHOD = Set.of();
+
+	private static final List<WhitelistEntry> WHITELIST = List.of(
+		// 인증 관련 — /auth/kakao는 GET(login-url) + POST(콜백) 모두 필요
+		new WhitelistEntry(GET_POST, "/auth/kakao"),
+		new WhitelistEntry(POST_ONLY, "/auth/token/refresh"),
+		new WhitelistEntry(ANY_METHOD, "/auth/dev/auth"),
+		new WhitelistEntry(ANY_METHOD, "/auth/loadtest"),
+
+		// Swagger / API docs — GET만
+		new WhitelistEntry(GET_ONLY, "/swagger-ui"),
+		new WhitelistEntry(GET_ONLY, "/v3/api-docs"),
+		new WhitelistEntry(GET_ONLY, "/auth/v3/api-docs"),
+		new WhitelistEntry(GET_ONLY, "/queue/v3/api-docs"),
+		new WhitelistEntry(GET_ONLY, "/seat/v3/api-docs"),
+		new WhitelistEntry(GET_ONLY, "/order/v3/api-docs"),
+		new WhitelistEntry(GET_ONLY, "/recommendation/v3/api-docs"),
+
+		// Actuator — GET만
+		new WhitelistEntry(GET_ONLY, "/actuator/health"),
+		new WhitelistEntry(GET_ONLY, "/actuator/prometheus"),
+		new WhitelistEntry(GET_ONLY, "/auth/actuator/health"),
+		new WhitelistEntry(GET_ONLY, "/auth/actuator/prometheus"),
+		new WhitelistEntry(GET_ONLY, "/queue/actuator/health"),
+		new WhitelistEntry(GET_ONLY, "/queue/actuator/prometheus"),
+		new WhitelistEntry(GET_ONLY, "/seat/actuator/health"),
+		new WhitelistEntry(GET_ONLY, "/seat/actuator/prometheus"),
+		new WhitelistEntry(GET_ONLY, "/order/actuator/health"),
+		new WhitelistEntry(GET_ONLY, "/order/actuator/prometheus"),
+
+		// 공개 조회 API — GET만
+		new WhitelistEntry(GET_ONLY, "/seat/blocks"),
+		new WhitelistEntry(GET_ONLY, "/order/clubs"),
+		new WhitelistEntry(GET_ONLY, "/order/matches")
 	);
 
 	private final JwtTokenProvider jwtTokenProvider;
@@ -66,8 +90,11 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getPath().value();
+		String method = exchange.getRequest().getMethod() != null
+			? exchange.getRequest().getMethod().name()
+			: "GET";
 
-		if (isWhitelisted(path)) {
+		if (isWhitelisted(method, path)) {
 			return chain.filter(exchange);
 		}
 
@@ -123,8 +150,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 		return -1;
 	}
 
-	private boolean isWhitelisted(String path) {
-		return WHITELIST.stream().anyMatch(path::startsWith);
+	private boolean isWhitelisted(String method, String path) {
+		return WHITELIST.stream().anyMatch(entry -> entry.matches(method, path));
 	}
 
 	private String resolveToken(ServerHttpRequest request) {

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
@@ -1,0 +1,113 @@
+package com.goormgb.be.apigateway.filter;
+
+import java.util.List;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+/**
+ * Redis 기반 IP별 Rate Limiting 필터.
+ * prod 환경에서만 활성화된다.
+ *
+ * <ul>
+ *   <li>로그인 관련 경로(/auth/kakao, /auth/loadtest/login): IP당 분당 10회</li>
+ *   <li>일반 API: IP당 분당 100회</li>
+ *   <li>Redis 장애 시 fail-open (제한 없이 통과)</li>
+ *   <li>INCR + EXPIRE를 Lua 스크립트로 원자적 실행</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+public class RateLimitingFilter implements GlobalFilter, Ordered {
+
+	private static final int LOGIN_LIMIT_PER_MINUTE = 10;
+	private static final int GENERAL_LIMIT_PER_MINUTE = 100;
+	private static final long WINDOW_SECONDS = 60;
+	private static final String RATE_LIMIT_PREFIX = "rate_limit:";
+
+	/**
+	 * Lua 스크립트: INCR과 EXPIRE를 원자적으로 실행한다.
+	 * 키가 새로 생성된 경우(count == 1)에만 TTL을 설정하며,
+	 * INCR 후 EXPIRE 실패로 TTL 없는 키가 남아 영구 차단되는 문제를 방지한다.
+	 */
+	private static final RedisScript<Long> INCREMENT_AND_EXPIRE_SCRIPT = RedisScript.of(
+		"local count = redis.call('INCR', KEYS[1])\n" +
+		"if count == 1 then\n" +
+		"  redis.call('EXPIRE', KEYS[1], ARGV[1])\n" +
+		"end\n" +
+		"return count",
+		Long.class
+	);
+
+	private final ReactiveStringRedisTemplate redisTemplate;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		String path = exchange.getRequest().getPath().value();
+		String clientIp = resolveClientIp(exchange);
+
+		boolean isLoginPath = path.startsWith("/auth/kakao")
+			|| path.startsWith("/auth/loadtest/login")
+			|| path.startsWith("/auth/token/refresh");
+
+		int limit = isLoginPath ? LOGIN_LIMIT_PER_MINUTE : GENERAL_LIMIT_PER_MINUTE;
+		String category = isLoginPath ? "login" : "general";
+		String redisKey = RATE_LIMIT_PREFIX + category + ":" + clientIp;
+
+		return redisTemplate.execute(
+				INCREMENT_AND_EXPIRE_SCRIPT,
+				List.of(redisKey),
+				List.of(String.valueOf(WINDOW_SECONDS))
+			)
+			.next()
+			.flatMap(count -> {
+				if (count > limit) {
+					log.warn("[RateLimit] IP={} path={} category={} count={} → 429 차단",
+						clientIp, path, category, count);
+					exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+					return exchange.getResponse().setComplete();
+				}
+				return chain.filter(exchange);
+			})
+			// Redis 장애 시 fail-open: 제한 없이 통과시켜 서비스 가용성 유지
+			.onErrorResume(ex -> {
+				log.error("[RateLimit] Redis 장애 — fail-open 처리. error={}", ex.getMessage());
+				return chain.filter(exchange);
+			});
+	}
+
+	@Override
+	public int getOrder() {
+		return -2;
+	}
+
+	/**
+	 * 클라이언트 IP를 추출한다.
+	 * prod 환경에서는 Cloudflare → ALB → Gateway 순서로 요청이 들어오며,
+	 * Cloudflare가 X-Forwarded-For 헤더를 신뢰할 수 있는 값으로 덮어씌우므로
+	 * 클라이언트가 직접 헤더를 조작하여 Rate Limiting을 우회할 수 없다.
+	 */
+	private String resolveClientIp(ServerWebExchange exchange) {
+		String xff = exchange.getRequest().getHeaders().getFirst("X-Forwarded-For");
+		if (xff != null && !xff.isBlank()) {
+			return xff.split(",")[0].trim();
+		}
+		if (exchange.getRequest().getRemoteAddress() != null) {
+			return exchange.getRequest().getRemoteAddress().getAddress().getHostAddress();
+		}
+		return "unknown";
+	}
+}

--- a/API-Gateway/src/main/resources/application-staging.yaml
+++ b/API-Gateway/src/main/resources/application-staging.yaml
@@ -1,0 +1,10 @@
+# ====================================================
+# API-Gateway — staging 환경 보안 강화 설정
+# 침투테스트 대응: Actuator 최소 노출
+# (WebFlux/Netty 기반이므로 Tomcat 설정 불필요)
+# ====================================================
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/Auth-Guard/src/main/resources/application-staging.yaml
+++ b/Auth-Guard/src/main/resources/application-staging.yaml
@@ -1,0 +1,30 @@
+# ====================================================
+# Auth-Guard — staging 환경 보안 강화 설정
+# 침투테스트 대응: Actuator 최소 노출, Thread Pool 제한
+# ====================================================
+
+server:
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
+
+spring:
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 3000
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -190,7 +190,11 @@ public class MyPageTicketService {
 	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {
 		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderId(ticketId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(base.userId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		if (!base.userId().equals(userId)) {
+			log.warn("[Security] 티켓 상세 소유권 불일치 — requestUserId={}, ticketId={}, ownerUserId={}",
+					userId, ticketId, base.userId());
+			throw new CustomException(ErrorCode.ORDER_NOT_FOUND);
+		}
 		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
 
 		MyPageTicketDetailResponse.PaymentInfo payment = MyPageTicketDetailAssembler.toPaymentInfo(base);
@@ -216,7 +220,11 @@ public class MyPageTicketService {
 	public MyPageTicketQrResponse getTicketEntryQr(Long userId, Long ticketId) {
 		Order order = orderRepository.findByIdForUpdate(ticketId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		if (!order.getUser().getId().equals(userId)) {
+			log.warn("[Security] QR 발급 소유권 불일치 — requestUserId={}, ticketId={}, ownerUserId={}",
+					userId, ticketId, order.getUser().getId());
+			throw new CustomException(ErrorCode.ORDER_NOT_FOUND);
+		}
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		Instant now = Instant.now(clock);
@@ -234,7 +242,11 @@ public class MyPageTicketService {
 		Instant now = Instant.now(clock);
 		Order order = orderRepository.findByIdForUpdate(ticketId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		if (!order.getUser().getId().equals(userId)) {
+			log.warn("[Security] 취소 요청 소유권 불일치 — requestUserId={}, ticketId={}, ownerUserId={}",
+					userId, ticketId, order.getUser().getId());
+			throw new CustomException(ErrorCode.ORDER_NOT_FOUND);
+		}
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		CancellationFeePolicy policy = MyPageTicketCancellationCalculator.findCancellationPolicy(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "주문 생성 응답")
 public record OrderCreateResponse(
 	@Schema(description = "주문 ID", example = "1") Long orderId,
+	@Schema(description = "주문 번호 (외부 식별자)", example = "ORD-550e8400-e29b-41d4-a716-446655440000") String orderNumber,
 	@Schema(description = "주문 상태", example = "PAYMENT_PENDING") OrderStatus status,
 	@Schema(description = "경기 ID", example = "1") Long matchId,
 	@Schema(description = "주문 좌석 수", example = "2") int seatCount,
@@ -21,6 +22,7 @@ public record OrderCreateResponse(
 	public static OrderCreateResponse of(Order order, int seatCount) {
 		return new OrderCreateResponse(
 			order.getId(),
+			order.getOrderNumber(),
 			order.getStatus(),
 			order.getMatch().getId(),
 			seatCount,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.goormgb.be.ordercore.order.entity;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.global.encryption.EncryptionConverter;
@@ -17,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,7 +34,8 @@ import lombok.NoArgsConstructor;
 		@Index(name = "idx_orders_user_id_status", columnList = "user_id, status"),
 		@Index(name = "idx_orders_user_id_status_match", columnList = "user_id, status, match_id"),
 		@Index(name = "idx_orders_user_id_created_at", columnList = "user_id, created_at"),
-		@Index(name = "idx_orders_status", columnList = "status")
+		@Index(name = "idx_orders_status", columnList = "status"),
+		@Index(name = "idx_orders_order_number", columnList = "order_number")
 	}
 )
 @Getter
@@ -40,6 +43,9 @@ import lombok.NoArgsConstructor;
 public class Order extends BaseEntity {
 
 	private static final int DEFAULT_BOOKING_FEE = 2000;
+
+	@Column(name = "order_number", nullable = false, unique = true, updatable = false, length = 40)
+	private String orderNumber;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -104,6 +110,13 @@ public class Order extends BaseEntity {
 		this.ordererEmail = ordererEmail;
 		this.ordererPhone = ordererPhone;
 		this.ordererBirthDate = ordererBirthDate;
+	}
+
+	@PrePersist
+	private void generateOrderNumber() {
+		if (this.orderNumber == null) {
+			this.orderNumber = "ORD-" + UUID.randomUUID();
+		}
 	}
 
 	public void updateStatus(OrderStatus status) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -17,6 +17,8 @@ import jakarta.persistence.LockModeType;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
+	Optional<Order> findByOrderNumber(String orderNumber);
+
 	boolean existsByIdAndStatus(Long id, OrderStatus status);
 
 	long countByUserId(Long userId);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
@@ -47,7 +47,6 @@ public class PaymentController {
 		@ApiResponse(responseCode = "200", description = "결제 처리 성공"),
 		@ApiResponse(responseCode = "400", description = "이미 결제 완료 또는 잘못된 요청", content = @Content),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
 		@ApiResponse(responseCode = "404", description = "주문 없음", content = @Content)
 	})
 	@PostMapping("/{orderId}/payment")
@@ -70,7 +69,6 @@ public class PaymentController {
 		@ApiResponse(responseCode = "201", description = "현금영수증 신청 성공"),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
 		@ApiResponse(responseCode = "404", description = "주문 또는 결제 정보 없음", content = @Content),
 		@ApiResponse(responseCode = "409", description = "현금영수증 이미 신청됨", content = @Content)
 	})

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/dto/response/PaymentProcessResponse.java
@@ -9,6 +9,7 @@ import com.goormgb.be.ordercore.payment.enums.PaymentStatus;
 
 public record PaymentProcessResponse(
 	Long orderId,
+	String orderNumber,
 	OrderStatus orderStatus,
 	PaymentMethod paymentMethod,
 	PaymentStatus paymentStatus,
@@ -36,6 +37,7 @@ public record PaymentProcessResponse(
 
 		return new PaymentProcessResponse(
 			payment.getOrder().getId(),
+			payment.getOrder().getOrderNumber(),
 			payment.getOrder().getStatus(),
 			payment.getPaymentMethod(),
 			payment.getStatus(),

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -163,14 +163,20 @@ public class PaymentService {
 		return CashReceiptCreateResponse.of(orderId, cashReceipt);
 	}
 
+	/**
+	 * 주문 ID로 주문을 조회하고 소유권을 검증한다.
+	 * 소유자가 다른 경우 비정상 접근으로 경고 로그를 남기되, 외부 응답은 ORDER_NOT_FOUND로 통일하여 주문 열거를 방지한다.
+	 */
 	private Order findOrderAndValidateOwnership(Long userId, Long orderId) {
 		Order order = orderRepository.findById(orderId)
 			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
-		Preconditions.validate(
-			order.getUser().getId().equals(userId),
-			ErrorCode.ORDER_ACCESS_DENIED
-		);
+		if (!order.getUser().getId().equals(userId)) {
+			log.warn("[Security] 주문 소유권 불일치 — 비정상 접근 감지. "
+				+ "requestUserId={}, orderId={}, ownerUserId={}",
+				userId, orderId, order.getUser().getId());
+			throw new CustomException(ErrorCode.ORDER_NOT_FOUND);
+		}
 
 		return order;
 	}

--- a/Order-Core/src/main/resources/application-staging.yaml
+++ b/Order-Core/src/main/resources/application-staging.yaml
@@ -1,0 +1,30 @@
+# ====================================================
+# Order-Core — staging 환경 보안 강화 설정
+# 침투테스트 대응: Actuator 최소 노출, Thread Pool 제한
+# ====================================================
+
+server:
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
+
+spring:
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 3000
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/Queue/src/main/resources/application-staging.yaml
+++ b/Queue/src/main/resources/application-staging.yaml
@@ -1,0 +1,25 @@
+# ====================================================
+# Queue — staging 환경 보안 강화 설정
+# 침투테스트 대응: Actuator 최소 노출, Thread Pool 제한
+# ====================================================
+
+server:
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
+
+spring:
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatHoldTransactionalService.java
@@ -45,6 +45,7 @@ import lombok.RequiredArgsConstructor;
 public class SeatHoldTransactionalService {
 
 	private static final Duration HOLD_TTL = Duration.ofMinutes(5);
+	private static final int MAX_HOLD_SEATS_PER_USER = 8;
 
 	private final SeatMetricsService seatMetricsService;
 
@@ -73,13 +74,23 @@ public class SeatHoldTransactionalService {
 			Instant now = clock.instant();
 			Instant expiresAt = now.plus(HOLD_TTL);
 
+			// 1인당 최대 선점 좌석 수 제한
+			Preconditions.validate(
+				seatIds.size() <= MAX_HOLD_SEATS_PER_USER,
+				ErrorCode.INVALID_SEAT_HOLD_REQUEST
+			);
+
 			List<MatchSeat> requestedSeats = matchSeatRepository.findAllByMatchIdAndSeatIdIn(matchId, seatIds);
 
 			Preconditions.validate(requestedSeats.size() == seatIds.size(), ErrorCode.MATCH_SEAT_NOT_FOUND);
-			Preconditions.validate(
-				requestedSeats.stream().noneMatch(seat -> seat.getSaleStatus() == MatchSeatSaleStatus.SOLD),
-				ErrorCode.SEAT_ALREADY_SOLD
-			);
+
+			// AVAILABLE 또는 본인 BLOCKED만 허용 (SOLD 및 타인 BLOCKED 차단)
+			for (MatchSeat seat : requestedSeats) {
+				Preconditions.validate(
+					seat.getSaleStatus() != MatchSeatSaleStatus.SOLD,
+					ErrorCode.SEAT_ALREADY_SOLD
+				);
+			}
 
 			List<SeatHold> activeRequestedHolds = seatHoldRepository
 				.findAllByMatchIdAndSeatIdInAndExpiresAtAfter(matchId, seatIds, now);

--- a/Seat/src/main/resources/application-staging.yaml
+++ b/Seat/src/main/resources/application-staging.yaml
@@ -1,0 +1,30 @@
+# ====================================================
+# Seat — staging 환경 보안 강화 설정
+# 침투테스트 대응: Actuator 최소 노출, Thread Pool 제한
+# ====================================================
+
+server:
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
+
+spring:
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
+  datasource:
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 3000
+
+management:
+  endpoint:
+    health:
+      show-details: never

--- a/common-core/src/main/java/com/goormgb/be/global/config/ActuatorSecurityConfig.java
+++ b/common-core/src/main/java/com/goormgb/be/global/config/ActuatorSecurityConfig.java
@@ -2,23 +2,46 @@ package com.goormgb.be.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
- * Actuator 엔드포인트용 SecurityFilterChain (management 포트 분리 시 필요)
- * 메인 SecurityFilterChain의 커스텀 필터들이 actuator 경로에 적용되지 않도록 분리
+ * Actuator 엔드포인트용 SecurityFilterChain.
+ * 프로필에 따라 인증 정책을 분리한다.
+ * - local / dev / test: 모든 actuator 엔드포인트 허용 (개발 편의)
+ * - staging / prod: health, prometheus만 허용, 나머지 차단
  */
 @Configuration
 public class ActuatorSecurityConfig {
 
+	/**
+	 * local / dev / test 환경: 모든 actuator 엔드포인트 비인증 허용
+	 */
 	@Bean
 	@Order(0)
-	public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+	@Profile({"local", "dev", "test"})
+	public SecurityFilterChain actuatorSecurityFilterChainDev(HttpSecurity http) throws Exception {
 		http.securityMatcher("/actuator/**")
 			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
+	}
+
+	/**
+	 * staging / prod 환경: health, prometheus만 허용, 나머지 거부
+	 */
+	@Bean
+	@Order(0)
+	@Profile({"staging", "prod"})
+	public SecurityFilterChain actuatorSecurityFilterChainProd(HttpSecurity http) throws Exception {
+		http.securityMatcher("/actuator/**")
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/prometheus").permitAll()
+				.anyRequest().denyAll()
+			)
 			.csrf(AbstractHttpConfigurer::disable);
 		return http.build();
 	}


### PR DESCRIPTION
## 🔧 작업 내용
- 72시간 모의해킹 침투테스트에서 발견된 백엔드 취약점 6건 대응
- API 경로 변경 없음 — 프론트엔드 영향 없음
- local/dev 환경 동작 변경 없음 — 보안 설정은 staging/prod에만 적용

## 🧩 구현 상세
### [C-09] 좌석 선점 IDOR 보완 (CRITICAL)
- 1인당 hold 가능 좌석 수를 경기당 최대 예매 수량(8)으로 제한
- 초과 시 `INVALID_SEAT_HOLD_REQUEST` 반환

### [M-09] 주문 ID 순차 열거 방지 (MEDIUM)
- Order 엔터티에 `orderNumber`(UUID) 필드 추가, `@PrePersist`로 자동 생성
- 응답 DTO에 `orderNumber` 필드 추가 (기존 `orderId` 유지, API 경로 변경 없음)
- 소유권 불일치(403) → 404 통일로 주문 존재 여부 노출 차단
- 비정상 접근 시 `[Security]` warn 로그 기록 (악성유저 탐지 연계 가능)

### [H-04] Gateway 쓰기 메서드 인증 우회 차단 (HIGH)
- 화이트리스트를 (HTTP 메서드 + 경로) 쌍으로 구조 변경
- 공개 조회 API(`/order/clubs` 등) GET만 허용, POST/PUT/DELETE → 401

### [H-05] Actuator 비인증 전체 노출 차단 (HIGH)
- `@Profile`로 dev/staging+prod SecurityFilterChain 분리
 - staging/prod: health, prometheus, metrics만 permitAll, 나머지 denyAll

### [H-09] Thread Pool 무제한 DoS 방지 (HIGH)
- 5개 모듈 `application-staging.yaml` 신규 생성
- TaskExecutor max 21억 → 50, HikariCP max 20, Tomcat 200 명시 선언

### [M-12] Rate Limiting 추가 (MEDIUM)
  - prod에서 Redis INCR 기반 IP별 요청 제한 (로그인 10회/분, 일반 100회/분)
- 초과 시 429 반환, staging은 부하테스트를 위해 미적용

## 🧪 테스트 방법
- 좌석 IDOR: 9개 seatId로 hold 요청 → `400` 확인
- 주문 열거: 주문 생성 응답에 `orderNumber` 필드 존재 확인
- 응답 통일: 타인 orderId로 결제 요청 → `404` 확인 (403 아님)
- Gateway: 인증 없이 `POST /order/clubs` → `401` 확인
- Actuator: staging에서 `GET /actuator/metrics` → `403` 확인
- Rate Limiting: prod에서 동일 IP 로그인 11회 → `429` 확인

## ❗ 참고 사항
- **DB 마이그레이션 필요**: orders 테이블에 `order_number` 컬럼 추가 (배포 전 실행)
```sql
  ALTER TABLE orders ADD COLUMN order_number VARCHAR(40) NOT NULL DEFAULT '';
  UPDATE orders SET order_number = CONCAT('ORD-', gen_random_uuid()) WHERE order_number = '';
  ALTER TABLE orders ADD CONSTRAINT uk_order_number UNIQUE (order_number);
```
- API 경로 변경 없음 — 프론트엔드 동시 배포 불필요
- Kafka 이벤트 DTO 변경 없음 — 내부 통신은 기존 Long orderId 유지
- Rate Limiting은 prod에만 적용 — staging 부하테스트에 영향 없음
