### PR TITLE
hotfix(seat): prequeue Redis 환경변수명 REDIS_QUEUE_HOST/PORT로 변경

### DIFF
--- a/Seat/src/main/resources/application-dev.yaml
+++ b/Seat/src/main/resources/application-dev.yaml
@@ -50,8 +50,8 @@ booking:
 
 prequeue:
   redis:
-    host: ${QUEUE_REDIS_HOST:${REDIS_HOST}}
-    port: ${QUEUE_REDIS_PORT:${REDIS_PORT}}
+    host: ${REDIS_QUEUE_HOST}
+    port: ${REDIS_QUEUE_PORT}
   booking-option-key-prefix: queue:precheck:booking-option
   booking-option-ttl-seconds: ${booking.options-ttl-seconds}
 

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -50,8 +50,8 @@ booking:
 
 prequeue:
   redis:
-    host: ${QUEUE_REDIS_HOST:${REDIS_HOST}}
-    port: ${QUEUE_REDIS_PORT:${REDIS_PORT}}
+    host: ${REDIS_QUEUE_HOST}
+    port: ${REDIS_QUEUE_PORT}
   booking-option-key-prefix: queue:precheck:booking-option
   booking-option-ttl-seconds: ${booking.options-ttl-seconds}
 


### PR DESCRIPTION
## 🔧 작업 내용

배포 설정에 맞추어 변수 변경