### PR TITLE
feat(auth-guard): staging 프로필에 dev 회원가입/로그인 활성화 및 온보딩 자동 시딩

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/DevAuthController.java
@@ -28,8 +28,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Dev Auth", description = "개발용 인증 API (local/dev/test 프로필 전용)")
-@Profile({"local", "dev", "test"})
+@Tag(name = "Dev Auth", description = "개발용 인증 API (local/dev/test/staging 프로필 전용)")
+@Profile({"local", "dev", "test", "staging"})
 @RestController
 @RequestMapping("/dev/auth")
 @RequiredArgsConstructor

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/DevAuthService.java
@@ -2,7 +2,11 @@ package com.goormgb.be.authguard.auth.service;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -12,6 +16,16 @@ import com.goormgb.be.authguard.auth.dto.RefreshTokenInfo;
 import com.goormgb.be.authguard.jwt.config.JwtProperties;
 import com.goormgb.be.authguard.jwt.provider.JwtTokenProvider;
 import com.goormgb.be.authguard.jwt.repository.RefreshTokenRepository;
+import com.goormgb.be.domain.club.entity.Club;
+import com.goormgb.be.domain.club.repository.ClubRepository;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreferredBlock;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.enums.CheerProximityPref;
+import com.goormgb.be.domain.onboarding.enums.Viewpoint;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
@@ -31,6 +45,20 @@ import lombok.extern.slf4j.Slf4j;
 public class DevAuthService {
 
 	private static final String DEFAULT_AUTHORITY = "ROLE_USER";
+	private static final Viewpoint[] VIEWPOINTS = Viewpoint.values();
+	private static final List<Long> VALID_BLOCK_NUMS = List.of(
+			1L, 2L, 3L,
+			101L, 102L, 103L, 104L, 105L, 106L, 107L, 108L, 109L,
+			110L, 111L, 112L, 113L, 114L, 115L, 116L, 117L, 118L, 119L, 120L, 121L, 122L,
+			201L, 202L, 203L, 204L, 205L, 206L, 207L, 208L, 209L, 210L, 211L,
+			212L, 213L, 214L, 215L, 216L, 217L, 218L, 219L, 220L, 221L, 222L, 223L, 224L, 225L, 226L,
+			301L, 302L, 303L, 304L, 305L, 306L, 307L, 308L, 309L, 310L,
+			311L, 312L, 313L, 314L, 315L, 316L, 317L, 318L, 319L, 320L, 321L, 322L, 323L, 324L,
+			325L, 326L, 327L, 328L, 329L, 330L, 331L, 332L, 333L, 334L,
+			401L, 402L, 403L, 404L, 405L, 406L, 407L, 408L, 409L, 410L,
+			411L, 412L, 413L, 414L, 415L, 416L, 417L, 418L, 419L, 420L, 421L, 422L
+	);
+	private static final int PREFERRED_BLOCK_COUNT = 10;
 
 	private final UserRepository userRepository;
 	private final DevUserRepository devUserRepository;
@@ -38,7 +66,15 @@ public class DevAuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtProperties jwtProperties;
 	private final RefreshTokenRepository refreshTokenRepository;
+	private final ClubRepository clubRepository;
+	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
+	private final OnboardingPreferredBlockRepository onboardingPreferredBlockRepository;
+	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
 
+	/**
+	 * 개발용 회원가입 — 온보딩 정보(응원 구단·응원석·뷰포인트·선호 블록)를 자동 생성하여
+	 * 가입 즉시 서비스 이용이 가능하도록 처리한다.
+	 */
 	@Transactional
 	public void signup(String loginId, String password, String nickname, String email) {
 		if (devUserRepository.existsByLoginId(loginId)) {
@@ -58,7 +94,60 @@ public class DevAuthService {
 				.build();
 		devUserRepository.save(devUser);
 
-		log.info("Dev user created - loginId: {}, userId: {}", loginId, user.getId());
+		seedOnboarding(user);
+		user.completeOnboarding();
+		user.updateMarketingConsent(true);
+
+		log.info("Dev user created with onboarding - loginId: {}, userId: {}", loginId, user.getId());
+	}
+
+	/**
+	 * 온보딩 기본 데이터 자동 시딩:
+	 * - 응원 구단: 랜덤 선택
+	 * - 응원석 근접: 항상 NEAR (인접 선호)
+	 * - 뷰포인트 우선순위: 랜덤 3개
+	 * - 선호 블록: 유효 블록 중 랜덤 10개
+	 */
+	private void seedOnboarding(User user) {
+		List<Club> clubs = clubRepository.findAll();
+		if (clubs.isEmpty()) {
+			log.warn("클럽 데이터가 없어 온보딩 시딩을 건너뜁니다.");
+			return;
+		}
+
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+
+		// 응원 구단 랜덤 + 응원석 NEAR 고정
+		Club favoriteClub = clubs.get(random.nextInt(clubs.size()));
+		OnboardingPreference preference = OnboardingPreference.builder()
+				.user(user)
+				.favoriteClub(favoriteClub)
+				.cheerProximityPref(CheerProximityPref.NEAR)
+				.build();
+		onboardingPreferenceRepository.save(preference);
+
+		// 뷰포인트 우선순위: 랜덤 시작 인덱스로 3개 슬라이딩 윈도우
+		int startIdx = random.nextInt(VIEWPOINTS.length);
+		for (int p = 0; p < 3; p++) {
+			Viewpoint vp = VIEWPOINTS[(startIdx + p) % VIEWPOINTS.length];
+			OnboardingViewpointPriority priority = OnboardingViewpointPriority.builder()
+					.user(user)
+					.priority(p + 1)
+					.viewpoint(vp)
+					.build();
+			onboardingViewpointPriorityRepository.save(priority);
+		}
+
+		// 선호 블록: 랜덤 10개
+		List<Long> shuffledBlocks = new ArrayList<>(VALID_BLOCK_NUMS);
+		Collections.shuffle(shuffledBlocks, random);
+		for (int b = 0; b < PREFERRED_BLOCK_COUNT; b++) {
+			OnboardingPreferredBlock block = OnboardingPreferredBlock.builder()
+					.user(user)
+					.blockId(shuffledBlocks.get(b))
+					.build();
+			onboardingPreferredBlockRepository.save(block);
+		}
 	}
 
 	@Transactional


### PR DESCRIPTION
- DevAuthController @Profile에 staging 추가
- DevAuthService signup 시 온보딩 정보 자동 생성 (응원 구단, NEAR 응원석, 뷰포인트, 선호 블록 10개)
- AI 공격 방어 테스트용 계정 생성 지원

## 🔧 작업 내용
- AI 공격 방어 테스트를 위해 staging 환경에서 dev 회원가입/로그인 엔드포인트(/dev/auth/signup, /dev/auth/login) 활성화
 - dev 회원가입 시 온보딩 정보(응원 구단·응원석·뷰포인트·선호 블록)를 자동 생성하여 가입 즉시 서비스 이용 가능하도록 처리
- 기존 부하테스트 엔드포인트(/loadtest/*)는 인터널 키 필요 + 이름/이메일 커스텀 불가 → dev 엔드포인트로 AI팀이 자유롭게 계정 생성 가능
                                                                                                      
##  🧩 구현 상세
- DevAuthController @Profile에 "staging" 추가 — staging 프로필에서 빈 활성화
- DevAuthService.signup() — 회원가입 시 seedOnboarding() 호출 후 completeOnboarding() + updateMarketingConsent(true) 자동 처리
- 온보딩 시딩 상세: 
  - 응원 구단: DB 클럽 목록에서 랜덤 선택
  - 응원석 근접: NEAR (인접 선호) 고정
  - 뷰포인트 우선순위: 슬라이딩 윈도우로 랜덤 3개
  - 선호 블록: 전체 유효 블록(106개) 중 랜덤 10개

## 🧪 사용 방법
- staging 배포 후 curl로 검증:
# 회원가입
```
curl -X POST https://staging.playball.one/dev/auth/signup \
  -H "Content-Type: application/json" \
  -d '{"loginId":"attacker1","password":"test1234","nickname":"공격자1","email":"attacker1@test.com"}'
```
# 로그인
```
curl -X POST https://staging.playball.one/dev/auth/login \
  -H "Content-Type: application/json" \
  -d '{"loginId":"attacker1","password":"test1234"}'
```
- 로그인 응답에서 agreementRequired: false, onboardingRequired: false 확인
- accessToken으로 좌석 조회 등 서비스 API 정상 호출 확인

## ❗ 참고 사항
- /dev/auth/* 엔드포인트는 X-Internal-Api-Key 불필요 (부하테스트와 달리 인터널 키 없이 접근 가능)
- staging 전용이며 production 프로필에는 영향 없음 (@Profile 기반 빈 활성화)
- AI 방어서버에서 차단 요청 시 유저 IP는 RefreshTokenInfo에 이미 저장되어 있어 조회 가능