### PR TITLE
feat(auth-guard): /me 응답에 onboardingRequired 필드 추가

### DIFF
--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/UserControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/UserControllerTest.java
@@ -1,0 +1,81 @@
+package com.goormgb.be.authguard.auth.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.goormgb.be.authguard.support.WebMvcTestSupport;
+import com.goormgb.be.global.environment.ErrorResponseStrategy;
+import com.goormgb.be.user.dto.response.UserInfoGetResponse;
+import com.goormgb.be.user.enums.UserStatus;
+import com.goormgb.be.user.service.UserService;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("UserController 컨트롤러 테스트")
+class UserControllerTest extends WebMvcTestSupport {
+
+	@MockitoBean
+	private UserService userService;
+
+	@MockitoBean
+	private ErrorResponseStrategy errorResponseStrategy;
+
+	private void setAuthentication(Long userId) {
+		SecurityContextHolder.getContext().setAuthentication(
+			new UsernamePasswordAuthenticationToken(userId, null,
+				List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+	}
+
+	@Test
+	@DisplayName("GET /me - 온보딩 미완료 유저 조회 성공")
+	void 내_정보_조회_온보딩_미완료() throws Exception {
+		// given
+		Long userId = 1L;
+		setAuthentication(userId);
+
+		UserInfoGetResponse response = new UserInfoGetResponse(
+			userId, UserStatus.ACTIVATE, "user@example.com", "홍길동", true
+		);
+		given(userService.getMyInfo(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/me"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.data.id").value(1))
+			.andExpect(jsonPath("$.data.status").value("ACTIVATE"))
+			.andExpect(jsonPath("$.data.email").value("user@example.com"))
+			.andExpect(jsonPath("$.data.nickname").value("홍길동"))
+			.andExpect(jsonPath("$.data.onboardingRequired").value(true));
+	}
+
+	@Test
+	@DisplayName("GET /me - 온보딩 완료 유저 조회 성공")
+	void 내_정보_조회_온보딩_완료() throws Exception {
+		// given
+		Long userId = 2L;
+		setAuthentication(userId);
+
+		UserInfoGetResponse response = new UserInfoGetResponse(
+			userId, UserStatus.ACTIVATE, "user@example.com", "홍길동", false
+		);
+		given(userService.getMyInfo(userId)).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/me"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.onboardingRequired").value(false));
+	}
+}

--- a/common-core/src/main/java/com/goormgb/be/user/dto/response/UserInfoGetResponse.java
+++ b/common-core/src/main/java/com/goormgb/be/user/dto/response/UserInfoGetResponse.java
@@ -14,14 +14,17 @@ public record UserInfoGetResponse(
 	@Schema(description = "이메일", example = "user@example.com")
 	String email,
 	@Schema(description = "닉네임", example = "홍길동")
-	String nickname
+	String nickname,
+	@Schema(description = "온보딩 필요 여부", example = "true")
+	boolean onboardingRequired
 ) {
 	public static UserInfoGetResponse from(User user) {
 		return new UserInfoGetResponse(
 			user.getId(),
 			user.getStatus(),
 			user.getEmail(),
-			user.getNickname()
+			user.getNickname(),
+			!user.isCompletedOnboarding()
 		);
 	}
 }

