### PR TITLE
 fix: Redisson TLS 미적용으로 ElastiCache 연결 실패 수정

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
@@ -13,11 +13,13 @@ public class RedissonConfig {
 	@Bean(destroyMethod = "shutdown")
 	public RedissonClient redissonClient(
 		@Value("${spring.data.redis.host}") String host,
-		@Value("${spring.data.redis.port}") int port
+		@Value("${spring.data.redis.port}") int port,
+		@Value("${spring.data.redis.ssl.enabled:false}") boolean sslEnabled
 	) {
 		Config config = new Config();
+		String scheme = sslEnabled ? "rediss://" : "redis://";
 		config.useSingleServer()
-			.setAddress("redis://" + host + ":" + port);
+			.setAddress(scheme + host + ":" + port);
 		return Redisson.create(config);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
@@ -3,7 +3,7 @@ package com.goormgb.be.seat.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,15 +11,11 @@ import org.springframework.context.annotation.Configuration;
 public class RedissonConfig {
 
 	@Bean(destroyMethod = "shutdown")
-	public RedissonClient redissonClient(
-		@Value("${spring.data.redis.host}") String host,
-		@Value("${spring.data.redis.port}") int port,
-		@Value("${spring.data.redis.ssl.enabled:false}") boolean sslEnabled
-	) {
+	public RedissonClient redissonClient(RedisProperties redisProperties) {
 		Config config = new Config();
-		String scheme = sslEnabled ? "rediss://" : "redis://";
+		String scheme = redisProperties.getSsl().isEnabled() ? "rediss://" : "redis://";
 		config.useSingleServer()
-			.setAddress(scheme + host + ":" + port);
+			.setAddress(scheme + redisProperties.getHost() + ":" + redisProperties.getPort());
 		return Redisson.create(config);
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용                                                                                                             
   
  - RedissonConfig에서 Redis 연결 시 `redis://` 스킴이 하드코딩되어 있어                                                      
    TLS가 활성화된 ElastiCache에 연결 실패하는 문제 수정    
  - `spring.data.redis.ssl.enabled` 값에 따라 `rediss://` (TLS) / `redis://` 분기 처리                                        
  - staging/prod 환경에서 Seat Pod가 Redisson 연결 실패로 CrashLoopBackOff 발생                                               
                                                                                                                              
  ## 🧩 구현 상세                                                                                                             
                                                                                                                              
  - `RedissonConfig.java`에 `@Value("${spring.data.redis.ssl.enabled:false}")` 파라미터 추가                                  
  - sslEnabled=true → `rediss://` (TLS), false → `redis://` (평문)
  - 기존 Spring Data Redis는 `SPRING_DATA_REDIS_SSL_ENABLED=true`로 정상 동작했으나,                                          
    Redisson은 별도 설정이라 스킴 레벨에서 TLS를 지정해야 함                                                                  
  - 기본값 false로 설정하여 로컬/dev 환경 호환성 유지                                                                         
                                                                                                                              
  ## 🧪 테스트 방법                                                                                                           
                                                                                                                              
  - staging 환경 배포 후 Seat Pod 정상 기동 확인                                                                              
  - `kubectl logs -f deploy/seat -n staging-webs` 에서 Redisson 연결 성공 로그 확인
  - SeatHoldCleanupScheduler 정상 동작 확인 (이전 HikariPool 고갈 에러 재발 여부)                                             
                                                                                                                              
  ## ❗ 참고 사항                                                                                                             
                                                                                                                              
  - ElastiCache `redis_tls: true` 설정은 Terraform에서 이미 적용되어 있었음                                                   
  - 동일 패턴이 다른 서비스(order-core 등)에도 있는지 확인 필요
  - 배포 시 Seat Pod 롤링 재시작 발생 (Kafka, Redis 의존성 순서 주의)             