### PR TITLE
feat(seat): Kafka 이벤트 기반 유저별 경기 구매 좌석 수 Redis 캐싱 추가 [GRGB-367]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -11,6 +11,7 @@ import com.goormgb.be.kafka.event.BankTransferExpiredEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.matchSeat.repository.UserPurchasedSeatCountRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BankTransferExpiredEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final UserPurchasedSeatCountRepository userPurchasedSeatCountRepository;
 
 	@KafkaListener(topics = EventTopic.BANK_TRANSFER_EXPIRED, groupId = "seat-service")
 	@Transactional
@@ -62,5 +64,11 @@ public class BankTransferExpiredEventConsumer {
 			unexpectedStateCount,
 			missingSeatCount
 		);
+
+		// 구매 완료 좌석 수 Redis 카운터 갱신 (SOLD → AVAILABLE 복원된 수만큼 감소)
+		// PaymentCompletedEvent 발행 시 카운터가 증가했으므로, 만료 시 반드시 감소해야 한다
+		if (updatedCount > 0) {
+			userPurchasedSeatCountRepository.decrement(event.getUserId(), event.getMatchId(), updatedCount);
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
@@ -11,6 +11,7 @@ import com.goormgb.be.kafka.event.OrderCancelledEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.matchSeat.repository.UserPurchasedSeatCountRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderCancelledEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final UserPurchasedSeatCountRepository userPurchasedSeatCountRepository;
 
 	@KafkaListener(topics = EventTopic.ORDER_CANCELLED, groupId = "seat-service")
 	@Transactional
@@ -36,27 +38,35 @@ public class OrderCancelledEventConsumer {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				seat.markAvailable();
 				updatedCount++;
-					log.debug("[Kafka] 주문취소 좌석복원 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
+				log.debug(
+						"[Kafka] 주문취소 경기장 좌석복원 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=AVAILABLE",
 						event.getOrderId(), seat.getId(), MatchSeatSaleStatus.SOLD);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE) {
 				alreadyTargetStateCount++;
-					log.debug("[Kafka] 주문취소 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
+				log.debug(
+						"[Kafka] 주문취소 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_available",
 						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			} else {
 				unexpectedStateCount++;
-					log.warn("[Kafka] 주문취소 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+				log.warn(
+						"[Kafka] 주문취소 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
 						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 
 		log.info(
-			"[Kafka] 주문 취소 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
-			event.getOrderId(),
-			requestedIds.size(),
-			updatedCount,
-			alreadyTargetStateCount,
-			unexpectedStateCount,
-			missingSeatCount
+				"[Kafka] 주문 취소 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
+				event.getOrderId(),
+				requestedIds.size(),
+				updatedCount,
+				alreadyTargetStateCount,
+				unexpectedStateCount,
+				missingSeatCount
 		);
+
+		// 구매 완료 좌석 수 Redis 카운터 갱신 (SOLD → AVAILABLE 복원된 수만큼 감소)
+		if (updatedCount > 0) {
+			userPurchasedSeatCountRepository.decrement(event.getUserId(), event.getMatchId(), updatedCount);
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -11,6 +11,7 @@ import com.goormgb.be.kafka.event.PaymentCompletedEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.matchSeat.repository.UserPurchasedSeatCountRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentCompletedEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final UserPurchasedSeatCountRepository userPurchasedSeatCountRepository;
 
 	@KafkaListener(topics = EventTopic.PAYMENT_COMPLETED, groupId = "seat-service")
 	@Transactional
@@ -36,27 +38,35 @@ public class PaymentCompletedEventConsumer {
 			if (seat.getSaleStatus() == MatchSeatSaleStatus.BLOCKED) {
 				seat.markSold();
 				updatedCount++;
-					log.debug("[Kafka] 결제완료 좌석상태변경 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=SOLD",
+				log.debug(
+						"[Kafka] 결제완료 경기 좌석상태변경 - orderId={}, matchSeatId={}, currentStatus={}, action=update, targetStatus=SOLD",
 						event.getOrderId(), seat.getId(), MatchSeatSaleStatus.BLOCKED);
 			} else if (seat.getSaleStatus() == MatchSeatSaleStatus.SOLD) {
 				alreadyTargetStateCount++;
-					log.debug("[Kafka] 결제완료 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_sold",
+				log.debug(
+						"[Kafka] 결제완료 처리스킵 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=already_sold",
 						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			} else {
 				unexpectedStateCount++;
-					log.warn("[Kafka] 결제완료 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
+				log.warn(
+						"[Kafka] 결제완료 비정상상태 - orderId={}, matchSeatId={}, currentStatus={}, action=skip, reason=unexpected_state",
 						event.getOrderId(), seat.getId(), seat.getSaleStatus());
 			}
 		}
 
 		log.info(
-			"[Kafka] 결제 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
-			event.getOrderId(),
-			requestedIds.size(),
-			updatedCount,
-			alreadyTargetStateCount,
-			unexpectedStateCount,
-			missingSeatCount
+				"[Kafka] 결제 이벤트 처리 요약: orderId={}, requestedCount={}, updatedCount={}, alreadyTargetStateCount={}, unexpectedStateCount={}, missingSeatCount={}",
+				event.getOrderId(),
+				requestedIds.size(),
+				updatedCount,
+				alreadyTargetStateCount,
+				unexpectedStateCount,
+				missingSeatCount
 		);
+
+		// 구매 완료 좌석 수 Redis 카운터 갱신
+		if (updatedCount > 0) {
+			userPurchasedSeatCountRepository.increment(event.getUserId(), event.getMatchId(), updatedCount);
+		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/UserPurchasedSeatCountRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/UserPurchasedSeatCountRepository.java
@@ -1,0 +1,116 @@
+package com.goormgb.be.seat.matchSeat.repository;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 사용자별 경기당 구매 완료 좌석 수를 Redis에 캐싱하는 Repository.
+ *
+ * <p>Kafka 이벤트(결제완료/주문취소)를 통해 카운터를 동기화하며,
+ * Seat 서비스의 Hold 단계에서 최대 예매 수량(8매) 초과 여부를 사전 검증할 때 사용된다.</p>
+ *
+ * <h3>Redis Key</h3>
+ * <pre>purchased:{userId}:{matchId}</pre>
+ *
+ * <h3>TTL</h3>
+ * <p>90일 — 경기 종료 후 자동 만료</p>
+ *
+ * <h3>일관성 보장 수준</h3>
+ * <p>Kafka at-least-once 특성으로 중복 처리될 수 있으나,
+ * Order-Core의 DB 기반 검증이 최종 방어선이므로 허용 가능한 수준의 오차.</p>
+ * <p>Redis 장애 시 {@code get()}은 0을 반환하여 fail-open 처리한다.</p>
+ */
+@Slf4j
+@Repository
+public class UserPurchasedSeatCountRepository {
+
+	private static final String KEY_PREFIX = "purchased:";
+	private static final Duration TTL = Duration.ofDays(90);
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	public UserPurchasedSeatCountRepository(
+			@Qualifier("stringRedisTemplate") StringRedisTemplate stringRedisTemplate
+	) {
+		this.stringRedisTemplate = stringRedisTemplate;
+	}
+
+	/**
+	 * 해당 유저의 해당 경기 구매 완료 좌석 수를 반환한다.
+	 *
+	 * <p>키가 없거나 Redis 장애 시 0L을 반환한다.</p>
+	 *
+	 * @param userId  사용자 ID
+	 * @param matchId 경기 ID
+	 * @return 구매 완료 좌석 수 (0 이상)
+	 */
+	public long get(Long userId, Long matchId) {
+		try {
+			String value = stringRedisTemplate.opsForValue().get(key(userId, matchId));
+			return value == null ? 0L : Long.parseLong(value);
+		} catch (Exception e) {
+			log.warn("[PurchasedSeatCount 경기 구매 완료 좌석 수] Redis 조회 실패 — fail-open으로 0 반환: userId={}, matchId={}",
+					userId, matchId, e);
+			return 0L;
+		}
+	}
+
+	/**
+	 * 구매 완료 좌석 수를 증가시킨다.
+	 *
+	 * <p>결제 완료(PaymentCompletedEvent) 시 호출한다.</p>
+	 *
+	 * @param userId  사용자 ID
+	 * @param matchId 경기 ID
+	 * @param count   증가할 좌석 수
+	 */
+	public void increment(Long userId, Long matchId, int count) {
+		try {
+			String key = key(userId, matchId);
+			stringRedisTemplate.opsForValue().increment(key, count);
+			stringRedisTemplate.expire(key, TTL);
+			log.debug("[PurchasedSeatCount 경기 구매 완료 좌석 수] 증가: userId={}, matchId={}, count={}", userId, matchId, count);
+		} catch (Exception e) {
+			log.warn("[PurchasedSeatCount 경기 구매 완료 좌석 수] Redis 증가 실패: userId={}, matchId={}, count={}", userId, matchId,
+					count, e);
+		}
+	}
+
+	/**
+	 * 구매 완료 좌석 수를 감소시킨다.
+	 *
+	 * <p>주문 취소(OrderCancelledEvent) 시 호출한다.
+	 * 감소 결과가 음수가 되면 0으로 보정한다.</p>
+	 *
+	 * @param userId  사용자 ID
+	 * @param matchId 경기 ID
+	 * @param count   감소할 좌석 수
+	 */
+	public void decrement(Long userId, Long matchId, int count) {
+		try {
+			String key = key(userId, matchId);
+			Long result = stringRedisTemplate.opsForValue().decrement(key, count);
+			if (result != null && result < 0) {
+				stringRedisTemplate.opsForValue().set(key, "0", TTL);
+				log.debug("[PurchasedSeatCount 경기 구매 완료 좌석 수] 감소 후 음수 보정 → 0: userId={}, matchId={}", userId, matchId);
+			} else if (result != null) {
+				stringRedisTemplate.expire(key, TTL);
+				log.debug("[PurchasedSeatCount 경기 구매 완료 좌석 수] 감소: userId={}, matchId={}, count={}, result={}", userId,
+						matchId, count,
+						result);
+			}
+		} catch (Exception e) {
+			log.warn("[PurchasedSeatCount 경기 구매 완료 좌석 수] Redis 감소 실패: userId={}, matchId={}, count={}", userId, matchId,
+					count, e);
+		}
+	}
+
+	private String key(Long userId, Long matchId) {
+		return KEY_PREFIX + userId + ":" + matchId;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/UserPurchasedSeatCountRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/UserPurchasedSeatCountRepository.java
@@ -11,14 +11,15 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * 사용자별 경기당 구매 완료 좌석 수를 Redis에 캐싱하는 Repository.
  *
- * <p>Kafka 이벤트(결제완료/주문취소)를 통해 카운터를 동기화하며,
+ * <p>Kafka 이벤트(결제완료/주문취소/무통장만료)를 통해 카운터를 동기화하며,
  * Seat 서비스의 Hold 단계에서 최대 예매 수량(8매) 초과 여부를 사전 검증할 때 사용된다.</p>
  *
  * <h3>Redis Key</h3>
  * <pre>purchased:{userId}:{matchId}</pre>
  *
  * <h3>TTL</h3>
- * <p>90일 — 경기 종료 후 자동 만료</p>
+ * <p>7일 — 예매 오픈은 경기 7일 전 오전 11시이므로 구매 후 최대 7일 이내에 경기가 시작된다.
+ * 경기 시작 후에는 Hold 자체가 불가능하므로 카운터를 읽을 일이 없다.</p>
  *
  * <h3>일관성 보장 수준</h3>
  * <p>Kafka at-least-once 특성으로 중복 처리될 수 있으나,
@@ -30,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserPurchasedSeatCountRepository {
 
 	private static final String KEY_PREFIX = "purchased:";
-	private static final Duration TTL = Duration.ofDays(90);
+	private static final Duration TTL = Duration.ofDays(7);
 
 	private final StringRedisTemplate stringRedisTemplate;
 
@@ -84,7 +85,7 @@ public class UserPurchasedSeatCountRepository {
 	/**
 	 * 구매 완료 좌석 수를 감소시킨다.
 	 *
-	 * <p>주문 취소(OrderCancelledEvent) 시 호출한다.
+	 * <p>주문 취소(OrderCancelledEvent) 또는 무통장 만료(BankTransferExpiredEvent) 시 호출한다.
 	 * 감소 결과가 음수가 되면 0으로 보정한다.</p>
 	 *
 	 * @param userId  사용자 ID
@@ -101,8 +102,7 @@ public class UserPurchasedSeatCountRepository {
 			} else if (result != null) {
 				stringRedisTemplate.expire(key, TTL);
 				log.debug("[PurchasedSeatCount 경기 구매 완료 좌석 수] 감소: userId={}, matchId={}, count={}, result={}", userId,
-						matchId, count,
-						result);
+						matchId, count, result);
 			}
 		} catch (Exception e) {
 			log.warn("[PurchasedSeatCount 경기 구매 완료 좌석 수] Redis 감소 실패: userId={}, matchId={}, count={}", userId, matchId,


### PR DESCRIPTION
## 🔧 작업 내용
- 사용자가 특정 경기에서 구매 완료한 좌석 수를 Redis에 캐싱하는 `UserPurchasedSeatCountRepository` 추가
- `PaymentCompletedEvent` 수신 시 Redis 카운터 증가
- `OrderCancelledEvent` 수신 시 Redis 카운터 감소
- `BankTransferExpiredEvent` 수신 시 Redis 카운터 감소 (무통장 선택 시 PaymentCompleted로 이미 증가했으므로)
- Redis TTL을 예매 오픈 도메인 기준(경기 7일 전)에 맞게 7일로 설정

## 🧩 구현 상세

### 왜 Kafka + Redis 방식인가
Seat 서비스는 `orders`, `payments` 테이블에 직접 접근할 수 없는 독립적인 마이크로서비스다.
기존에도 Seat 서비스는 `PaymentCompletedEvent`, `OrderCancelledEvent`, `BankTransferExpiredEvent`를 이미 구독하고 있었고,
세 이벤트 모두 `userId`, `matchId`, `matchSeatIds`를 포함하고 있어 별도 스키마 변경 없이 카운터 동기화가 가능하다.

### Redis Key 구조
```
purchased:{userId}:{matchId}  →  Integer (구매 완료 좌석 수)
TTL: 7일
```
예매 오픈은 경기 7일 전 오전 11시(`ON_SALE`)이므로 구매 후 최대 7일 이내에 경기가 시작된다.
경기 시작 시 예매 마감으로 전환되어 Hold 자체가 불가능해지므로, 카운터가 7일 이후에도 남아있을 이유가 없다.

### 이벤트별 처리
| 이벤트 | 처리 | 이유 |
|--------|------|------|
| `PaymentCompletedEvent` | 카운터 += BLOCKED→SOLD 처리된 수 | 실제 좌석 상태 변경 수 기준으로 증가 |
| `OrderCancelledEvent` | 카운터 -= SOLD→AVAILABLE 복원된 수 | 실제 복원 수 기준으로 감소 |
| `BankTransferExpiredEvent` | 카운터 -= SOLD→AVAILABLE 복원된 수 | 무통장 선택 시 PaymentCompletedEvent로 카운터가 증가했으므로, 만료 시 반드시 감소해야 함 |

### Fail-safe 전략
Redis 장애 시 `get()`은 예외를 catch하여 `0L`을 반환한다(fail-open).
Order-Core의 DB 기반 검증이 최종 방어선이므로 Redis 카운터는 best-effort 캐시로 동작한다.

### 음수 보정 로직 (`decrement`)
`decrement` 후 결과가 음수가 될 수 있는 케이스가 존재한다. 이는 비정상이 아니며 아래 상황에서 발생한다.

**케이스 1 — 최초 배포 직후 (가장 흔함)**
Redis에 기존 구매 데이터가 없는 상태에서, 이미 결제 완료된 유저가 취소하면:
```
Redis key 없음 (0으로 취급)
→ OrderCancelledEvent 수신 → decrement(userId, matchId, 2)
→ 0 - 2 = -2  ← 음수 보정 발동
```

**케이스 2 — Redis 재시작 / 플러시 후**
ElastiCache 재시작이나 FLUSHALL 이후 카운터가 초기화된 상태에서 취소 이벤트가 들어오는 경우.

**케이스 3 — Kafka at-least-once 중복 처리**
동일한 `OrderCancelledEvent`가 두 번 처리되면:
```
1차 처리: 2 - 2 = 0  (정상)
2차 처리: 0 - 2 = -2  ← 음수 보정 발동
```
세 케이스 모두 음수 보정 후 `0`으로 클램핑하며, 실제 동작에는 문제가 없다‼️‼️‼️‼️‼️ 초기엔 음수 나오는게 정상임 ‼️‼️‼️‼️
정상 운영 중에는 거의 발생하지 않으며, `log.debug`로만 기록된다.

### 📌 관련 Jira Issue
- GRGB-367

## 🧪 테스트 방법
1. 특정 유저로 경기 2매 결제 완료
2. Redis CLI에서 키 확인
   ```
   GET purchased:{userId}:{matchId}
   → "2"
   ```
3. 해당 주문 취소
4. Redis 키 재확인
   ```
   GET purchased:{userId}:{matchId}
   → "0"
   ```

## ❗ 참고 사항
- 배포 초기에는 기존 구매자 데이터가 Redis에 없으므로 카운터가 실제 구매 수보다 낮을 수 있음
  → Hold 단계 검증이 통과되더라도 Order-Core DB 검증에서 최종적으로 차단되므로 안전
- Kafka at-least-once로 인한 중복 increment 가능성 있음 → 마찬가지로 Order-Core DB가 최종 방어
- 무통장 입금 흐름: PaymentCompleted(카운터 +) → 기한 내 미결제 → BankTransferExpired(카운터 -) 로 정확히 대칭됨
