### PR TITLE
fix(seat): RedissonConfig Spring Boot 4 호환 (RedisProperties → DataRedisProperties 전환)

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/RedissonConfig.java
@@ -3,7 +3,7 @@ package com.goormgb.be.seat.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class RedissonConfig {
 
 	@Bean(destroyMethod = "shutdown")
-	public RedissonClient redissonClient(RedisProperties redisProperties) {
+	public RedissonClient redissonClient(DataRedisProperties redisProperties) {
 		Config config = new Config();
 		String scheme = redisProperties.getSsl().isEnabled() ? "rediss://" : "redis://";
 		config.useSingleServer()


### PR DESCRIPTION
## 🔧 작업 내용
- Spring Boot 4에서 RedisProperties 클래스가 DataRedisProperties로  이름·패키지 변경되어 Seat 모듈 컴파일 실패하는 문제 수정           
- org.springframework.boot.autoconfigure.data.redis.RedisProperties → org.springframework.boot.data.redis.autoconfigure.DataRedisProperties로 전환

## 🧩 구현 상세 (선택)

- Spring Boot 4(4.0.2)에서 Redis autoconfiguration 모듈이 spring-boot-data-redis로 분리되면서 클래스명이 변경됨
- API(getHost(), getPort(), getSsl().isEnabled())는 동일하므로 import와 타입명만 교체