--- a/common-core/src/test/java/com/goormgb/be/user/dto/response/UserInfoGetResponseTest.java
+++ b/common-core/src/test/java/com/goormgb/be/user/dto/response/UserInfoGetResponseTest.java
@@ -1,0 +1,44 @@
+package com.goormgb.be.user.dto.response;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.enums.UserStatus;
+import com.goormgb.be.user.fixture.UserFixture;
+
+@DisplayName("UserInfoGetResponse DTO 단위 테스트")
+class UserInfoGetResponseTest {
+
+	@Test
+	@DisplayName("온보딩 미완료 유저 → onboardingRequired = true")
+	void from_온보딩_미완료_유저() {
+		// given
+		User user = UserFixture.createWithId(1L);
+
+		// when
+		UserInfoGetResponse response = UserInfoGetResponse.from(user);
+
+		// then
+		assertThat(response.id()).isEqualTo(1L);
+		assertThat(response.status()).isEqualTo(UserStatus.ACTIVATE);
+		assertThat(response.email()).isEqualTo(UserFixture.DEFAULT_EMAIL);
+		assertThat(response.nickname()).isEqualTo(UserFixture.DEFAULT_NICKNAME);
+		assertThat(response.onboardingRequired()).isTrue();
+	}
+
+	@Test
+	@DisplayName("온보딩 완료 유저 → onboardingRequired = false")
+	void from_온보딩_완료_유저() {
+		// given
+		User user = UserFixture.createOnboardingCompleted();
+
+		// when
+		UserInfoGetResponse response = UserInfoGetResponse.from(user);
+
+		// then
+		assertThat(response.onboardingRequired()).isFalse();
+	}
+}

--- a/common-core/src/test/java/com/goormgb/be/user/service/UserServiceTest.java
+++ b/common-core/src/test/java/com/goormgb/be/user/service/UserServiceTest.java
@@ -10,6 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.user.dto.response.UserInfoGetResponse;
 import com.goormgb.be.user.entity.User;
@@ -46,7 +48,7 @@ class UserServiceTest {
 	void getMyInfo_온보딩_완료() {
 		// given
 		User user = UserFixture.createOnboardingCompleted();
-		org.springframework.test.util.ReflectionTestUtils.setField(user, "id", 2L);
+		ReflectionTestUtils.setField(user, "id", 2L);
 		given(userRepository.findByIdOrThrow(2L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
 
 		// when

--- a/common-core/src/test/java/com/goormgb/be/user/service/UserServiceTest.java
+++ b/common-core/src/test/java/com/goormgb/be/user/service/UserServiceTest.java
@@ -1,0 +1,58 @@
+package com.goormgb.be.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.user.dto.response.UserInfoGetResponse;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.fixture.UserFixture;
+import com.goormgb.be.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 단위 테스트")
+class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserService userService;
+
+	@Test
+	@DisplayName("getMyInfo - 온보딩 미완료 유저 조회 시 onboardingRequired = true")
+	void getMyInfo_온보딩_미완료() {
+		// given
+		User user = UserFixture.createWithId(1L);
+		given(userRepository.findByIdOrThrow(1L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+
+		// when
+		UserInfoGetResponse response = userService.getMyInfo(1L);
+
+		// then
+		assertThat(response.onboardingRequired()).isTrue();
+		assertThat(response.email()).isEqualTo(UserFixture.DEFAULT_EMAIL);
+	}
+
+	@Test
+	@DisplayName("getMyInfo - 온보딩 완료 유저 조회 시 onboardingRequired = false")
+	void getMyInfo_온보딩_완료() {
+		// given
+		User user = UserFixture.createOnboardingCompleted();
+		org.springframework.test.util.ReflectionTestUtils.setField(user, "id", 2L);
+		given(userRepository.findByIdOrThrow(2L, ErrorCode.USER_NOT_FOUND)).willReturn(user);
+
+		// when
+		UserInfoGetResponse response = userService.getMyInfo(2L);
+
+		// then
+		assertThat(response.onboardingRequired()).isFalse();
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용

 - GET /me 응답 DTO(UserInfoGetResponse)에 onboardingRequired (boolean) 필드 추가
- 프론트엔드에서 페이지 이동 시 상시 온보딩 여부를 체크할 수 있도록 지원
- 기존 GET /onboarding/status API는 그대로 유지

## 🧪 테스트 방법
- UserInfoGetResponseTest — DTO 변환 검증 (온보딩 완료/미완료)
- UserServiceTest — 서비스 단위 테스트 (Mockito)
- UserControllerTest — GET /me MockMvc 응답 JSON 검증

## ❗ 참고 사항
- 기존 응답 필드(id, status, email, nickname)에 onboardingRequired만 추가된 것이므로 하위 호환성 유지

cc. @806hyogi 