### PR TITLE
fix(api-gateway, common): Gateway 쓰기 메서드 인증 우회 + Thread Pool 무제한 DoS 대응 [GRGB-371]

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -39,8 +39,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private static final Set<HttpMethod> POST_ONLY = Set.of(HttpMethod.POST);
 
 	private static final List<WhitelistEntry> WHITELIST = List.of(
-			// 인증 엔드포인트 — POST 전용
-			new WhitelistEntry(POST_ONLY, "/auth/kakao"),
+			// 인증 엔드포인트 — 경로별 메서드 분리
+			new WhitelistEntry(GET_ONLY, "/auth/kakao/login-url"),
+			new WhitelistEntry(POST_ONLY, "/auth/kakao/login"),
 			new WhitelistEntry(POST_ONLY, "/auth/token/refresh"),
 			new WhitelistEntry(POST_ONLY, "/auth/dev/auth"),
 			new WhitelistEntry(POST_ONLY, "/auth/loadtest"),
@@ -143,8 +144,16 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 		if (method == null) {
 			return false;
 		}
-		return WHITELIST.stream()
-				.anyMatch(entry -> entry.methods().contains(method) && path.startsWith(entry.pathPrefix()));
+		for (WhitelistEntry entry : WHITELIST) {
+			if (!entry.methods().contains(method)) {
+				continue;
+			}
+			String prefix = entry.pathPrefix();
+			if (path.equals(prefix) || path.startsWith(prefix + "/")) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private String resolveToken(ServerHttpRequest request) {

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.goormgb.be.apigateway.filter;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
@@ -32,33 +34,46 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	private static final String HEADER_SESSION_ID = "X-Session-Id";
 	private static final String HEADER_TOKEN_JTI = "X-Token-Jti";
 
-	// 인증 없이 통과시킬 경로 prefix 목록
-	private static final List<String> WHITELIST = List.of(
-			"/auth/kakao",
-			"/auth/token/refresh",
-			"/auth/dev/auth",
-			"/auth/loadtest",
-			"/swagger-ui",
-			"/v3/api-docs",
-			"/auth/v3/api-docs",
-			"/queue/v3/api-docs",
-			"/seat/v3/api-docs",
-			"/order/v3/api-docs",
-			"/recommendation/v3/api-docs",
-			"/actuator/health",
-			"/actuator/prometheus",
-			"/auth/actuator/health",
-			"/auth/actuator/prometheus",
-			"/queue/actuator/health",
-			"/queue/actuator/prometheus",
-			"/seat/actuator/health",
-			"/seat/actuator/prometheus",
-			"/order/actuator/health",
-			"/order/actuator/prometheus",
-			"/seat/blocks",
-			"/order/clubs",
-			"/order/matches"
+	// 인증 없이 통과시킬 (HTTP 메서드 + 경로 prefix) 쌍 목록
+	private static final Set<HttpMethod> GET_ONLY = Set.of(HttpMethod.GET);
+	private static final Set<HttpMethod> POST_ONLY = Set.of(HttpMethod.POST);
+
+	private static final List<WhitelistEntry> WHITELIST = List.of(
+			// 인증 엔드포인트 — POST 전용
+			new WhitelistEntry(POST_ONLY, "/auth/kakao"),
+			new WhitelistEntry(POST_ONLY, "/auth/token/refresh"),
+			new WhitelistEntry(POST_ONLY, "/auth/dev/auth"),
+			new WhitelistEntry(POST_ONLY, "/auth/loadtest"),
+
+			// Swagger / OpenAPI 문서 — GET 전용
+			new WhitelistEntry(GET_ONLY, "/swagger-ui"),
+			new WhitelistEntry(GET_ONLY, "/v3/api-docs"),
+			new WhitelistEntry(GET_ONLY, "/auth/v3/api-docs"),
+			new WhitelistEntry(GET_ONLY, "/queue/v3/api-docs"),
+			new WhitelistEntry(GET_ONLY, "/seat/v3/api-docs"),
+			new WhitelistEntry(GET_ONLY, "/order/v3/api-docs"),
+			new WhitelistEntry(GET_ONLY, "/recommendation/v3/api-docs"),
+
+			// Actuator 공개 엔드포인트 — GET 전용
+			new WhitelistEntry(GET_ONLY, "/actuator/health"),
+			new WhitelistEntry(GET_ONLY, "/actuator/prometheus"),
+			new WhitelistEntry(GET_ONLY, "/auth/actuator/health"),
+			new WhitelistEntry(GET_ONLY, "/auth/actuator/prometheus"),
+			new WhitelistEntry(GET_ONLY, "/queue/actuator/health"),
+			new WhitelistEntry(GET_ONLY, "/queue/actuator/prometheus"),
+			new WhitelistEntry(GET_ONLY, "/seat/actuator/health"),
+			new WhitelistEntry(GET_ONLY, "/seat/actuator/prometheus"),
+			new WhitelistEntry(GET_ONLY, "/order/actuator/health"),
+			new WhitelistEntry(GET_ONLY, "/order/actuator/prometheus"),
+
+			// 공개 조회 API — GET 전용
+			new WhitelistEntry(GET_ONLY, "/seat/blocks"),
+			new WhitelistEntry(GET_ONLY, "/order/clubs"),
+			new WhitelistEntry(GET_ONLY, "/order/matches")
 	);
+
+	private record WhitelistEntry(Set<HttpMethod> methods, String pathPrefix) {
+	}
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final AccessTokenBlacklistRepository blacklistRepository;
@@ -66,8 +81,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getPath().value();
+		HttpMethod method = exchange.getRequest().getMethod();
 
-		if (isWhitelisted(path)) {
+		if (isWhitelisted(method, path)) {
 			return chain.filter(exchange);
 		}
 
@@ -123,8 +139,12 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 		return -1;
 	}
 
-	private boolean isWhitelisted(String path) {
-		return WHITELIST.stream().anyMatch(path::startsWith);
+	private boolean isWhitelisted(HttpMethod method, String path) {
+		if (method == null) {
+			return false;
+		}
+		return WHITELIST.stream()
+				.anyMatch(entry -> entry.methods().contains(method) && path.startsWith(entry.pathPrefix()));
 	}
 
 	private String resolveToken(ServerHttpRequest request) {

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
@@ -84,12 +84,14 @@ class JwtAuthenticationFilterTest {
 
 		@ParameterizedTest
 		@CsvSource({
-				// 인증 엔드포인트 — POST 전용
-				"POST, /auth/kakao",
-				"POST, /auth/kakao/callback",
+				// 인증 엔드포인트 — 경로별 메서드 분리
+				"GET, /auth/kakao/login-url",
+				"POST, /auth/kakao/login",
 				"POST, /auth/token/refresh",
 				"POST, /auth/dev/auth",
 				"POST, /auth/dev/auth/login",
+				"POST, /auth/loadtest",
+				"POST, /auth/loadtest/users",
 				// Swagger / OpenAPI 문서 — GET 전용
 				"GET, /swagger-ui",
 				"GET, /swagger-ui/index.html",
@@ -135,8 +137,12 @@ class JwtAuthenticationFilterTest {
 				"POST, /seat/blocks",
 				"PUT, /seat/blocks",
 				"DELETE, /seat/blocks",
-				// POST 전용 엔드포인트에 GET → 401
-				"GET, /auth/kakao",
+				// 카카오 로그인 URL(GET 전용)에 쓰기 메서드 → 401
+				"POST, /auth/kakao/login-url",
+				"DELETE, /auth/kakao/login-url",
+				// 카카오 로그인(POST 전용)에 GET → 401
+				"GET, /auth/kakao/login",
+				// 토큰 갱신(POST 전용)에 GET → 401
 				"GET, /auth/token/refresh",
 				// Swagger 경로에 쓰기 메서드 → 401
 				"POST, /v3/api-docs",
@@ -147,6 +153,31 @@ class JwtAuthenticationFilterTest {
 		})
 		@DisplayName("화이트리스트 경로라도 허용되지 않은 메서드는 인증 우회가 차단된다")
 		void whitelistedPath_wrongMethod_isBlocked(HttpMethod method, String path) {
+			MockServerWebExchange exchange = createExchange(method, path);
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
+			verify(blacklistRepository, never()).isBlacklisted(anyString());
+		}
+
+		@ParameterizedTest
+		@CsvSource({
+				// prefix 문자열만 겹치는 경로는 하위 경로로 취급하지 않는다
+				"POST, /auth/loadtestx",
+				"POST, /auth/loadtestx/users",
+				"GET, /order/clubsaurus",
+				"GET, /order/matches-evil",
+				"GET, /seat/blocksX",
+				"GET, /auth/kakao/login-url-malicious",
+				// 화이트리스트에 없는 상위 경로 자체도 통과하지 않는다
+				"GET, /auth/kakao",
+				"POST, /auth/kakao"
+		})
+		@DisplayName("화이트리스트 prefix 문자열 유사 경로는 통과시키지 않는다 (prefix-bleed 방지)")
+		void similarPrefix_isBlocked(HttpMethod method, String path) {
 			MockServerWebExchange exchange = createExchange(method, path);
 
 			StepVerifier.create(filter.filter(exchange, chain))

--- a/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
+++ b/API-Gateway/src/test/java/com/goormgb/be/apigateway/filter/JwtAuthenticationFilterTest.java
@@ -12,12 +12,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -59,6 +60,11 @@ class JwtAuthenticationFilterTest {
 				MockServerHttpRequest.get(path).build());
 	}
 
+	private MockServerWebExchange createExchange(HttpMethod method, String path) {
+		return MockServerWebExchange.from(
+				MockServerHttpRequest.method(method, path).build());
+	}
+
 	private MockServerWebExchange createExchangeWithToken(String path, String token) {
 		return MockServerWebExchange.from(
 				MockServerHttpRequest.get(path)
@@ -73,44 +79,81 @@ class JwtAuthenticationFilterTest {
 	}
 
 	@Nested
-	@DisplayName("화이트리스트 경로")
+	@DisplayName("화이트리스트 경로 + 허용 메서드")
 	class WhitelistedPaths {
 
 		@ParameterizedTest
-		@ValueSource(strings = {
-				"/auth/kakao",
-				"/auth/kakao/callback",
-				"/auth/token/refresh",
-				"/auth/dev/auth",
-				"/auth/dev/auth/login",
-				"/swagger-ui",
-				"/swagger-ui/index.html",
-				"/v3/api-docs",
-				"/v3/api-docs/swagger-config",
-				"/auth/v3/api-docs",
-				"/queue/v3/api-docs",
-				"/seat/v3/api-docs",
-				"/seat/blocks",
-				"/order/v3/api-docs",
-				"/recommendation/v3/api-docs",
-				"/actuator",
-				"/actuator/health",
-				"/actuator/prometheus",
-				"/order/clubs",
-				"/order/clubs/1",
-				"/order/clubs/1/matches",
-				"/order/matches",
-				"/order/matches/1"
+		@CsvSource({
+				// 인증 엔드포인트 — POST 전용
+				"POST, /auth/kakao",
+				"POST, /auth/kakao/callback",
+				"POST, /auth/token/refresh",
+				"POST, /auth/dev/auth",
+				"POST, /auth/dev/auth/login",
+				// Swagger / OpenAPI 문서 — GET 전용
+				"GET, /swagger-ui",
+				"GET, /swagger-ui/index.html",
+				"GET, /v3/api-docs",
+				"GET, /v3/api-docs/swagger-config",
+				"GET, /auth/v3/api-docs",
+				"GET, /queue/v3/api-docs",
+				"GET, /seat/v3/api-docs",
+				"GET, /order/v3/api-docs",
+				"GET, /recommendation/v3/api-docs",
+				// Actuator 공개 엔드포인트 — GET 전용
+				"GET, /actuator/health",
+				"GET, /actuator/prometheus",
+				// 공개 조회 API — GET 전용
+				"GET, /seat/blocks",
+				"GET, /order/clubs",
+				"GET, /order/clubs/1",
+				"GET, /order/clubs/1/matches",
+				"GET, /order/matches",
+				"GET, /order/matches/1"
 		})
-		@DisplayName("화이트리스트 경로는 인증 없이 통과한다")
-		void whitelistedPath_passesWithoutAuth(String path) {
-			MockServerWebExchange exchange = createExchange(path);
+		@DisplayName("허용 메서드 + 화이트리스트 경로는 인증 없이 통과한다")
+		void whitelistedPath_passesWithoutAuth(HttpMethod method, String path) {
+			MockServerWebExchange exchange = createExchange(method, path);
 			when(chain.filter(any())).thenReturn(Mono.empty());
 
 			StepVerifier.create(filter.filter(exchange, chain))
 					.verifyComplete();
 
 			verify(chain).filter(any());
+			verify(blacklistRepository, never()).isBlacklisted(anyString());
+		}
+
+		@ParameterizedTest
+		@CsvSource({
+				// 공개 조회 API에 쓰기 메서드 → 401
+				"POST, /order/clubs",
+				"PUT, /order/clubs",
+				"PATCH, /order/clubs",
+				"DELETE, /order/clubs",
+				"POST, /order/matches",
+				"DELETE, /order/matches",
+				"POST, /seat/blocks",
+				"PUT, /seat/blocks",
+				"DELETE, /seat/blocks",
+				// POST 전용 엔드포인트에 GET → 401
+				"GET, /auth/kakao",
+				"GET, /auth/token/refresh",
+				// Swagger 경로에 쓰기 메서드 → 401
+				"POST, /v3/api-docs",
+				"DELETE, /swagger-ui",
+				// Actuator health에 쓰기 메서드 → 401
+				"POST, /actuator/health",
+				"DELETE, /actuator/prometheus"
+		})
+		@DisplayName("화이트리스트 경로라도 허용되지 않은 메서드는 인증 우회가 차단된다")
+		void whitelistedPath_wrongMethod_isBlocked(HttpMethod method, String path) {
+			MockServerWebExchange exchange = createExchange(method, path);
+
+			StepVerifier.create(filter.filter(exchange, chain))
+					.verifyComplete();
+
+			assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+			verify(chain, never()).filter(any());
 			verify(blacklistRepository, never()).isBlacklisted(anyString());
 		}
 	}

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -2,6 +2,12 @@ server:
   port: 8080
   servlet:
     context-path: /auth
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
 
 spring:
   application:
@@ -9,6 +15,13 @@ spring:
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
 
   datasource:
     url: ${DB_URL}

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -2,6 +2,12 @@ server:
   port: 8083
   servlet:
     context-path: /order
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
 
 spring:
   application:
@@ -9,6 +15,13 @@ spring:
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
 
   datasource:
     url: ${DB_URL}

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -3,6 +3,12 @@ server:
   port: 8081
   servlet:
     context-path: /queue
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
 
 spring:
   application:
@@ -10,6 +16,13 @@ spring:
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
 
   datasource:
     url: ${DB_URL}

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -2,6 +2,12 @@ server:
   port: 8082
   servlet:
     context-path: /seat
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    max-connections: 8192
+    accept-count: 100
 
 spring:
   application:
@@ -9,6 +15,13 @@ spring:
   jackson:
     time-zone: UTC
     data-format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+
+  task:
+    execution:
+      pool:
+        core-size: 8
+        max-size: 50
+        queue-capacity: 100
 
   datasource:
     url: ${DB_URL}


### PR DESCRIPTION
## 🔧 작업 내용

KT Cloud TechUp 72시간 모의해킹 침투테스트(2026-04-02~04)에서 발견된 2건의 HIGH 취약점을 대응
두 건 모두 DB 마이그레이션·프론트엔드 영향이 없어 단일 PR로 묶어 처리했습니다.

### H-04 — Gateway 화이트리스트 HTTP 메서드 미구분
- `API-Gateway`의 `JwtAuthenticationFilter` 화이트리스트가 경로 prefix만 확인하고 HTTP 메서드를 구분하지 않아, 공개 조회 API(GET 의도)로 `POST/PUT/DELETE` 요청을 보내도 인증 없이 다운스트림 서비스에 도달하고 500으로 떨어지던 문제를 차단했습니다.
- 화이트리스트를 `(HttpMethod Set, path prefix)` 쌍으로 구조화하여 **메서드 + 경로**를 동시 검증하도록 변경했습니다.

### H-09 — Thread Pool / TaskExecutor 무제한(DoS 취약)
- Spring Boot의 `spring.task.execution.pool.max-size` 기본값이 `Integer.MAX_VALUE`(약 21억)로 설정되어 있어, 동시 요청 대량 전송 시 스레드가 무한히 생성되어 OOM DoS로 이어질 수 있는 문제를 보완했습니다.
- Servlet 기반 4개 모듈(`auth-guard`, `queue`, `seat`, `order-core`) `application.yaml`에 Tomcat · TaskExecutor 리소스 상한을 명시했습니다.

## 🧩 구현 상세

### H-04 — JwtAuthenticationFilter 구조 변경

AS-IS: 경로만 검증 (메서드 무관 통과)
```java
private static final List<String> WHITELIST = List.of("/order/clubs", "/seat/blocks", ...);
private boolean isWhitelisted(String path) {
    return WHITELIST.stream().anyMatch(path::startsWith);
}
```

TO-BE: 메서드 + 경로 동시 검증
```java
private static final Set<HttpMethod> GET_ONLY  = Set.of(HttpMethod.GET);
private static final Set<HttpMethod> POST_ONLY = Set.of(HttpMethod.POST);

private record WhitelistEntry(Set<HttpMethod> methods, String pathPrefix) {}

private static final List<WhitelistEntry> WHITELIST = List.of(
    new WhitelistEntry(POST_ONLY, "/auth/kakao"),
    new WhitelistEntry(POST_ONLY, "/auth/token/refresh"),
    new WhitelistEntry(GET_ONLY,  "/order/clubs"),
    new WhitelistEntry(GET_ONLY,  "/seat/blocks"),
    // ...
);

private boolean isWhitelisted(HttpMethod method, String path) {
    if (method == null) return false;
    return WHITELIST.stream()
        .anyMatch(e -> e.methods().contains(method) && path.startsWith(e.pathPrefix()));
}
```

**경로별 허용 메서드 정책**

| 경로 카테고리 | AS-IS | TO-BE |
|---|---|---|
| `/auth/kakao`, `/auth/token/refresh`, `/auth/dev/auth`, `/auth/loadtest` | ALL | **POST** |
| `/order/clubs`, `/order/matches`, `/seat/blocks` | ALL | **GET** |
| `/swagger-ui`, `/v3/api-docs`, `/{module}/v3/api-docs` | ALL | **GET** |
| `/{module}/actuator/health`, `/{module}/actuator/prometheus` | ALL | **GET** |

### H-09 — 리소스 상한 명시

4개 Servlet 모듈 `application.yaml`에 공통 추가:

```yaml
server:
  tomcat:
    threads:
      max: 200
      min-spare: 10
    max-connections: 8192
    accept-count: 100

spring:
  task:
    execution:
      pool:
        core-size: 8
        max-size: 50
        queue-capacity: 100
```

- `max-size: 50`, `queue-capacity: 100`은 현재 트래픽 대비 충분한 여유 값
- API-Gateway는 WebFlux/Netty 기반이라 Tomcat 설정이 해당 없어 제외했습니당

### 📌 관련 Jira Issue
- GRGB-371

## 🧪 테스트 방법
### H-04 검증 (`JwtAuthenticationFilterTest` 자동화 테스트 추가)

| 케이스 | 요청 | 기대 응답 |
|---|---|---|
| 정상 공개 조회 | `GET /order/clubs` (토큰 없음) | 200 OK |
| 쓰기 우회 차단 | `POST /order/clubs` (토큰 없음) | **401 Unauthorized** |
| 쓰기 우회 차단 | `DELETE /seat/blocks` (토큰 없음) | **401 Unauthorized** |
| 카카오 로그인 정상 | `POST /auth/kakao` (토큰 없음) | 200 OK |
| 엔드포인트 오남용 | `GET /auth/kakao` (토큰 없음) | **401 Unauthorized** |
| 인증 정상 흐름 | `POST /order/...` (유효 토큰) | 200 OK |

- 테스트 파일: `JwtAuthenticationFilterTest.java` (기존 `@ValueSource` → `@CsvSource`로 전환, 허용 조합 21건 + 차단 조합 15건 파라미터화)
- 실행: `./gradlew :API-Gateway:test --tests "*JwtAuthenticationFilterTest*WhitelistedPaths*"` → 전부 통과

### H-09 검증 (staging 배포 후)

| 항목 | 검증 방식 | 기대 결과 |
|---|---|---|
| 설정 반영 | `GET /{module}/actuator/metrics/executor.pool.max` | `value: 50` |
| Tomcat 설정 반영 | 기동 로그 or actuator metrics | max=200 |
| 기본 기능 리그레션 | 좌석 hold / 주문 생성 / 카카오 로그인 | 200 OK (기존과 동일) |
| 부하 상황 | 동시 요청 300건 | queue 100 후 일부 503 반환(무한 생성 없이 보호됨) |

## ❗ 참고 사항
- **프론트엔드 영향 없음**: API 경로·응답 구조 변경 없음, 동시 배포 불필요
- **DB 마이그레이션 없음**
- **Kafka 이벤트 DTO 영향 없음**
- **롤백 전략**: 두 항목 모두 독립적으로 롤백 가능 (H-04는 `JwtAuthenticationFilter` 1개 파일 revert, H-09는 4개 `application.yaml`의 `server.tomcat` / `spring.task.execution` 블록 제거)