### PR TITLE
hotfix(seat): PreQueue Redis TLS 미적용으로 booking-options 504 Timeout 수정

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/config/PreQueueRedisConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/PreQueueRedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -16,25 +17,30 @@ public class PreQueueRedisConfig {
 	@Value("${prequeue.redis.port:${REDIS_QUEUE_PORT}}")
 	private int port;
 
+	@Value("${spring.data.redis.ssl.enabled:false}")
+	private boolean sslEnabled;
+
 	/**
 	 * PreQueue 전용 StringRedisTemplate 설정
-	 * * [참고]
-	 * LettuceConnectionFactory를 @Bean으로 등록하지 않고 내부에서 직접 생성합니다.
+	 *
+	 * <p>LettuceConnectionFactory를 @Bean으로 등록하지 않고 내부에서 직접 생성합니다.
 	 * 이 방식은 Spring Boot의 RedisAutoConfiguration(기본 Redis 설정)을 방해하지 않으면서
-	 * 특정 목적(PreQueue)을 위한 별도의 Redis 연결을 생성할 때 가장 안전한 방법입니다.
+	 * 특정 목적(PreQueue)을 위한 별도의 Redis 연결을 생성할 때 가장 안전한 방법입니다.</p>
 	 */
 	@Bean(name = "preQueueStringRedisTemplate")
 	public StringRedisTemplate preQueueStringRedisTemplate() {
-		// 1. PreQueue 전용 Standalone 설정 생성
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
 
-		// 2. ConnectionFactory를 Bean이 아닌 일반 객체로 생성
-		LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+		LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder =
+			LettuceClientConfiguration.builder();
 
-		// 3. (중요) Bean 관리 대상이 아니므로 수동으로 초기화 메서드를 호출해야 연결이 활성화됩니다.
+		if (sslEnabled) {
+			clientConfigBuilder.useSsl().disablePeerVerification();
+		}
+
+		LettuceConnectionFactory factory = new LettuceConnectionFactory(config, clientConfigBuilder.build());
 		factory.afterPropertiesSet();
 
-		// 4. 생성된 전용 Factory를 주입한 템플릿 반환
 		return new StringRedisTemplate(factory);
 	}
 }


### PR DESCRIPTION
## 🔧 작업 내용

- Seat에서 Queue Redis(PreQueue 마커)에 연결 시 TLS 설정 누락으로 staging에서 booking-options 504 Timeout 발생
- PreQueueRedisConfig의 수동 LettuceConnectionFactory 생성 시 ssl.enabled 분기 처리 추가 

## 🧩 구현 상세 (선택)

- spring.data.redis.ssl.enabled 값에 따라 TLS 적용 여부 분기
- 기본값 false로 local/dev 환경 호환성 유지
- Redisson TLS 이슈(#275)와 동일 패턴 — 수동 생성 ConnectionFactory에 TLS 누락

### 📌 관련 Jira Issue

- GRGB-XX

## 🧪 테스트 방법(선택)

- staging 배포 후 POST /seat/matches/{matchId}/booking-options 정상 응답 확인
- 이후 POST /queue/matches/{matchId}/enter 대기열 진입 정상 확인

## ❗ 참고 사항

- 리뷰 시 유의할 점
- 후속 작업 예정
- 배포 시 주의 사항
