### PR TITLE
fix(seat): HikariCP 커넥션 풀 20 설정 및 OSIV 비활성화 누락 적용

### DIFF
--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ spring:
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 20
-      minimum-idle: 5
+      minimum-idle: 20
       connection-timeout: 30000
       leak-detection-threshold: 10000
 

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -15,8 +15,14 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000
+      leak-detection-threshold: 10000
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     show-sql: false


### PR DESCRIPTION
- hikari maximum-pool-size: 20, minimum-idle: 5, leak-detection 설정 추가
- open-in-view: false 적용

## 🔧 작업 내용
 staging 환경에서 Seat 서비스 HikariCP 커넥션 풀 고갈 사항으로인한 조치
- 프론트엔드에서 POST /seat/matches/71/booking-options 504 Gateway Timeout 발생 확인

##  🧩 구현 상세
- hikari.maximum-pool-size: 20으로 증가
- hikari.minimum-idle: 5 설정
- hikari.leak-detection-threshold: 10000ms (10초 이상 점유 시 경고 로그)
- spring.jpa.open-in-view: false 적용 — OSIV가 true(기본값)로  남아있어 HTTP 요청 종료 시점까지 커넥션을 점유하고 있었음

##  🧪 테스트 방법
- staging 배포 후 kubectl logs -f deploy/seat -n staging-webs에서 HikariPool 로그 확인
- total=20 으로 변경되었는지 확인
- leak-detection 경고 발생 여부 모니터링
- 동시 요청 시 504 Gateway Timeout 재발 여부 확인

## ❗ 참고 사항
- OSIV 비활성화로 인해 Controller 레이어에서 Lazy Loading 사용 시 LazyInitializationException 발생 가능 — 현재 Seat 서비스에서는 해당 패턴 없음 확인 완료