### PR TITLE
hotfix(order-core): 8매 초과 시 에러 메시지 미노출 수정 [GRGB-366]

### DIFF
--- a/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
@@ -81,7 +81,7 @@ public class AbstractErrorResponseStrategy implements ErrorResponseStrategy {
 				 MATCH_SEAT_NOT_FOUND, SEAT_HOLD_NOT_FOUND, QUEUE_ENTRY_NOT_FOUND,
 
 				 USER_ALREADY_EXISTS, USER_ALREADY_BLOCKED, USER_ALREADY_ACTIVE,
-				 USER_NOT_FOUND, EXCEEDED_MAX_TICKETS_PER_MATCH -> errorCode.getMessage();
+				 USER_NOT_FOUND, EXCEEDED_MAX_TICKETS_PER_MATCH, ORDER_TOTAL_PRICE_MISMATCH -> errorCode.getMessage();
 
 			default -> switch (errorCode.getStatus().series()) {
 				case SERVER_ERROR -> "서버 통신에 일시적 오류가 발생했습니다.";

--- a/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
+++ b/common-core/src/main/java/com/goormgb/be/global/environment/AbstractErrorResponseStrategy.java
@@ -81,7 +81,7 @@ public class AbstractErrorResponseStrategy implements ErrorResponseStrategy {
 				 MATCH_SEAT_NOT_FOUND, SEAT_HOLD_NOT_FOUND, QUEUE_ENTRY_NOT_FOUND,
 
 				 USER_ALREADY_EXISTS, USER_ALREADY_BLOCKED, USER_ALREADY_ACTIVE,
-				 USER_NOT_FOUND -> errorCode.getMessage();
+				 USER_NOT_FOUND, EXCEEDED_MAX_TICKETS_PER_MATCH -> errorCode.getMessage();
 
 			default -> switch (errorCode.getStatus().series()) {
 				case SERVER_ERROR -> "서버 통신에 일시적 오류가 발생했습니다.";


### PR DESCRIPTION
## 🔧 작업 내용
- staging/prod 환경에서 경기당 8매 초과 예매 시도 시 `"요청을 처리할 수 없습니다."` 라는 의미 없는 메시지가 내려가던 버그 수정
- `AbstractErrorResponseStrategy`의 switch 케이스에 `EXCEEDED_MAX_TICKETS_PER_MATCH`가 누락되어 default 분기로 떨어지던 문제
- 수정 후 `"경기당 최대 8매까지만 예매 가능합니다."` 메시지가 클라이언트에 정상 노출됨

## 🧩 구현 상세
### 문제 원인
`AbstractErrorResponseStrategy.resolveMessage()`는 staging/prod 환경에서 `ErrorCode` → 노출 메시지를 결정하는 switch 문을 가진다.
`EXCEEDED_MAX_TICKETS_PER_MATCH`가 어떤 case에도 포함되지 않아 default 분기인 `"요청을 처리할 수 없습니다."`가 반환되고 있었다.

```
// Before
default -> "요청을 처리할 수 없습니다.";   // EXCEEDED_MAX_TICKETS_PER_MATCH 도 여기로 떨어짐

// After
EXCEEDED_MAX_TICKETS_PER_MATCH -> errorCode.getMessage();  // "경기당 최대 8매까지만 예매 가능합니다."
```

### 📌 관련 Jira Issue
- GRGB-366

## 🧪 테스트 방법
1. staging 환경에서 동일 경기에 이미 2매 결제 완료 상태인 유저로 로그인
2. 해당 경기 좌석 7매 이상 선택 후 주문 생성 API 호출
3. 응답 확인
```
"code": "CLIENT_ERROR"
"message": "경기당 최대 8매까지만 예매 가능합니다."
```

## ❗ 참고 사항
- `AbstractErrorResponseStrategy`는 staging/prod 프로파일에서만 활성화됨 (local/dev는 `DetailedErrorResponseStrategy` 사용)
- 본 수정은 메시지 노출 로직만 변경하며 실제 검증 로직(Order-Core DB 기반)에는 영향 없음
- 이후 PR(GRGB-368)에서 Hold 단계 사전 검증이 추가되어 에러 자체가 더 앞단에서 발생하게 됨