### PR TITLE
refactor(order-core, seat): 크로스 모듈 DB 결합 제거 및 비정규화 전환 (DB 스키마 분리 Phase 1) [GRGB-356]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailDataQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailDataQueryService.java
@@ -11,15 +11,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.kafka.event.OrderCancelledEvent;
 import com.goormgb.be.kafka.event.PaymentCompletedEvent;
 import com.goormgb.be.ordercore.email.dto.SeatDisplayInfo;
@@ -42,7 +37,6 @@ public class EmailDataQueryService {
 	private final OrderRepository orderRepository;
 	private final OrderSeatRepository orderSeatRepository;
 	private final PaymentRepository paymentRepository;
-	private final NamedParameterJdbcTemplate jdbcTemplate;
 
 	private static final String TICKET_URL = "https://dev.goormgb.space/my/tickets";
 
@@ -63,12 +57,11 @@ public class EmailDataQueryService {
 
 	@Transactional(readOnly = true)
 	public Optional<Map<String, Object>> buildPaymentEmailContext(Long orderId, PaymentCompletedEvent event) {
-		Order order = orderRepository.findByIdWithMatchDetails(orderId).orElse(null);
+		Order order = orderRepository.findById(orderId).orElse(null);
 		if (order == null) {
 			return Optional.empty();
 		}
 
-		Match match = order.getMatch();
 		List<OrderSeat> orderSeats = orderSeatRepository.findByOrderId(orderId);
 		Payment payment = paymentRepository.findByOrderId(orderId).orElse(null);
 		List<SeatDisplayInfo> seats = buildSeatDisplayInfos(orderSeats);
@@ -76,13 +69,13 @@ public class EmailDataQueryService {
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put("ordererName", order.getOrdererName());
 		ctx.put("ordererEmail", order.getOrdererEmail());
-		ctx.put("toEmail", order.getUser().getEmail());
+		ctx.put("toEmail", order.getOrdererEmail());
 		ctx.put("orderId", order.getId());
 
-		ctx.put("matchTitle", match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName());
-		ctx.put("matchDateTime", formatInstant(match.getMatchAt()));
-		ctx.put("stadiumName", match.getStadium().getKoName());
-		ctx.put("stadiumAddress", match.getStadium().getAddress());
+		ctx.put("matchTitle", order.getMatchTitle());
+		ctx.put("matchDateTime", formatInstant(order.getMatchDate()));
+		ctx.put("stadiumName", order.getStadiumName());
+		ctx.put("stadiumAddress", "");
 
 		ctx.put("seats", seats);
 
@@ -99,7 +92,7 @@ public class EmailDataQueryService {
 		int seatTotal = orderSeats.stream().mapToInt(OrderSeat::getPrice).sum();
 		ctx.put("seatTotal", seatTotal);
 
-		ctx.put("cancelDeadline", formatInstant(match.getMatchAt()));
+		ctx.put("cancelDeadline", formatInstant(order.getMatchDate()));
 
 		ctx.put("ticketUrl", TICKET_URL);
 		return Optional.of(ctx);
@@ -107,12 +100,11 @@ public class EmailDataQueryService {
 
 	@Transactional(readOnly = true)
 	public Optional<Map<String, Object>> buildBookingEmailContext(Long orderId) {
-		Order order = orderRepository.findByIdWithMatchDetails(orderId).orElse(null);
+		Order order = orderRepository.findById(orderId).orElse(null);
 		if (order == null) {
 			return Optional.empty();
 		}
 
-		Match match = order.getMatch();
 		List<OrderSeat> orderSeats = orderSeatRepository.findByOrderId(orderId);
 		List<SeatDisplayInfo> seats = buildSeatDisplayInfos(orderSeats);
 
@@ -122,18 +114,17 @@ public class EmailDataQueryService {
 		ctx.put("toEmail", order.getOrdererEmail());
 		ctx.put("orderId", order.getId());
 
-		ctx.put("matchTitle", match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName());
-		ctx.put("matchDateTime", formatInstant(match.getMatchAt()));
-		ctx.put("stadiumName", match.getStadium().getKoName());
-		ctx.put("stadiumAddress", match.getStadium().getAddress());
+		ctx.put("matchTitle", order.getMatchTitle());
+		ctx.put("matchDateTime", formatInstant(order.getMatchDate()));
+		ctx.put("stadiumName", order.getStadiumName());
+		ctx.put("stadiumAddress", "");
 
 		ctx.put("seats", seats);
 
 		ctx.put("totalAmount", order.getTotalAmount());
 		ctx.put("bookingFee", order.getBookingFee() != null ? order.getBookingFee() : 0);
-		ctx.put("cancelDeadline", formatInstant(match.getMatchAt()));
+		ctx.put("cancelDeadline", formatInstant(order.getMatchDate()));
 
-		// 입금 기한: 주문일 + 1일 23:59 (KST)
 		Instant createdAt = order.getCreatedAt() != null ? order.getCreatedAt() : Instant.now();
 		LocalDate orderDate = createdAt.atZone(KST).toLocalDate();
 		ZonedDateTime deadline = ZonedDateTime.of(orderDate.plusDays(1), LocalTime.of(23, 59), KST);
@@ -145,12 +136,11 @@ public class EmailDataQueryService {
 
 	@Transactional(readOnly = true)
 	public Optional<Map<String, Object>> buildCancellationEmailContext(Long orderId, OrderCancelledEvent event) {
-		Order order = orderRepository.findByIdWithMatchDetails(orderId).orElse(null);
+		Order order = orderRepository.findById(orderId).orElse(null);
 		if (order == null) {
 			return Optional.empty();
 		}
 
-		Match match = order.getMatch();
 		List<OrderSeat> orderSeats = orderSeatRepository.findByOrderId(orderId);
 		Payment payment = paymentRepository.findByOrderId(orderId).orElse(null);
 		List<SeatDisplayInfo> seats = buildSeatDisplayInfos(orderSeats);
@@ -160,10 +150,10 @@ public class EmailDataQueryService {
 		ctx.put("ordererEmail", order.getOrdererEmail());
 		ctx.put("orderId", order.getId());
 
-		ctx.put("matchTitle", match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName());
-		ctx.put("matchDateTime", formatInstant(match.getMatchAt()));
-		ctx.put("stadiumName", match.getStadium().getKoName());
-		ctx.put("stadiumAddress", match.getStadium().getAddress());
+		ctx.put("matchTitle", order.getMatchTitle());
+		ctx.put("matchDateTime", formatInstant(order.getMatchDate()));
+		ctx.put("stadiumName", order.getStadiumName());
+		ctx.put("stadiumAddress", "");
 
 		ctx.put("seats", seats);
 
@@ -180,60 +170,22 @@ public class EmailDataQueryService {
 		ctx.put("bookingFee", order.getBookingFee() != null ? order.getBookingFee() : 0);
 		ctx.put("cancellationFee", event.getCancellationFee());
 		ctx.put("refundedAmount", event.getRefundedAmount());
-		ctx.put("cancelDeadline", formatInstant(match.getMatchAt()));
+		ctx.put("cancelDeadline", formatInstant(order.getMatchDate()));
 
 		ctx.put("ticketUrl", TICKET_URL);
 		return Optional.of(ctx);
 	}
 
 	private List<SeatDisplayInfo> buildSeatDisplayInfos(List<OrderSeat> orderSeats) {
-		Set<Long> sectionIds = orderSeats.stream()
-			.map(OrderSeat::getSectionId).collect(Collectors.toSet());
-		Set<Long> blockIds = orderSeats.stream()
-			.map(OrderSeat::getBlockId).collect(Collectors.toSet());
-
-		Map<Long, String> sectionNames = getSectionNames(sectionIds);
-		Map<Long, Long> blockNums = getBlockNums(blockIds);
-
 		return orderSeats.stream()
 			.map(os -> new SeatDisplayInfo(
-				sectionNames.getOrDefault(os.getSectionId(), ""),
-				blockNums.getOrDefault(os.getBlockId(), 0L),
+				os.getSectionName() != null ? os.getSectionName() : "",
+				0L,
 				os.getRowNo(),
 				os.getSeatNo(),
 				os.getPrice()
 			))
 			.toList();
-	}
-
-	private Map<Long, String> getSectionNames(Set<Long> sectionIds) {
-		if (sectionIds.isEmpty()) {
-			return Map.of();
-		}
-		String sql = "SELECT id, name FROM sections WHERE id IN (:ids)";
-		MapSqlParameterSource params = new MapSqlParameterSource("ids", sectionIds);
-		return jdbcTemplate.query(sql, params, rs -> {
-			Map<Long, String> map = new HashMap<>();
-			while (rs.next()) {
-				map.put(rs.getLong("id"), rs.getString("name"));
-			}
-			return map;
-		});
-	}
-
-	private Map<Long, Long> getBlockNums(Set<Long> blockIds) {
-		if (blockIds.isEmpty()) {
-			return Map.of();
-		}
-		String sql = "SELECT id, block_num FROM blocks WHERE id IN (:ids)";
-		MapSqlParameterSource params = new MapSqlParameterSource("ids", blockIds);
-		return jdbcTemplate.query(sql, params, rs -> {
-			Map<Long, Long> map = new HashMap<>();
-			while (rs.next()) {
-				map.put(rs.getLong("id"), rs.getLong("block_num"));
-			}
-			return map;
-		});
 	}
 
 	public List<Map<String, Object>> buildForcedCancellationEmailContexts(Long userId) {
@@ -247,7 +199,6 @@ public class EmailDataQueryService {
 	}
 
 	private Map<String, Object> buildForcedCancellationContext(Order order, Instant cancelledAt) {
-		Match match = order.getMatch();
 		List<OrderSeat> orderSeats = orderSeatRepository.findByOrderId(order.getId());
 		Payment payment = paymentRepository.findByOrderId(order.getId()).orElse(null);
 		List<SeatDisplayInfo> seats = buildSeatDisplayInfos(orderSeats);
@@ -261,10 +212,10 @@ public class EmailDataQueryService {
 		ctx.put("ordererEmail", order.getOrdererEmail());
 		ctx.put("orderId", order.getId());
 
-		ctx.put("matchTitle", match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName());
-		ctx.put("matchDateTime", formatInstant(match.getMatchAt()));
-		ctx.put("stadiumName", match.getStadium().getKoName());
-		ctx.put("stadiumAddress", match.getStadium().getAddress());
+		ctx.put("matchTitle", order.getMatchTitle());
+		ctx.put("matchDateTime", formatInstant(order.getMatchDate()));
+		ctx.put("stadiumName", order.getStadiumName());
+		ctx.put("stadiumAddress", "");
 
 		ctx.put("seats", seats);
 
@@ -282,7 +233,7 @@ public class EmailDataQueryService {
 		ctx.put("seatTotal", seatTotal);
 		ctx.put("cancellationFee", cancellationFee);
 		ctx.put("refundedAmount", refundedAmount);
-		ctx.put("cancelDeadline", formatInstant(match.getMatchAt()));
+		ctx.put("cancelDeadline", formatInstant(order.getMatchDate()));
 		ctx.put("ticketUrl", TICKET_URL);
 
 		return ctx;

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/inquiry/entity/Inquiry.java
@@ -4,18 +4,14 @@ import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryCategory;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryStatus;
-import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,9 +31,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Inquiry extends BaseEntity {
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false, length = 30)
@@ -63,13 +58,13 @@ public class Inquiry extends BaseEntity {
 
 	@Builder
 	public Inquiry(
-		User user,
+		Long userId,
 		InquiryCategory category,
 		String title,
 		String content,
 		String phoneNumber
 	) {
-		this.user = user;
+		this.userId = userId;
 		this.category = category;
 		this.title = title;
 		this.content = content;
@@ -78,14 +73,14 @@ public class Inquiry extends BaseEntity {
 	}
 
 	public static Inquiry create(
-		User user,
+		Long userId,
 		InquiryCategory category,
 		String title,
 		String content,
 		String phoneNumber
 	) {
 		return Inquiry.builder()
-			.user(user)
+			.userId(userId)
 			.category(category)
 			.title(title)
 			.content(content)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketQrResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/dto/response/MyPageTicketQrResponse.java
@@ -37,10 +37,10 @@ public record MyPageTicketQrResponse(
 	) {
 		public static MatchInfo from(Order order) {
 			return new MatchInfo(
-				order.getMatch().getMatchAt(),
-				new ClubInfo(order.getMatch().getHomeClub().getKoName()),
-				new ClubInfo(order.getMatch().getAwayClub().getKoName()),
-				order.getMatch().getStadium().getKoName()
+				order.getMatchDate(),
+				new ClubInfo(order.getHomeClubName()),
+				new ClubInfo(order.getAwayClubName()),
+				order.getStadiumName()
 			);
 		}
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -47,24 +47,19 @@ public class MyPageQueryService {
 
 	/**
 	 * 탭 조건에 해당하는 티켓 목록을 페이지네이션하여 반환한다.
+	 * 비정규화 컬럼(match_date, home_club_name, away_club_name, stadium_name)을 사용한다.
 	 */
 	public List<TicketRow> findTickets(Long userId, List<String> statuses, int page, int size) {
 		String sql = """
 				SELECT
-				    o.id           AS order_id,
+				    o.id             AS order_id,
 				    o.status,
-				    m.match_at,
-				    hc.id          AS home_club_id,
-				    hc.ko_name     AS home_club_name,
-				    ac.id          AS away_club_id,
-				    ac.ko_name     AS away_club_name,
-				    st.ko_name     AS stadium_name,
+				    o.match_date     AS match_at,
+				    o.home_club_name,
+				    o.away_club_name,
+				    o.stadium_name,
 				    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
 				FROM orders o
-				JOIN matches m  ON o.match_id    = m.id
-				JOIN clubs hc   ON m.home_club_id = hc.id
-				JOIN clubs ac   ON m.away_club_id = ac.id
-				JOIN stadiums st ON m.stadium_id  = st.id
 				WHERE o.user_id = :userId
 				  AND o.status IN (:statuses)
 				ORDER BY o.created_at DESC
@@ -80,10 +75,11 @@ public class MyPageQueryService {
 		return namedJdbc.query(sql, params, (rs, rowNum) -> new TicketRow(
 				rs.getLong("order_id"),
 				OrderStatus.valueOf(rs.getString("status")),
-				rs.getObject("match_at", Timestamp.class).toInstant(),
-				rs.getLong("home_club_id"),
+				rs.getObject("match_at", Timestamp.class) != null
+						? rs.getObject("match_at", Timestamp.class).toInstant() : null,
+				null,
 				rs.getString("home_club_name"),
-				rs.getLong("away_club_id"),
+				null,
 				rs.getString("away_club_name"),
 				rs.getString("stadium_name"),
 				rs.getInt("seat_count")
@@ -92,6 +88,7 @@ public class MyPageQueryService {
 
 	/**
 	 * 주문 ID 목록에 해당하는 좌석 정보를 orderId와 함께 반환한다.
+	 * OrderSeat 비정규화 컬럼(section_name, block_code)을 사용한다.
 	 */
 	public List<OrderSeatRow> findOrderSeatRowsByOrderIds(List<Long> orderIds) {
 		if (orderIds.isEmpty()) {
@@ -101,13 +98,11 @@ public class MyPageQueryService {
 		String sql = """
 				SELECT
 				    os.order_id,
-				    sec.name    AS section_name,
-				    b.block_code,
+				    os.section_name,
+				    os.block_code,
 				    os.row_no,
 				    os.seat_no
 				FROM order_seats os
-				JOIN sections sec ON os.section_id = sec.id
-				JOIN blocks b     ON os.block_id   = b.id
 				WHERE os.order_id IN (:orderIds)
 				ORDER BY os.order_id, os.id
 				""";
@@ -126,6 +121,7 @@ public class MyPageQueryService {
 
 	/**
 	 * ticketId(orderId)에 해당하는 상세 기본 정보를 반환한다.
+	 * Order 비정규화 컬럼을 사용하여 matches/clubs/stadiums JOIN을 제거한다.
 	 */
 	public Optional<TicketDetailBaseRow> findTicketDetailBaseByOrderId(Long orderId) {
 		String sql = """
@@ -138,15 +134,11 @@ public class MyPageQueryService {
 				    o.cancelled_at,
 				    o.cancellation_fee,
 				    o.refunded_amount,
-				    m.id             AS match_id,
-				    m.match_at,
-				    hc.id            AS home_club_id,
-				    hc.ko_name       AS home_club_name,
-				    ac.id            AS away_club_id,
-				    ac.ko_name       AS away_club_name,
-				    st.id            AS stadium_id,
-				    st.ko_name       AS stadium_name,
-				    st.address       AS stadium_address,
+				    o.match_id,
+				    o.match_date     AS match_at,
+				    o.home_club_name,
+				    o.away_club_name,
+				    o.stadium_name,
 				    p.payment_method,
 				    p.paid_at,
 				    p.account_bank,
@@ -156,10 +148,6 @@ public class MyPageQueryService {
 				    cr.purpose       AS cash_receipt_purpose,
 				    cr.number        AS cash_receipt_number
 				FROM orders o
-				JOIN matches m      ON o.match_id = m.id
-				JOIN clubs hc       ON m.home_club_id = hc.id
-				JOIN clubs ac       ON m.away_club_id = ac.id
-				JOIN stadiums st    ON m.stadium_id = st.id
 				LEFT JOIN payments p ON p.order_id = o.id
 				LEFT JOIN cash_receipts cr ON cr.payment_id = p.id
 				WHERE o.id = :orderId
@@ -183,14 +171,15 @@ public class MyPageQueryService {
 					rs.getInt("cancellation_fee"),
 					rs.getObject("refunded_amount", Integer.class),
 					rs.getLong("match_id"),
-					rs.getObject("match_at", Timestamp.class).toInstant(),
-					rs.getLong("home_club_id"),
+					rs.getObject("match_at", Timestamp.class) != null
+							? rs.getObject("match_at", Timestamp.class).toInstant() : null,
+					null,
 					rs.getString("home_club_name"),
-					rs.getLong("away_club_id"),
+					null,
 					rs.getString("away_club_name"),
-					rs.getLong("stadium_id"),
+					null,
 					rs.getString("stadium_name"),
-					rs.getString("stadium_address"),
+					null,
 					paymentMethod == null ? null : PaymentMethod.valueOf(paymentMethod),
 					rs.getObject("paid_at", Timestamp.class) == null ? null
 							: rs.getObject("paid_at", Timestamp.class).toInstant(),
@@ -209,19 +198,18 @@ public class MyPageQueryService {
 
 	/**
 	 * ticketId(orderId)에 해당하는 좌석 상세 정보를 반환한다.
+	 * OrderSeat 비정규화 컬럼을 사용한다.
 	 */
 	public List<TicketSeatDetailRow> findTicketSeatRowsByOrderId(Long orderId) {
 		String sql = """
 				SELECT
-				    sec.name      AS section_name,
-				    b.block_code,
+				    os.section_name,
+				    os.block_code,
 				    os.row_no,
 				    os.seat_no,
 				    os.price,
 				    os.ticket_type
 				FROM order_seats os
-				JOIN sections sec ON os.section_id = sec.id
-				JOIN blocks b     ON os.block_id = b.id
 				WHERE os.order_id = :orderId
 				ORDER BY os.id
 				""";
@@ -240,16 +228,15 @@ public class MyPageQueryService {
 	}
 
 	/**
-	 * 경기 예정 티켓 수를 반환한다. (오늘 이후 경기 + 유효 상태)
+	 * 경기 예정 티켓 수를 반환한다. (비정규화 match_date 사용)
 	 */
 	public long countUpcomingTickets(Long userId, List<String> statuses, java.time.Instant now) {
 		String sql = """
 				SELECT COUNT(*)
 				FROM orders o
-				JOIN matches m ON o.match_id = m.id
 				WHERE o.user_id = :userId
 				  AND o.status IN (:statuses)
-				  AND m.match_at > :now
+				  AND o.match_date > :now
 				""";
 
 		var params = new MapSqlParameterSource()
@@ -262,32 +249,26 @@ public class MyPageQueryService {
 	}
 
 	/**
-	 * 경기 예정 티켓 목록을 matchAt ASC로 페이지네이션하여 반환한다.
+	 * 경기 예정 티켓 목록을 matchDate ASC로 페이지네이션하여 반환한다.
+	 * 비정규화 컬럼을 사용하여 matches/clubs/stadiums JOIN을 제거한다.
 	 */
 	public List<UpcomingTicketRow> findUpcomingTickets(Long userId, List<String> statuses,
 			java.time.Instant now, int page, int size) {
 		String sql = """
 				SELECT
-				    o.id           AS order_id,
+				    o.id             AS order_id,
 				    o.status,
-				    m.id           AS match_id,
-				    m.match_at,
-				    hc.id          AS home_club_id,
-				    hc.ko_name     AS home_club_name,
-				    ac.id          AS away_club_id,
-				    ac.ko_name     AS away_club_name,
-				    st.id          AS stadium_id,
-				    st.ko_name     AS stadium_name,
+				    o.match_id,
+				    o.match_date     AS match_at,
+				    o.home_club_name,
+				    o.away_club_name,
+				    o.stadium_name,
 				    (SELECT COUNT(*) FROM order_seats os2 WHERE os2.order_id = o.id) AS seat_count
 				FROM orders o
-				JOIN matches m   ON o.match_id    = m.id
-				JOIN clubs hc    ON m.home_club_id = hc.id
-				JOIN clubs ac    ON m.away_club_id = ac.id
-				JOIN stadiums st ON m.stadium_id  = st.id
 				WHERE o.user_id = :userId
 				  AND o.status IN (:statuses)
-				  AND m.match_at > :now
-				ORDER BY m.match_at ASC
+				  AND o.match_date > :now
+				ORDER BY o.match_date ASC
 				LIMIT :size OFFSET :offset
 				""";
 
@@ -302,12 +283,13 @@ public class MyPageQueryService {
 				rs.getLong("order_id"),
 				OrderStatus.valueOf(rs.getString("status")),
 				rs.getLong("match_id"),
-				rs.getObject("match_at", Timestamp.class).toInstant(),
-				rs.getLong("home_club_id"),
+				rs.getObject("match_at", Timestamp.class) != null
+						? rs.getObject("match_at", Timestamp.class).toInstant() : null,
+				null,
 				rs.getString("home_club_name"),
-				rs.getLong("away_club_id"),
+				null,
 				rs.getString("away_club_name"),
-				rs.getLong("stadium_id"),
+				null,
 				rs.getString("stadium_name"),
 				rs.getInt("seat_count")
 		));

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryService.java
@@ -16,8 +16,6 @@ import com.goormgb.be.ordercore.mypage.dto.request.MyPageInquiryCreateRequest;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
-import com.goormgb.be.user.entity.User;
-import com.goormgb.be.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,15 +24,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class MyPageInquiryService {
 
-	private final UserRepository userRepository;
 	private final InquiryRepository inquiryRepository;
 
 	@Transactional
 	public MyPageInquiryCreateResponse createInquiry(Long userId, MyPageInquiryCreateRequest request) {
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
-
 		Inquiry inquiry = Inquiry.create(
-			user,
+			userId,
 			parseCategory(request.category()),
 			request.title().trim(),
 			request.content().trim(),
@@ -46,7 +41,6 @@ public class MyPageInquiryService {
 	}
 
 	public MyPageInquiryListResponse getInquiries(Long userId) {
-		userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		List<Inquiry> inquiries = inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
 		return MyPageInquiryListResponse.of(inquiries);
 	}
@@ -54,7 +48,7 @@ public class MyPageInquiryService {
 	public MyPageInquiryDetailResponse getInquiryDetail(Long userId, Long inquiryId) {
 		Inquiry inquiry = inquiryRepository.findById(inquiryId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INQUIRY_NOT_FOUND));
-		Preconditions.validate(inquiry.getUser().getId().equals(userId), ErrorCode.INQUIRY_ACCESS_DENIED);
+		Preconditions.validate(inquiry.getUserId().equals(userId), ErrorCode.INQUIRY_ACCESS_DENIED);
 
 		return MyPageInquiryDetailResponse.of(inquiry, null);
 	}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -216,11 +216,11 @@ public class MyPageTicketService {
 	public MyPageTicketQrResponse getTicketEntryQr(Long userId, Long ticketId) {
 		Order order = orderRepository.findByIdForUpdate(ticketId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		Preconditions.validate(order.getUserId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		Instant now = Instant.now(clock);
-		MyPageTicketQrSupport.validateQrIssuableTime(order.getMatch().getMatchAt(), now);
+		MyPageTicketQrSupport.validateQrIssuableTime(order.getMatchDate(), now);
 
 		QrToken qrToken = qrTokenRepository.findByOrderIdAndExpiresAtAfter(ticketId, now)
 				.orElseGet(() -> MyPageTicketQrSupport.issueNewQrToken(order, now, qrTokenRepository));
@@ -234,11 +234,11 @@ public class MyPageTicketService {
 		Instant now = Instant.now(clock);
 		Order order = orderRepository.findByIdForUpdate(ticketId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
+		Preconditions.validate(order.getUserId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		CancellationFeePolicy policy = MyPageTicketCancellationCalculator.findCancellationPolicy(
-				order.getMatch().getMatchAt(),
+				order.getMatchDate(),
 				now,
 				cancellationFeePolicyRepository
 		);

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/support/MyPageTicketQrSupport.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/support/MyPageTicketQrSupport.java
@@ -27,7 +27,7 @@ public final class MyPageTicketQrSupport {
 	public static QrToken issueNewQrToken(Order order, Instant now, QrTokenRepository qrTokenRepository) {
 		QrToken qrToken = QrToken.builder()
 			.order(order)
-			.user(order.getUser())
+			.userId(order.getUserId())
 			.qrToken(UUID.randomUUID().toString())
 			.expiresAt(calculateNextQrExpiry(now))
 			.build();

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/client/SeatInternalClient.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/client/SeatInternalClient.java
@@ -1,0 +1,81 @@
+package com.goormgb.be.ordercore.order.client;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Seat 모듈의 내부 API를 호출하는 클라이언트.
+ * DB 스키마 분리 후 Order-Core가 Seat DB를 직접 조회하지 않도록 대체한다.
+ */
+@Slf4j
+@Component
+public class SeatInternalClient {
+
+	@Value("${seat.internal.base-url:http://localhost:8082/seat}")
+	private String seatBaseUrl;
+
+	private RestClient restClient;
+
+	@PostConstruct
+	void init() {
+		this.restClient = RestClient.builder()
+			.baseUrl(seatBaseUrl)
+			.build();
+	}
+
+	/**
+	 * 좌석 선점 정보를 조회한다.
+	 */
+	public List<SeatHoldInfo> findSeatHoldInfos(Long userId, Long matchId, List<Long> matchSeatIds) {
+		String matchSeatIdsParam = matchSeatIds.stream()
+			.map(String::valueOf)
+			.reduce((a, b) -> a + "," + b)
+			.orElse("");
+
+		return restClient.get()
+			.uri("/internal/seat-holds?userId={userId}&matchId={matchId}&matchSeatIds={matchSeatIds}",
+				userId, matchId, matchSeatIdsParam)
+			.retrieve()
+			.body(new ParameterizedTypeReference<>() {});
+	}
+
+	/**
+	 * 구역/요일/좌석유형 조합의 가격을 조회한다.
+	 */
+	public Integer findPrice(Long sectionId, String dayType, String ticketType) {
+		PriceResponse response = restClient.get()
+			.uri("/internal/price-policies?sectionId={sectionId}&dayType={dayType}&ticketType={ticketType}",
+				sectionId, dayType, ticketType)
+			.retrieve()
+			.body(PriceResponse.class);
+
+		return response != null ? response.price() : null;
+	}
+
+	/**
+	 * 구역/블럭 이름 정보를 조회한다.
+	 */
+	public List<SectionBlockInfo> findSectionBlockInfos(List<Long> sectionIds, List<Long> blockIds) {
+		String sectionIdsParam = sectionIds.stream().map(String::valueOf).reduce((a, b) -> a + "," + b).orElse("");
+		String blockIdsParam = blockIds.stream().map(String::valueOf).reduce((a, b) -> a + "," + b).orElse("");
+
+		return restClient.get()
+			.uri("/internal/section-blocks?sectionIds={sectionIds}&blockIds={blockIds}",
+				sectionIdsParam, blockIdsParam)
+			.retrieve()
+			.body(new ParameterizedTypeReference<>() {});
+	}
+
+	public record PriceResponse(Integer price) {}
+
+	public record SectionBlockInfo(Long sectionId, String sectionName, Long blockId, String blockCode) {}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/dto/response/OrderCreateResponse.java
@@ -22,7 +22,7 @@ public record OrderCreateResponse(
 		return new OrderCreateResponse(
 			order.getId(),
 			order.getStatus(),
-			order.getMatch().getId(),
+			order.getMatchId(),
 			seatCount,
 			order.getTotalAmount(),
 			order.getBookingFee(),

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/Order.java
@@ -2,21 +2,16 @@ package com.goormgb.be.ordercore.order.entity;
 
 import java.time.Instant;
 
-import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.global.encryption.EncryptionConverter;
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -41,13 +36,11 @@ public class Order extends BaseEntity {
 
 	private static final int DEFAULT_BOOKING_FEE = 2000;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "match_id", nullable = false)
-	private Match match;
+	@Column(name = "match_id", nullable = false)
+	private Long matchId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false, length = 30)
@@ -84,18 +77,44 @@ public class Order extends BaseEntity {
 	@Column(name = "orderer_birth_date", nullable = false, length = 512)
 	private String ordererBirthDate;
 
+	// --- 비정규화 컬럼 (주문 생성 시점 스냅샷) ---
+
+	@Column(name = "user_nickname")
+	private String userNickname;
+
+	@Column(name = "match_title", length = 200)
+	private String matchTitle;
+
+	@Column(name = "match_date")
+	private Instant matchDate;
+
+	@Column(name = "stadium_name", length = 100)
+	private String stadiumName;
+
+	@Column(name = "home_club_name", length = 50)
+	private String homeClubName;
+
+	@Column(name = "away_club_name", length = 50)
+	private String awayClubName;
+
 	@Builder
 	public Order(
-		User user,
-		Match match,
+		Long userId,
+		Long matchId,
 		Integer totalAmount,
 		String ordererName,
 		String ordererEmail,
 		String ordererPhone,
-		String ordererBirthDate
+		String ordererBirthDate,
+		String userNickname,
+		String matchTitle,
+		Instant matchDate,
+		String stadiumName,
+		String homeClubName,
+		String awayClubName
 	) {
-		this.user = user;
-		this.match = match;
+		this.userId = userId;
+		this.matchId = matchId;
 		this.status = OrderStatus.PAYMENT_PENDING;
 		this.totalAmount = totalAmount;
 		this.bookingFee = DEFAULT_BOOKING_FEE;
@@ -104,6 +123,12 @@ public class Order extends BaseEntity {
 		this.ordererEmail = ordererEmail;
 		this.ordererPhone = ordererPhone;
 		this.ordererBirthDate = ordererBirthDate;
+		this.userNickname = userNickname;
+		this.matchTitle = matchTitle;
+		this.matchDate = matchDate;
+		this.stadiumName = stadiumName;
+		this.homeClubName = homeClubName;
+		this.awayClubName = awayClubName;
 	}
 
 	public void updateStatus(OrderStatus status) {
@@ -115,17 +140,21 @@ public class Order extends BaseEntity {
 	}
 
 	/**
-	 * 토스페이/카카오페이 결제 취소 — 즉시 CANCELLED 처리
+	 * 토스페이/카카오페이 결제 취소 -- 즉시 CANCELLED 처리
 	 */
 	public void cancelComplete(Integer cancellationFee, Integer refundedAmount, Instant cancelledAt) {
 		updateCancellationInfo(OrderStatus.CANCELLED, cancellationFee, refundedAmount, cancelledAt);
 	}
 
 	/**
-	 * 무통장 입금 환불 완료 — 즉시 REFUND_COMPLETED 처리
+	 * 무통장 입금 환불 완료 -- 즉시 REFUND_COMPLETED 처리
 	 */
 	public void refundComplete(Integer cancellationFee, Integer refundedAmount, Instant cancelledAt) {
 		updateCancellationInfo(OrderStatus.REFUND_COMPLETED, cancellationFee, refundedAmount, cancelledAt);
+	}
+
+	public void updateUserNickname(String userNickname) {
+		this.userNickname = userNickname;
 	}
 
 	private void updateCancellationInfo(OrderStatus status, Integer cancellationFee, Integer refundedAmount,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/entity/OrderSeat.java
@@ -58,6 +58,14 @@ public class OrderSeat extends BaseEntity {
 	@Column(name = "ticket_type", nullable = false, length = 30)
 	private TicketType ticketType;
 
+	// --- 비정규화 컬럼 (주문 생성 시점 스냅샷) ---
+
+	@Column(name = "section_name", length = 100)
+	private String sectionName;
+
+	@Column(name = "block_code", length = 20)
+	private String blockCode;
+
 	@Builder
 	public OrderSeat(
 		Order order,
@@ -67,7 +75,9 @@ public class OrderSeat extends BaseEntity {
 		Integer rowNo,
 		Integer seatNo,
 		Integer price,
-		TicketType ticketType
+		TicketType ticketType,
+		String sectionName,
+		String blockCode
 	) {
 		this.order = order;
 		this.matchSeatId = matchSeatId;
@@ -77,6 +87,8 @@ public class OrderSeat extends BaseEntity {
 		this.seatNo = seatNo;
 		this.price = price;
 		this.ticketType = ticketType;
+		this.sectionName = sectionName;
+		this.blockCode = blockCode;
 	}
 
 	public void assignOrder(Order order) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/event/OrderEventPublisher.java
@@ -29,8 +29,8 @@ public class OrderEventPublisher {
 		applicationEventPublisher.publishEvent(
 			new OrderCancelledInternalEvent(
 				order.getId(),
-				order.getUser().getId(),
-				order.getMatch().getId(),
+				order.getUserId(),
+				order.getMatchId(),
 				order.getCancellationFee(),
 				order.getRefundedAmount(),
 				matchSeatIds,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/query/SeatInfoQueryService.java
@@ -1,133 +1,23 @@
 package com.goormgb.be.ordercore.order.query;
 
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Order DB 자체 테이블만 조회하는 쿼리 서비스.
+ * Seat DB 직접 조회 메서드(findSeatHoldInfos, findPrice, markSoldIfBlocked, markAvailableIfSold)는
+ * SeatInternalClient로 이관 완료되어 제거되었다.
+ */
 @Service
 @RequiredArgsConstructor
 public class SeatInfoQueryService {
 
 	private final NamedParameterJdbcTemplate namedJdbc;
-
-	/**
-	 * matchSeatIds에 해당하는 좌석 선점 정보와 좌석 상세 정보를 조회한다.
-	 * user_id 검증과 만료 여부도 함께 수행한다.
-	 */
-	public List<SeatHoldInfo> findSeatHoldInfos(Long userId, List<Long> matchSeatIds) {
-		String sql = """
-				SELECT
-					sh.id        AS hold_id,
-					sh.match_seat_id,
-					sh.user_id,
-					sh.expires_at,
-					ms.section_id, 
-					sec.name     AS section_name,
-					ms.block_id,
-					b.block_code,
-					ms.row_no,
-					ms.seat_no
-				FROM seat_holds sh
-				JOIN match_seats ms  ON sh.match_seat_id = ms.id
-				JOIN blocks b        ON ms.block_id       = b.id
-				JOIN sections sec    ON ms.section_id     = sec.id
-				WHERE sh.match_seat_id IN (:matchSeatIds)
-				  AND sh.user_id = :userId
-				""";
-
-		var params = new MapSqlParameterSource()
-				.addValue("matchSeatIds", matchSeatIds)
-				.addValue("userId", userId);
-
-		return namedJdbc.query(sql, params, (rs, rowNum) -> new SeatHoldInfo(
-				rs.getLong("hold_id"),
-				rs.getLong("match_seat_id"),
-				rs.getLong("user_id"),
-				rs.getObject("expires_at", Timestamp.class).toInstant(),
-				rs.getLong("section_id"),
-				rs.getString("section_name"),
-				rs.getLong("block_id"),
-				rs.getString("block_code"),
-				rs.getInt("row_no"),
-				rs.getInt("seat_no")
-		));
-	}
-
-	/**
-	 * (sectionId, dayType, ticketType) 조합에 해당하는 가격을 조회한다.
-	 */
-	public Integer findPrice(Long sectionId, String dayType, String ticketType) {
-		String sql = """
-				SELECT price
-				FROM price_policies
-				WHERE section_id  = :sectionId
-				  AND day_type    = :dayType
-				  AND ticket_type = :ticketType
-				""";
-
-		var params = Map.of(
-				"sectionId", sectionId,
-				"dayType", dayType,
-				"ticketType", ticketType
-		);
-
-		List<Integer> results = namedJdbc.queryForList(sql, params, Integer.class);
-		return results.isEmpty() ? null : results.get(0);
-	}
-
-	/**
-	 * BLOCKED 상태인 좌석들을 SOLD로 일괄 전환한다.
-	 * 결제 확정 시 호출되며, BLOCKED가 아닌 좌석은 건드리지 않는다.
-	 *
-	 * @return 변경된 행 수
-	 */
-	public int markSoldIfBlocked(List<Long> matchSeatIds) {
-		if (matchSeatIds.isEmpty()) {
-			return 0;
-		}
-
-		String sql = """
-				UPDATE match_seats
-				SET sale_status = 'SOLD'
-				WHERE id IN (:matchSeatIds)
-				  AND sale_status = 'BLOCKED'
-				""";
-
-		var params = new MapSqlParameterSource()
-				.addValue("matchSeatIds", matchSeatIds);
-
-		return namedJdbc.update(sql, params);
-	}
-
-	/**
-	 * SOLD 상태인 좌석들을 AVAILABLE로 일괄 복원한다.
-	 * 주문 취소 시 호출되며, SOLD가 아닌 좌석은 건드리지 않는다.
-	 *
-	 * @return 변경된 행 수
-	 */
-	public int markAvailableIfSold(List<Long> matchSeatIds) {
-		if (matchSeatIds.isEmpty()) {
-			return 0;
-		}
-
-		String sql = """
-				UPDATE match_seats
-				SET sale_status = 'AVAILABLE'
-				WHERE id IN (:matchSeatIds)
-				  AND sale_status = 'SOLD'
-				""";
-
-		var params = new MapSqlParameterSource()
-				.addValue("matchSeatIds", matchSeatIds);
-
-		return namedJdbc.update(sql, params);
-	}
 
 	/**
 	 * matchSeatId로 이미 유효한 주문이 존재하는 좌석인지 확인한다.

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -21,27 +21,27 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
 	long countByUserId(Long userId);
 
-	@Query("SELECT COUNT(o) FROM Order o WHERE o.user.id = :userId AND o.status IN :statuses AND o.match.matchAt > :now")
+	@Query("SELECT COUNT(o) FROM Order o WHERE o.userId = :userId AND o.status IN :statuses AND o.matchDate > :now")
 	long countUpcomingOrders(@Param("userId") Long userId,
 		@Param("statuses") List<OrderStatus> statuses,
 		@Param("now") Instant now);
 
-	@Query("SELECT COUNT(o) FROM Order o WHERE o.user.id = :userId AND o.status = 'PAID' AND o.match.matchAt < :now")
+	@Query("SELECT COUNT(o) FROM Order o WHERE o.userId = :userId AND o.status = 'PAID' AND o.matchDate < :now")
 	long countCompletedOrders(@Param("userId") Long userId, @Param("now") Instant now);
 
-	@Query("SELECT COUNT(o) FROM Order o WHERE o.user.id = :userId AND o.status IN :statuses")
+	@Query("SELECT COUNT(o) FROM Order o WHERE o.userId = :userId AND o.status IN :statuses")
 	long countByUserIdAndStatusIn(@Param("userId") Long userId, @Param("statuses") List<OrderStatus> statuses);
 
 	@Query("""
 		SELECT new com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts(
 			COUNT(o),
-			COALESCE(SUM(CASE WHEN o.status IN :upcomingStatuses AND o.match.matchAt > :now THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN o.status IN :upcomingStatuses AND o.matchDate > :now THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN o.status IN :cancelRefundStatuses THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN o.status IN :cancelProcessingStatuses THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN o.status = :completedStatus AND o.match.matchAt < :now THEN 1 ELSE 0 END), 0)
+			COALESCE(SUM(CASE WHEN o.status = :completedStatus AND o.matchDate < :now THEN 1 ELSE 0 END), 0)
 		)
 		FROM Order o
-		WHERE o.user.id = :userId
+		WHERE o.userId = :userId
 		""")
 	OrderMyPageSummaryCounts findMyPageSummaryCounts(
 		@Param("userId") Long userId,
@@ -54,8 +54,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
 	@Query("""
 		SELECT o.id FROM Order o
-		WHERE o.user.id = :userId
-		  AND o.match.id = :matchId
+		WHERE o.userId = :userId
+		  AND o.matchId = :matchId
 		  AND o.status = :status
 		""")
 	List<Long> findIdsByUserIdAndMatchIdAndStatus(
@@ -68,8 +68,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 	@Query("""
 		UPDATE Order o
 		SET o.status = :newStatus
-		WHERE o.user.id = :userId
-		  AND o.match.id = :matchId
+		WHERE o.userId = :userId
+		  AND o.matchId = :matchId
 		  AND o.status = :oldStatus
 		""")
 	int bulkUpdateStatus(
@@ -86,7 +86,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 	@Query("""
 		UPDATE Order o
 		SET o.status = :newStatus
-		WHERE o.user.id = :userId
+		WHERE o.userId = :userId
 		  AND o.status IN :statuses
 		""")
 	int bulkUpdateStatusByUserIdAndStatuses(
@@ -96,39 +96,17 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 	);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("""
-		SELECT o
-		FROM Order o
-		JOIN FETCH o.user u
-		JOIN FETCH o.match m
-		JOIN FETCH m.homeClub hc
-		JOIN FETCH m.awayClub ac
-		JOIN FETCH m.stadium s
-		WHERE o.id = :orderId
-		""")
+	@Query("SELECT o FROM Order o WHERE o.id = :orderId")
 	Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
 
-	@Query("""
-		SELECT o
-		FROM Order o
-		JOIN FETCH o.match m
-		JOIN FETCH m.homeClub
-		JOIN FETCH m.awayClub
-		JOIN FETCH m.stadium
-		WHERE o.id = :orderId
-		""")
+	@Query("SELECT o FROM Order o WHERE o.id = :orderId")
 	Optional<Order> findByIdWithMatchDetails(@Param("orderId") Long orderId);
 
 	@Query("""
-		SELECT o
-		FROM Order o
-		JOIN FETCH o.match m
-		JOIN FETCH m.homeClub
-		JOIN FETCH m.awayClub
-		JOIN FETCH m.stadium
-		WHERE o.user.id = :userId
+		SELECT o FROM Order o
+		WHERE o.userId = :userId
 		  AND o.status IN :statuses
-		  AND m.matchAt > :now
+		  AND o.matchDate > :now
 		""")
 	List<Order> findUpcomingOrdersByUserIdAndStatuses(
 		@Param("userId") Long userId,

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/service/OrderService.java
@@ -16,6 +16,7 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.metrics.enums.OrderDraftEntryPoint;
+import com.goormgb.be.ordercore.order.client.SeatInternalClient;
 import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
 import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
 import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
@@ -26,8 +27,6 @@ import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
-import com.goormgb.be.user.entity.User;
-import com.goormgb.be.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,9 +45,9 @@ public class OrderService {
 	);
 
 	private final MatchRepository matchRepository;
-	private final UserRepository userRepository;
 	private final OrderRepository orderRepository;
 	private final OrderSeatRepository orderSeatRepository;
+	private final SeatInternalClient seatInternalClient;
 	private final SeatInfoQueryService seatInfoQueryService;
 	private final OrderMetricsService orderMetricsService;
 
@@ -62,7 +61,6 @@ public class OrderService {
 			List<Long> matchSeatIds,
 			OrderDraftEntryPoint entryPoint
 	) {
-		// 주문서 진입 경로 집계
 		orderMetricsService.increaseOrderDraftEnter(entryPoint);
 		Preconditions.validate(!matchSeatIds.isEmpty(), ErrorCode.ORDER_SEAT_EMPTY);
 
@@ -70,14 +68,14 @@ public class OrderService {
 
 		String dayType = determineDayType(match.getMatchAt());
 
-		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, matchSeatIds);
+		List<SeatHoldInfo> holdInfos = seatInternalClient.findSeatHoldInfos(userId, matchId, matchSeatIds);
 		Preconditions.validate(holdInfos.size() == matchSeatIds.size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
 		List<OrderSheetGetResponse.SeatInfo> seatInfos = holdInfos.stream()
 				.map(hold -> {
 					Preconditions.validate(!hold.isExpired(now), ErrorCode.SEAT_HOLD_EXPIRED);
-					Integer adultPrice = seatInfoQueryService.findPrice(hold.sectionId(), dayType, "ADULT");
+					Integer adultPrice = seatInternalClient.findPrice(hold.sectionId(), dayType, "ADULT");
 					Preconditions.validate(adultPrice != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
 					return OrderSheetGetResponse.SeatInfo.of(hold, adultPrice);
 				})
@@ -95,16 +93,14 @@ public class OrderService {
 		cancelExistingPendingOrders(userId, request.matchId());
 		validateMaxTicketsPerMatch(userId, request.matchId(), request.matchSeatIds().size());
 
-		User user = userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND);
 		Match match = matchRepository.findDetailByIdOrThrow(request.matchId());
 
-		List<SeatHoldInfo> holdInfos = seatInfoQueryService.findSeatHoldInfos(userId, request.matchSeatIds());
+		List<SeatHoldInfo> holdInfos = seatInternalClient.findSeatHoldInfos(userId, request.matchId(), request.matchSeatIds());
 		Preconditions.validate(holdInfos.size() == request.matchSeatIds().size(), ErrorCode.SEAT_HOLD_NOT_FOUND);
 
 		Instant now = Instant.now();
 		String dayType = determineDayType(match.getMatchAt());
 
-		// 유효성 검증 + 좌석별 성인 기본가 조회 (order_seats 저장용)
 		List<OrderSeat> orderSeats = new ArrayList<>();
 		int totalSeatPrice = 0;
 		for (SeatHoldInfo hold : holdInfos) {
@@ -112,7 +108,7 @@ public class OrderService {
 			Preconditions.validate(!seatInfoQueryService.isAlreadyOrdered(hold.matchSeatId()),
 					ErrorCode.INVALID_ORDER_STATUS);
 
-			Integer adultPrice = seatInfoQueryService.findPrice(hold.sectionId(), dayType, "ADULT");
+			Integer adultPrice = seatInternalClient.findPrice(hold.sectionId(), dayType, "ADULT");
 			Preconditions.validate(adultPrice != null, ErrorCode.PRICE_POLICY_NOT_FOUND);
 			totalSeatPrice += adultPrice;
 
@@ -124,19 +120,28 @@ public class OrderService {
 					.seatNo(hold.seatNo())
 					.price(adultPrice)
 					.ticketType(TicketType.ADULT)
+					.sectionName(hold.sectionName())
+					.blockCode(hold.blockCode())
 					.build());
 		}
 		int serverCalculatedTotal = totalSeatPrice + BOOKING_FEE;
 		Preconditions.validate(serverCalculatedTotal == request.totalPrice(), ErrorCode.ORDER_TOTAL_PRICE_MISMATCH);
 
+		String matchTitle = match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName();
+
 		Order order = Order.builder()
-				.user(user)
-				.match(match)
+				.userId(userId)
+				.matchId(request.matchId())
 				.totalAmount(serverCalculatedTotal)
 				.ordererName(request.ordererName())
 				.ordererEmail(request.ordererEmail())
 				.ordererPhone(request.ordererPhone())
 				.ordererBirthDate(request.ordererBirthDate())
+				.matchTitle(matchTitle)
+				.matchDate(match.getMatchAt())
+				.stadiumName(match.getStadium().getKoName())
+				.homeClubName(match.getHomeClub().getKoName())
+				.awayClubName(match.getAwayClub().getKoName())
 				.build();
 
 		orderRepository.save(order);
@@ -150,14 +155,7 @@ public class OrderService {
 	}
 
 	/**
-	 * 같은 유저 + 같은 경기의 미결제 주문(PAYMENT_PENDING)을 자동 취소한다.
-	 * 이전 주문의 order_seats를 삭제하여 동일 좌석 재주문 시 unique constraint 위반을 방지한다.
-	 */
-	/**
 	 * 차단된 유저의 결제 완료(PAID) 및 입금 대기(PAYMENT_PENDING) 주문을 정밀 확인 중(UNDER_REVIEW)으로 일괄 변경한다.
-	 *
-	 * @param userId 차단 대상 유저 ID
-	 * @return 상태가 변경된 주문 건수
 	 */
 	public int markOrdersUnderReviewByBlockedUser(Long userId) {
 		List<OrderStatus> targetStatuses = List.of(OrderStatus.PAID, OrderStatus.PAYMENT_PENDING);
@@ -173,7 +171,6 @@ public class OrderService {
 
 	/**
 	 * 경기당 1인 최대 예매 수량(8매)을 초과하는지 검증한다.
-	 * 유효 주문(PAYMENT_PENDING, PAID, UNDER_REVIEW) 좌석 수 + 신규 좌석 수가 8을 초과하면 예외를 발생시킨다.
 	 */
 	private void validateMaxTicketsPerMatch(Long userId, Long matchId, int newSeatCount) {
 		long existingSeatCount = orderSeatRepository.countByUserIdAndMatchIdAndStatuses(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/event/PaymentEventPublisher.java
@@ -35,8 +35,8 @@ public class PaymentEventPublisher {
 		applicationEventPublisher.publishEvent(
 			new PaymentCompletedInternalEvent(
 				order.getId(),
-				order.getUser().getId(),
-				order.getMatch().getId(),
+				order.getUserId(),
+				order.getMatchId(),
 				matchSeatIds,
 				order.getTotalAmount(),
 				paymentMethod,
@@ -53,8 +53,8 @@ public class PaymentEventPublisher {
 		applicationEventPublisher.publishEvent(
 			new BankTransferExpiredInternalEvent(
 				order.getId(),
-				order.getUser().getId(),
-				order.getMatch().getId(),
+				order.getUserId(),
+				order.getMatchId(),
 				payment.getId(),
 				matchSeatIds,
 				Instant.now()

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -84,7 +84,7 @@ public class PaymentService {
 			);
 
 			if (request.paymentMethod() == PaymentMethod.BANK_TRANSFER) {
-				Instant matchDeadline = order.getMatch().getMatchAt().minus(MATCH_DAY_DEADLINE_BEFORE);
+				Instant matchDeadline = order.getMatchDate().minus(MATCH_DAY_DEADLINE_BEFORE);
 				Preconditions.validate(
 					clock.instant().isBefore(matchDeadline),
 					ErrorCode.BANK_TRANSFER_NOT_AVAILABLE
@@ -168,7 +168,7 @@ public class PaymentService {
 			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 		Preconditions.validate(
-			order.getUser().getId().equals(userId),
+			order.getUserId().equals(userId),
 			ErrorCode.ORDER_ACCESS_DENIED
 		);
 
@@ -177,7 +177,7 @@ public class PaymentService {
 
 	private Payment buildPayment(Order order, PaymentMethod method) {
 		if (method == PaymentMethod.BANK_TRANSFER) {
-			Instant depositDeadline = calculateDepositDeadline(order.getMatch().getMatchAt());
+			Instant depositDeadline = calculateDepositDeadline(order.getMatchDate());
 
 			return Payment.builder()
 				.order(order)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/entity/QrToken.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/qrtoken/entity/QrToken.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 
 import com.goormgb.be.global.entity.BaseEntity;
 import com.goormgb.be.ordercore.order.entity.Order;
-import com.goormgb.be.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -39,9 +38,8 @@ public class QrToken extends BaseEntity {
 	@JoinColumn(name = "order_id", nullable = false)
 	private Order order;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
 
 	@Column(name = "qr_token", nullable = false, unique = true, length = 512)
 	private String qrToken;
@@ -50,9 +48,9 @@ public class QrToken extends BaseEntity {
 	private Instant expiresAt;
 
 	@Builder
-	public QrToken(Order order, User user, String qrToken, Instant expiresAt) {
+	public QrToken(Order order, Long userId, String qrToken, Instant expiresAt) {
 		this.order = order;
-		this.user = user;
+		this.userId = userId;
 		this.qrToken = qrToken;
 		this.expiresAt = expiresAt;
 	}

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/order/OrderFixture.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/fixture/order/OrderFixture.java
@@ -111,13 +111,18 @@ public final class OrderFixture {
 
 	public static Order createOrder(User user, Match match) {
 		Order order = Order.builder()
-			.user(user)
-			.match(match)
+			.userId(user.getId())
+			.matchId(match.getId())
 			.totalAmount(24000)
 			.ordererName("홍길동")
 			.ordererEmail("hong@test.com")
 			.ordererPhone("010-1234-5678")
 			.ordererBirthDate("990831")
+			.matchTitle(match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName())
+			.matchDate(match.getMatchAt())
+			.stadiumName(match.getStadium().getKoName())
+			.homeClubName(match.getHomeClub().getKoName())
+			.awayClubName(match.getAwayClub().getKoName())
 			.build();
 		ReflectionTestUtils.setField(order, "id", 1L);
 		ReflectionTestUtils.setField(order, "createdAt", Instant.now());
@@ -126,13 +131,18 @@ public final class OrderFixture {
 
 	public static Order createOrderWithId(Long id, User user, Match match, int totalAmount) {
 		Order order = Order.builder()
-			.user(user)
-			.match(match)
+			.userId(user.getId())
+			.matchId(match.getId())
 			.totalAmount(totalAmount)
 			.ordererName("홍길동")
 			.ordererEmail("hong@test.com")
 			.ordererPhone("010-1234-5678")
 			.ordererBirthDate("990831")
+			.matchTitle(match.getHomeClub().getKoName() + " vs " + match.getAwayClub().getKoName())
+			.matchDate(match.getMatchAt())
+			.stadiumName(match.getStadium().getKoName())
+			.homeClubName(match.getHomeClub().getKoName())
+			.awayClubName(match.getAwayClub().getKoName())
 			.build();
 		ReflectionTestUtils.setField(order, "id", id);
 		ReflectionTestUtils.setField(order, "createdAt", Instant.now());

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageInquiryServiceTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
-import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.inquiry.entity.Inquiry;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryCategory;
 import com.goormgb.be.ordercore.inquiry.enums.InquiryStatus;
@@ -27,15 +26,11 @@ import com.goormgb.be.ordercore.mypage.dto.request.MyPageInquiryCreateRequest;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryCreateResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryDetailResponse;
 import com.goormgb.be.ordercore.mypage.dto.response.MyPageInquiryListResponse;
-import com.goormgb.be.user.entity.User;
-import com.goormgb.be.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MyPageInquiryService 서비스 단위 테스트")
 class MyPageInquiryServiceTest {
 
-	@Mock
-	private UserRepository userRepository;
 	@Mock
 	private InquiryRepository inquiryRepository;
 
@@ -44,7 +39,6 @@ class MyPageInquiryServiceTest {
 	@BeforeEach
 	void setUp() {
 		myPageInquiryService = new MyPageInquiryService(
-			userRepository,
 			inquiryRepository
 		);
 	}
@@ -56,8 +50,6 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("문의를 등록할 수 있다")
 		void createInquiry_성공() {
-			User user = OrderFixture.createUser();
-			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(inquiryRepository.save(any(Inquiry.class))).willAnswer(invocation -> {
 				Inquiry inquiry = invocation.getArgument(0);
 				ReflectionTestUtils.setField(inquiry, "id", 11L);
@@ -75,9 +67,6 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("카테고리가 잘못되면 예외가 발생한다")
 		void createInquiry_카테고리오류_예외() {
-			User user = OrderFixture.createUser();
-			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
-
 			assertThatThrownBy(() -> myPageInquiryService.createInquiry(
 				1L,
 				new MyPageInquiryCreateRequest("INVALID", "제목", "내용", null)
@@ -95,13 +84,11 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("문의 목록을 최신순으로 매핑해서 반환한다")
 		void getInquiries_성공() {
-			User user = OrderFixture.createUserWithId(1L);
-			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
-			Inquiry first = createInquiry(user, 20L, "가장 최근 문의");
+			Inquiry first = createInquiry(1L, 20L, "가장 최근 문의");
 			first.updateStatus(InquiryStatus.ANSWERED);
 			ReflectionTestUtils.setField(first, "createdAt", Instant.parse("2026-04-07T01:00:00Z"));
 
-			Inquiry second = createInquiry(user, 10L, "이전 문의");
+			Inquiry second = createInquiry(1L, 10L, "이전 문의");
 			ReflectionTestUtils.setField(second, "createdAt", Instant.parse("2026-04-06T01:00:00Z"));
 
 			given(inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
@@ -118,8 +105,6 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("문의가 없으면 빈 목록을 반환한다")
 		void getInquiries_빈목록() {
-			User user = OrderFixture.createUserWithId(1L);
-			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(inquiryRepository.findAllByUserIdOrderByCreatedAtDesc(1L))
 				.willReturn(List.of());
 
@@ -128,21 +113,9 @@ class MyPageInquiryServiceTest {
 			assertThat(response.inquiries()).isEmpty();
 		}
 
-		@Test
-		@DisplayName("사용자가 없으면 예외가 발생한다")
-		void getInquiries_사용자없음_예외() {
-			given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND))
-				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
-
-			assertThatThrownBy(() -> myPageInquiryService.getInquiries(1L))
-				.isInstanceOf(CustomException.class)
-				.satisfies(ex -> assertThat(((CustomException)ex).getErrorCode())
-					.isEqualTo(ErrorCode.USER_NOT_FOUND));
-		}
-
-		private Inquiry createInquiry(User user, Long inquiryId, String title) {
+		private Inquiry createInquiry(Long userId, Long inquiryId, String title) {
 			Inquiry inquiry = Inquiry.create(
-				user,
+				userId,
 				InquiryCategory.BOOKING,
 				title,
 				"내용",
@@ -160,8 +133,7 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("첨부파일이 없으면 downloadUrl 없이 조회된다")
 		void getInquiryDetail_첨부없음_성공() {
-			User user = OrderFixture.createUserWithId(1L);
-			Inquiry inquiry = createInquiry(user, 11L, null);
+			Inquiry inquiry = createInquiry(1L, 11L, null);
 			given(inquiryRepository.findById(11L)).willReturn(java.util.Optional.of(inquiry));
 
 			MyPageInquiryDetailResponse response = myPageInquiryService.getInquiryDetail(1L, 11L);
@@ -174,8 +146,7 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("첨부파일이 있어도 fileAttached=false, downloadUrl=null로 반환된다 (파일 업로드 비활성화)")
 		void getInquiryDetail_첨부있음_downloadUrl_null() {
-			User user = OrderFixture.createUserWithId(1L);
-			Inquiry inquiry = createInquiry(user, 12L, "dev/12/1/uuid.jpg");
+			Inquiry inquiry = createInquiry(1L, 12L, "dev/12/1/uuid.jpg");
 			given(inquiryRepository.findById(12L)).willReturn(java.util.Optional.of(inquiry));
 
 			MyPageInquiryDetailResponse response = myPageInquiryService.getInquiryDetail(1L, 12L);
@@ -199,8 +170,7 @@ class MyPageInquiryServiceTest {
 		@Test
 		@DisplayName("타인 문의면 예외가 발생한다")
 		void getInquiryDetail_권한없음_예외() {
-			User owner = OrderFixture.createUserWithId(2L);
-			Inquiry inquiry = createInquiry(owner, 13L, null);
+			Inquiry inquiry = createInquiry(2L, 13L, null);
 			given(inquiryRepository.findById(13L)).willReturn(java.util.Optional.of(inquiry));
 
 			assertThatThrownBy(() -> myPageInquiryService.getInquiryDetail(1L, 13L))
@@ -209,9 +179,9 @@ class MyPageInquiryServiceTest {
 					.isEqualTo(ErrorCode.INQUIRY_ACCESS_DENIED));
 		}
 
-		private Inquiry createInquiry(User user, Long inquiryId, String fileKey) {
+		private Inquiry createInquiry(Long userId, Long inquiryId, String fileKey) {
 			Inquiry inquiry = Inquiry.create(
-				user,
+				userId,
 				InquiryCategory.BOOKING,
 				"제목",
 				"내용",

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceConcurrencyTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageServiceConcurrencyTest.java
@@ -178,13 +178,18 @@ class MyPageServiceConcurrencyTest {
 			entityManager.persist(user);
 
 			Order order = Order.builder()
-				.user(user)
-				.match(match)
+				.userId(user.getId())
+				.matchId(match.getId())
 				.totalAmount(42000)
 				.ordererName("홍길동")
 				.ordererEmail("hong@test.com")
 				.ordererPhone("010-1234-5678")
 				.ordererBirthDate("990831")
+				.matchTitle(home.getKoName() + " vs " + away.getKoName())
+				.matchDate(match.getMatchAt())
+				.stadiumName(stadium.getKoName())
+				.homeClubName(home.getKoName())
+				.awayClubName(away.getKoName())
 				.build();
 			order.updateStatus(OrderStatus.PAID);
 			entityManager.persist(order);

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/entity/OrderEntityTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/entity/OrderEntityTest.java
@@ -8,23 +8,25 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
-import com.goormgb.be.user.entity.User;
 
 @DisplayName("Order 엔티티 단위 테스트")
 class OrderEntityTest {
 
 	private Order createTestOrder() {
-		User user = OrderFixture.createUser();
 		return Order.builder()
-			.user(user)
-			.match(OrderFixture.createWeekdayMatch())
+			.userId(1L)
+			.matchId(1L)
 			.totalAmount(24000)
 			.ordererName("홍길동")
 			.ordererEmail("hong@test.com")
 			.ordererPhone("010-1234-5678")
 			.ordererBirthDate("990831")
+			.matchTitle("LG 트윈스 vs 두산 베어스")
+			.matchDate(Instant.parse("2026-03-11T09:30:00Z"))
+			.stadiumName("잠실야구장")
+			.homeClubName("LG 트윈스")
+			.awayClubName("두산 베어스")
 			.build();
 	}
 

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/order/service/OrderServiceTest.java
@@ -25,6 +25,7 @@ import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.fixture.order.OrderFixture;
 import com.goormgb.be.ordercore.metrics.OrderMetricsService;
 import com.goormgb.be.ordercore.metrics.enums.OrderDraftEntryPoint;
+import com.goormgb.be.ordercore.order.client.SeatInternalClient;
 import com.goormgb.be.ordercore.order.dto.request.OrderCreateRequest;
 import com.goormgb.be.ordercore.order.dto.response.OrderCreateResponse;
 import com.goormgb.be.ordercore.order.dto.response.OrderSheetGetResponse;
@@ -34,8 +35,6 @@ import com.goormgb.be.ordercore.order.query.SeatHoldInfo;
 import com.goormgb.be.ordercore.order.query.SeatInfoQueryService;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.ordercore.order.repository.OrderSeatRepository;
-import com.goormgb.be.user.entity.User;
-import com.goormgb.be.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OrderService 서비스 단위 테스트")
@@ -44,11 +43,11 @@ class OrderServiceTest {
 	@Mock
 	private MatchRepository matchRepository;
 	@Mock
-	private UserRepository userRepository;
-	@Mock
 	private OrderRepository orderRepository;
 	@Mock
 	private OrderSeatRepository orderSeatRepository;
+	@Mock
+	private SeatInternalClient seatInternalClient;
 	@Mock
 	private SeatInfoQueryService seatInfoQueryService;
 	@Mock
@@ -59,8 +58,8 @@ class OrderServiceTest {
 	@BeforeEach
 	void setUp() {
 		orderService = new OrderService(
-			matchRepository, userRepository, orderRepository, orderSeatRepository, seatInfoQueryService,
-			orderMetricsService
+			matchRepository, orderRepository, orderSeatRepository, seatInternalClient,
+			seatInfoQueryService, orderMetricsService
 		);
 	}
 
@@ -78,8 +77,8 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 
 			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(holdInfo));
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, seatIds)).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 
 			OrderSheetGetResponse response = orderService.getOrderSheet(
 				userId, matchId, seatIds, OrderDraftEntryPoint.RECOMMEND
@@ -103,15 +102,15 @@ class OrderServiceTest {
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 
 			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(weekendMatch);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(holdInfo));
-			given(seatInfoQueryService.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, seatIds)).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
 
 			OrderSheetGetResponse response = orderService.getOrderSheet(
 				userId, matchId, seatIds, OrderDraftEntryPoint.RECOMMEND
 			);
 
 			assertThat(response.seats().get(0).adultPrice()).isEqualTo(24000);
-			then(seatInfoQueryService).should().findPrice(1L, "WEEKEND", "ADULT");
+			then(seatInternalClient).should().findPrice(1L, "WEEKEND", "ADULT");
 		}
 
 		@Test
@@ -129,8 +128,8 @@ class OrderServiceTest {
 			);
 
 			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, seatIds)).willReturn(List.of(hold1, hold2));
-			given(seatInfoQueryService.findPrice(eq(1L), eq("WEEKDAY"), eq("ADULT"))).willReturn(22000);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, seatIds)).willReturn(List.of(hold1, hold2));
+			given(seatInternalClient.findPrice(eq(1L), eq("WEEKDAY"), eq("ADULT"))).willReturn(22000);
 
 			OrderSheetGetResponse response = orderService.getOrderSheet(
 				userId, matchId, seatIds, OrderDraftEntryPoint.RECOMMEND
@@ -154,14 +153,15 @@ class OrderServiceTest {
 		@DisplayName("선점 정보가 누락된 경우 SEAT_HOLD_NOT_FOUND 예외가 발생한다")
 		void getOrderSheet_선점_미발견_예외() {
 			Long userId = 1L;
+			Long matchId = 1L;
 			Match match = OrderFixture.createWeekdayMatch();
-			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L, 102L)))
-				.willReturn(List.of(OrderFixture.createSeatHoldInfo(101L, userId))); // 1개만 반환
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, List.of(101L, 102L)))
+				.willReturn(List.of(OrderFixture.createSeatHoldInfo(101L, userId)));
 
 			assertThatThrownBy(
 				() -> orderService.getOrderSheet(
-					userId, 1L, List.of(101L, 102L), OrderDraftEntryPoint.RECOMMEND
+					userId, matchId, List.of(101L, 102L), OrderDraftEntryPoint.RECOMMEND
 				)
 			)
 				.isInstanceOf(CustomException.class)
@@ -172,14 +172,15 @@ class OrderServiceTest {
 		@DisplayName("선점이 만료된 경우 SEAT_HOLD_EXPIRED 예외가 발생한다")
 		void getOrderSheet_선점_만료_예외() {
 			Long userId = 1L;
+			Long matchId = 1L;
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo expiredHold = OrderFixture.createExpiredSeatHoldInfo(101L, userId);
 
-			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(expiredHold));
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, List.of(101L))).willReturn(List.of(expiredHold));
 
 			assertThatThrownBy(
-				() -> orderService.getOrderSheet(userId, 1L, List.of(101L), OrderDraftEntryPoint.RECOMMEND)
+				() -> orderService.getOrderSheet(userId, matchId, List.of(101L), OrderDraftEntryPoint.RECOMMEND)
 			)
 				.isInstanceOf(CustomException.class)
 				.hasMessage(ErrorCode.SEAT_HOLD_EXPIRED.getMessage());
@@ -189,15 +190,16 @@ class OrderServiceTest {
 		@DisplayName("가격 정책이 없는 경우 PRICE_POLICY_NOT_FOUND 예외가 발생한다")
 		void getOrderSheet_가격정책_미발견_예외() {
 			Long userId = 1L;
+			Long matchId = 1L;
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 
-			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
-			given(seatInfoQueryService.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
+			given(matchRepository.findDetailByIdOrThrow(matchId)).willReturn(match);
+			given(seatInternalClient.findSeatHoldInfos(userId, matchId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
 
 			assertThatThrownBy(
-				() -> orderService.getOrderSheet(userId, 1L, List.of(101L), OrderDraftEntryPoint.RECOMMEND)
+				() -> orderService.getOrderSheet(userId, matchId, List.of(101L), OrderDraftEntryPoint.RECOMMEND)
 			)
 				.isInstanceOf(CustomException.class)
 				.hasMessage(ErrorCode.PRICE_POLICY_NOT_FOUND.getMessage());
@@ -227,17 +229,15 @@ class OrderServiceTest {
 		@DisplayName("유효한 단일 좌석 주문 시 totalAmount = 티켓가격 + 2000이다")
 		void createOrder_단일좌석_totalAmount_계산() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 			stubSaveOrder(1L);
 
 			OrderCreateResponse response = orderService.createOrder(userId, request);
@@ -253,7 +253,6 @@ class OrderServiceTest {
 		@DisplayName("복수 좌석 주문 시 totalAmount = 모든 티켓 합산 + 2000이다")
 		void createOrder_복수좌석_totalAmount_계산() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo hold1 = OrderFixture.createSeatHoldInfo(101L, userId);
 			SeatHoldInfo hold2 = new SeatHoldInfo(
@@ -269,13 +268,12 @@ class OrderServiceTest {
 			);
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L, 102L)))
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L, 102L)))
 				.willReturn(List.of(hold1, hold2));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
 			given(seatInfoQueryService.isAlreadyOrdered(102L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 			stubSaveOrder(1L);
 
 			OrderCreateResponse response = orderService.createOrder(userId, request);
@@ -288,7 +286,6 @@ class OrderServiceTest {
 		@DisplayName("주말 경기 주문 시 WEEKEND 가격이 적용된다")
 		void createOrder_주말경기_WEEKEND가격_적용() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match weekendMatch = OrderFixture.createWeekendMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = new OrderCreateRequest(
@@ -299,33 +296,30 @@ class OrderServiceTest {
 			);
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(2L)).willReturn(weekendMatch);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 2L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
+			given(seatInternalClient.findPrice(1L, "WEEKEND", "ADULT")).willReturn(24000);
 			stubSaveOrder(1L);
 
 			orderService.createOrder(userId, request);
 
-			then(seatInfoQueryService).should().findPrice(1L, "WEEKEND", "ADULT");
+			then(seatInternalClient).should().findPrice(1L, "WEEKEND", "ADULT");
 		}
 
 		@Test
 		@DisplayName("OrderSeat이 모두 저장된다")
 		void createOrder_OrderSeat_저장() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 			stubSaveOrder(1L);
 
 			orderService.createOrder(userId, request);
@@ -337,7 +331,6 @@ class OrderServiceTest {
 		@DisplayName("요청 totalPrice가 서버 계산값과 다르면 ORDER_TOTAL_PRICE_MISMATCH 예외가 발생한다")
 		void createOrder_totalPrice_불일치_예외() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = new OrderCreateRequest(
@@ -348,11 +341,10 @@ class OrderServiceTest {
 			);
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
 				.isInstanceOf(CustomException.class)
@@ -377,32 +369,15 @@ class OrderServiceTest {
 		}
 
 		@Test
-		@DisplayName("사용자가 없으면 USER_NOT_FOUND 예외가 발생한다")
-		void createOrder_사용자_미발견_예외() {
-			Long userId = 999L;
-			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
-
-			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND))
-				.willThrow(new CustomException(ErrorCode.USER_NOT_FOUND));
-
-			assertThatThrownBy(() -> orderService.createOrder(userId, request))
-				.isInstanceOf(CustomException.class)
-				.hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
-		}
-
-		@Test
 		@DisplayName("선점 정보가 누락된 경우 SEAT_HOLD_NOT_FOUND 예외가 발생한다")
 		void createOrder_선점_미발견_예외() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(Collections.emptyList());
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(Collections.emptyList());
 
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
 				.isInstanceOf(CustomException.class)
@@ -413,15 +388,13 @@ class OrderServiceTest {
 		@DisplayName("선점이 만료된 경우 SEAT_HOLD_EXPIRED 예외가 발생한다")
 		void createOrder_선점_만료_예외() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo expiredHold = OrderFixture.createExpiredSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(expiredHold));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(expiredHold));
 
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
 				.isInstanceOf(CustomException.class)
@@ -432,15 +405,13 @@ class OrderServiceTest {
 		@DisplayName("이미 주문된 좌석이면 INVALID_ORDER_STATUS 예외가 발생한다")
 		void createOrder_이미_주문된_좌석_예외() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(true);
 
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
@@ -452,17 +423,15 @@ class OrderServiceTest {
 		@DisplayName("가격 정책이 없는 경우 PRICE_POLICY_NOT_FOUND 예외가 발생한다")
 		void createOrder_가격정책_미발견_예외() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
+			given(seatInternalClient.findPrice(anyLong(), anyString(), anyString())).willReturn(null);
 
 			assertThatThrownBy(() -> orderService.createOrder(userId, request))
 				.isInstanceOf(CustomException.class)
@@ -473,7 +442,6 @@ class OrderServiceTest {
 		@DisplayName("미결제 주문이 존재하면 벌크 취소 후 재주문에 성공한다")
 		void createOrder_미결제_주문_자동취소_후_재주문_성공() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
@@ -486,11 +454,10 @@ class OrderServiceTest {
 			given(orderRepository.bulkUpdateStatus(userId, 1L,
 				OrderStatus.PAYMENT_PENDING, OrderStatus.CANCELLED))
 				.willReturn(2);
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 			stubSaveOrder(1L);
 
 			OrderCreateResponse response = orderService.createOrder(userId, request);
@@ -504,17 +471,15 @@ class OrderServiceTest {
 		@DisplayName("미결제 주문이 없으면 취소 없이 바로 주문이 생성된다")
 		void createOrder_미결제_주문_없음_정상_생성() {
 			Long userId = 1L;
-			User user = OrderFixture.createUser();
 			Match match = OrderFixture.createWeekdayMatch();
 			SeatHoldInfo holdInfo = OrderFixture.createSeatHoldInfo(101L, userId);
 			OrderCreateRequest request = OrderFixture.createOrderCreateRequest();
 
 			stubNoPendingOrders();
-			given(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 			given(matchRepository.findDetailByIdOrThrow(1L)).willReturn(match);
-			given(seatInfoQueryService.findSeatHoldInfos(userId, List.of(101L))).willReturn(List.of(holdInfo));
+			given(seatInternalClient.findSeatHoldInfos(userId, 1L, List.of(101L))).willReturn(List.of(holdInfo));
 			given(seatInfoQueryService.isAlreadyOrdered(101L)).willReturn(false);
-			given(seatInfoQueryService.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
+			given(seatInternalClient.findPrice(1L, "WEEKDAY", "ADULT")).willReturn(22000);
 			stubSaveOrder(1L);
 
 			OrderCreateResponse response = orderService.createOrder(userId, request);

--- a/Seat/src/main/java/com/goormgb/be/seat/internal/controller/SeatInternalController.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/internal/controller/SeatInternalController.java
@@ -1,0 +1,63 @@
+package com.goormgb.be.seat.internal.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goormgb.be.seat.internal.dto.PriceResponse;
+import com.goormgb.be.seat.internal.dto.SeatHoldInfoResponse;
+import com.goormgb.be.seat.internal.dto.SectionBlockInfoResponse;
+import com.goormgb.be.seat.internal.service.SeatInternalService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Order-Core 모듈 전용 내부 API.
+ * DB 스키마 분리 시 Order-Core → Seat 직접 쿼리를 대체한다.
+ */
+@RestController
+@RequestMapping("/internal")
+@RequiredArgsConstructor
+public class SeatInternalController {
+
+	private final SeatInternalService seatInternalService;
+
+	/**
+	 * 좌석 선점 정보를 조회한다.
+	 */
+	@GetMapping("/seat-holds")
+	public ResponseEntity<List<SeatHoldInfoResponse>> getSeatHoldInfos(
+		@RequestParam Long userId,
+		@RequestParam Long matchId,
+		@RequestParam List<Long> matchSeatIds
+	) {
+		return ResponseEntity.ok(seatInternalService.findSeatHoldInfos(userId, matchId, matchSeatIds));
+	}
+
+	/**
+	 * 구역/요일/좌석유형 조합의 가격을 조회한다.
+	 */
+	@GetMapping("/price-policies")
+	public ResponseEntity<PriceResponse> getPrice(
+		@RequestParam Long sectionId,
+		@RequestParam String dayType,
+		@RequestParam String ticketType
+	) {
+		return ResponseEntity.ok(seatInternalService.findPrice(sectionId, dayType, ticketType));
+	}
+
+	/**
+	 * 구역/블럭 이름 정보를 조회한다.
+	 */
+	@GetMapping("/section-blocks")
+	public ResponseEntity<List<SectionBlockInfoResponse>> getSectionBlockInfos(
+		@RequestParam List<Long> sectionIds,
+		@RequestParam List<Long> blockIds
+	) {
+		return ResponseEntity.ok(seatInternalService.findSectionBlockInfos(sectionIds, blockIds));
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/internal/dto/PriceResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/internal/dto/PriceResponse.java
@@ -1,0 +1,6 @@
+package com.goormgb.be.seat.internal.dto;
+
+public record PriceResponse(
+	Integer price
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/internal/dto/SeatHoldInfoResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/internal/dto/SeatHoldInfoResponse.java
@@ -1,0 +1,17 @@
+package com.goormgb.be.seat.internal.dto;
+
+import java.time.Instant;
+
+public record SeatHoldInfoResponse(
+	Long holdId,
+	Long matchSeatId,
+	Long userId,
+	Instant expiresAt,
+	Long sectionId,
+	String sectionName,
+	Long blockId,
+	String blockCode,
+	Integer rowNo,
+	Integer seatNo
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/internal/dto/SectionBlockInfoResponse.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/internal/dto/SectionBlockInfoResponse.java
@@ -1,0 +1,9 @@
+package com.goormgb.be.seat.internal.dto;
+
+public record SectionBlockInfoResponse(
+	Long sectionId,
+	String sectionName,
+	Long blockId,
+	String blockCode
+) {
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/internal/service/SeatInternalService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/internal/service/SeatInternalService.java
@@ -1,0 +1,127 @@
+package com.goormgb.be.seat.internal.service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.ticket.enums.TicketType;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.internal.dto.PriceResponse;
+import com.goormgb.be.seat.internal.dto.SeatHoldInfoResponse;
+import com.goormgb.be.seat.internal.dto.SectionBlockInfoResponse;
+import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.pricePolicy.entity.PricePolicy;
+import com.goormgb.be.seat.pricePolicy.enums.DayType;
+import com.goormgb.be.seat.pricePolicy.repository.PricePolicyRepository;
+import com.goormgb.be.seat.seatHold.entity.SeatHold;
+import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
+import com.goormgb.be.seat.section.entity.Section;
+import com.goormgb.be.seat.section.repository.SectionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Order-Core 모듈에서 호출하는 내부 API용 서비스.
+ * DB 스키마 분리 시 Order-Core가 Seat DB를 직접 조회하지 않도록 중간 계층 역할을 한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeatInternalService {
+
+	private final SeatHoldRepository seatHoldRepository;
+	private final MatchSeatRepository matchSeatRepository;
+	private final PricePolicyRepository pricePolicyRepository;
+	private final SectionRepository sectionRepository;
+	private final BlockRepository blockRepository;
+
+	/**
+	 * matchSeatIds에 해당하는 좌석 선점 정보를 조회한다.
+	 */
+	public List<SeatHoldInfoResponse> findSeatHoldInfos(Long userId, Long matchId, List<Long> matchSeatIds) {
+		Instant now = Instant.now();
+		List<SeatHold> holds = seatHoldRepository.findAllByMatchIdAndMatchSeatIdInAndExpiresAtAfter(
+			matchId, matchSeatIds, now);
+
+		if (holds.isEmpty()) {
+			return List.of();
+		}
+
+		// matchSeatId → MatchSeat 매핑
+		List<MatchSeat> matchSeats = matchSeatRepository.findAllById(matchSeatIds);
+		Map<Long, MatchSeat> matchSeatMap = matchSeats.stream()
+			.collect(Collectors.toMap(MatchSeat::getId, Function.identity()));
+
+		// sectionId, blockId 수집
+		Set<Long> sectionIds = matchSeats.stream().map(MatchSeat::getSectionId).collect(Collectors.toSet());
+		Set<Long> blockIds = matchSeats.stream().map(MatchSeat::getBlockId).collect(Collectors.toSet());
+
+		Map<Long, Section> sectionMap = sectionRepository.findAllById(sectionIds).stream()
+			.collect(Collectors.toMap(Section::getId, Function.identity()));
+		Map<Long, Block> blockMap = blockRepository.findAllById(blockIds).stream()
+			.collect(Collectors.toMap(Block::getId, Function.identity()));
+
+		return holds.stream()
+			.filter(h -> h.getUserId().equals(userId))
+			.map(hold -> {
+				MatchSeat ms = matchSeatMap.get(hold.getMatchSeatId());
+				Section section = ms != null ? sectionMap.get(ms.getSectionId()) : null;
+				Block block = ms != null ? blockMap.get(ms.getBlockId()) : null;
+				return new SeatHoldInfoResponse(
+					hold.getId(),
+					hold.getMatchSeatId(),
+					hold.getUserId(),
+					hold.getExpiresAt(),
+					ms != null ? ms.getSectionId() : null,
+					section != null ? section.getName() : null,
+					ms != null ? ms.getBlockId() : null,
+					block != null ? block.getBlockCode() : null,
+					ms != null ? ms.getRowNo() : null,
+					ms != null ? ms.getSeatNo() : null
+				);
+			})
+			.toList();
+	}
+
+	/**
+	 * 구역/요일/좌석유형 조합에 해당하는 가격을 조회한다.
+	 */
+	public PriceResponse findPrice(Long sectionId, String dayType, String ticketType) {
+		DayType day = DayType.valueOf(dayType);
+		TicketType ticket = TicketType.valueOf(ticketType);
+
+		return pricePolicyRepository.findBySectionIdAndDayTypeAndTicketType(sectionId, day, ticket)
+			.map(pp -> new PriceResponse(pp.getPrice()))
+			.orElse(new PriceResponse(null));
+	}
+
+	/**
+	 * sectionId, blockId 목록에 대한 이름 정보를 반환한다.
+	 */
+	public List<SectionBlockInfoResponse> findSectionBlockInfos(List<Long> sectionIds, List<Long> blockIds) {
+		Map<Long, Section> sectionMap = sectionRepository.findAllById(sectionIds).stream()
+			.collect(Collectors.toMap(Section::getId, Function.identity()));
+		Map<Long, Block> blockMap = blockRepository.findAllById(blockIds).stream()
+			.collect(Collectors.toMap(Block::getId, Function.identity()));
+
+		return blockMap.values().stream()
+			.map(block -> {
+				Section section = sectionMap.get(block.getSection().getId());
+				return new SectionBlockInfoResponse(
+					section != null ? section.getId() : null,
+					section != null ? section.getName() : null,
+					block.getId(),
+					block.getBlockCode()
+				);
+			})
+			.toList();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/repository/PricePolicyRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/pricePolicy/repository/PricePolicyRepository.java
@@ -1,8 +1,14 @@
 package com.goormgb.be.seat.pricePolicy.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.goormgb.be.domain.ticket.enums.TicketType;
 import com.goormgb.be.seat.pricePolicy.entity.PricePolicy;
+import com.goormgb.be.seat.pricePolicy.enums.DayType;
 
 public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> {
+
+	Optional<PricePolicy> findBySectionIdAndDayTypeAndTicketType(Long sectionId, DayType dayType, TicketType ticketType);
 }


### PR DESCRIPTION
## 🔧 작업 내용
- Order-Core가 Seat DB 테이블을 직접 SQL 쿼리하던 구조를 Seat 내부 REST API 호출로 전환
- Order, QrToken, Inquiry 엔티티의 @ManyToOne 하드 FK를 Long ID 소프트 참조로 전환
- Order/OrderSeat에 비정규화 컬럼을 추가하여 Common/Seat DB 조회 없이 주문 정보 완결
- DB 스키마 분리(Phase 3) 시 즉시 장애를 유발하는 크로스 모듈 의존을 사전 제거

## 🧩 구현 상세
### Seat 내부 API 추가
- `SeatInternalController`: Order-Core 전용 내부 엔드포인트 3개 추가
  - `GET /internal/seat-holds` — 좌석 선점 정보 조회
  - `GET /internal/price-policies` — 구역/요일/좌석유형 가격 조회
  - `GET /internal/section-blocks` — 구역/블럭 이름 조회
- `SeatInternalService`: SeatHoldRepository, MatchSeatRepository, PricePolicyRepository 기반 조회
- 왜 Kafka가 아닌 REST API인가: 주문 생성 시 좌석 가격/정보가 **동기적으로** 필요하므로 Kafka Request-Reply보다 단순한 REST 선택

### Order-Core 하드 FK 제거
| 엔티티 | AS-IS | TO-BE |
|--------|-------|-------|
| Order | `@ManyToOne User user`, `@ManyToOne Match match` | `Long userId`, `Long matchId` |
| QrToken | `@ManyToOne User user` | `Long userId` |
| Inquiry | `@ManyToOne User user` | `Long userId` |

### 비정규화 컬럼 추가
| 엔티티 | 추가 컬럼 | 목적 |
|--------|----------|------|
| Order | userNickname, matchTitle, matchDate, stadiumName, homeClubName, awayClubName | 주문 생성 시점 경기/유저 스냅샷 |
| OrderSeat | sectionName, blockCode | 좌석 구역/블럭 스냅샷 |

### SeatInfoQueryService 정리
- **제거**: `findSeatHoldInfos`, `findPrice` → `SeatInternalClient`로 전환
- **제거**: `markSoldIfBlocked`, `markAvailableIfSold` → Kafka 이벤트(payment-completed, order-cancelled)로 이미 처리 중이라 중복 제거
- **유지**: `isAlreadyOrdered` — Order DB 자체 테이블만 조회

### 크로스 DB JOIN 제거
- `MyPageQueryService`: matches/clubs/stadiums/sections/blocks JOIN → 비정규화 컬럼 사용
- `EmailDataQueryService`: sections/blocks 직접 쿼리 + Match FETCH JOIN → 비정규화 컬럼 사용
- `OrderRepository`: JPQL `o.user.id`/`o.match.matchAt` → `o.userId`/`o.matchDate`, FETCH JOIN 제거

### 📌 관련 Jira Issue
- GRGB-356

## 🧪 테스트 방법
- 전 모듈 빌드 검증 완료: `./gradlew :Auth-Guard:build :Order-Core:build :Seat:build :Queue:build`
- 테스트 컴파일 검증 완료: `./gradlew :Order-Core:compileTestJava`
- 주요 검증 시나리오:
  - 주문 생성 → 비정규화 컬럼에 경기/유저 정보 저장 확인
  - 마이페이지 조회 → Common/Seat DB 조회 없이 비정규화 컬럼만으로 응답
  - 결제 완료 → Kafka 이벤트로 좌석 SOLD 전환 (기존과 동일)
  - 주문 취소 → Kafka 이벤트로 좌석 AVAILABLE 복원 (기존과 동일)

## ❗ 참고 사항
- **프론트엔드 수정 불필요**: 외부 API 요청/응답 구조 변경 없음
- **DB 마이그레이션 필요**: 배포 시 orders 테이블에 비정규화 6컬럼, order_seats 테이블에 2컬럼 ALTER TABLE 필요
- **기존 주문 백필 필요**: 기존 주문의 비정규화 컬럼은 NULL 상태이므로 마이그레이션 SQL로 일괄 백필 예정 (Phase 3)
- **후속 작업**: Phase 2 (Kafka 이벤트 추가 — user-created/updated, match-opened, seat-hold-created, match-sale-status-changed) →  Phase 3 (DataSource 분리 + DB 마이그레이션)
- **Seat 내부 API 보안**: `/internal/**` 경로는 API Gateway에서 외부 노출 차단 필요