### PR TITLE
fix(order-core): 결제 수단별 예매 완료 메일 입금 안내 분기

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/event/EmailEventConsumer.java
@@ -29,7 +29,7 @@ public class EmailEventConsumer {
 	public void handlePaymentCompleted(PaymentCompletedEvent event) {
 		if (emailDataQueryService.isOrderPaid(event.getOrderId())) {
 			Map<String, Object> bookingContext = emailDataQueryService
-				.buildBookingEmailContext(event.getOrderId())
+				.buildBookingEmailContext(event.getOrderId(), event)
 				.orElse(null);
 
 			if (bookingContext == null) {

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailDataQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/email/service/EmailDataQueryService.java
@@ -106,7 +106,7 @@ public class EmailDataQueryService {
 	}
 
 	@Transactional(readOnly = true)
-	public Optional<Map<String, Object>> buildBookingEmailContext(Long orderId) {
+	public Optional<Map<String, Object>> buildBookingEmailContext(Long orderId, PaymentCompletedEvent event) {
 		Order order = orderRepository.findByIdWithMatchDetails(orderId).orElse(null);
 		if (order == null) {
 			return Optional.empty();
@@ -115,6 +115,8 @@ public class EmailDataQueryService {
 		Match match = order.getMatch();
 		List<OrderSeat> orderSeats = orderSeatRepository.findByOrderId(orderId);
 		List<SeatDisplayInfo> seats = buildSeatDisplayInfos(orderSeats);
+
+		boolean isBankTransfer = event != null && "BANK_TRANSFER".equals(event.getPaymentMethod());
 
 		Map<String, Object> ctx = new HashMap<>();
 		ctx.put("ordererName", order.getOrdererName());
@@ -133,11 +135,15 @@ public class EmailDataQueryService {
 		ctx.put("bookingFee", order.getBookingFee() != null ? order.getBookingFee() : 0);
 		ctx.put("cancelDeadline", formatInstant(match.getMatchAt()));
 
-		// 입금 기한: 주문일 + 1일 23:59 (KST)
-		Instant createdAt = order.getCreatedAt() != null ? order.getCreatedAt() : Instant.now();
-		LocalDate orderDate = createdAt.atZone(KST).toLocalDate();
-		ZonedDateTime deadline = ZonedDateTime.of(orderDate.plusDays(1), LocalTime.of(23, 59), KST);
-		ctx.put("paymentDeadline", deadline.format(DATE_FORMATTER));
+		ctx.put("isBankTransfer", isBankTransfer);
+
+		// 입금 기한은 무통장 입금일 때만 사용
+		if (isBankTransfer) {
+			Instant createdAt = order.getCreatedAt() != null ? order.getCreatedAt() : Instant.now();
+			LocalDate orderDate = createdAt.atZone(KST).toLocalDate();
+			ZonedDateTime deadline = ZonedDateTime.of(orderDate.plusDays(1), LocalTime.of(23, 59), KST);
+			ctx.put("paymentDeadline", deadline.format(DATE_FORMATTER));
+		}
 
 		ctx.put("ticketUrl", TICKET_URL);
 		return Optional.of(ctx);

--- a/Order-Core/src/main/resources/templates/email/booking-confirmation.html
+++ b/Order-Core/src/main/resources/templates/email/booking-confirmation.html
@@ -30,9 +30,15 @@
                                         <span style="color:#00c292;" th:text="${ordererName}"></span>
                                         님!
                                     </p>
-                                    <p style="margin:0 0 20px; font-size:18px; font-weight:500; color:#292929; line-height:1.4;">
+                                    <p th:if="${isBankTransfer}"
+                                       style="margin:0 0 20px; font-size:18px; font-weight:500; color:#292929; line-height:1.4;">
                                         고객님의 좌석 예약이 완료되었습니다.<br/>
                                         예약된 티켓 확정을 위해 기한 내 <span style="font-weight:600;">결제를 완료해주세요.</span>
+                                    </p>
+                                    <p th:unless="${isBankTransfer}"
+                                       style="margin:0 0 20px; font-size:18px; font-weight:500; color:#292929; line-height:1.4;">
+                                        고객님의 <span style="font-weight:600;">결제가 완료되어 티켓이 확정</span>되었습니다.<br/>
+                                        아래 내 티켓 확인하기에서 예매 내역을 확인해주세요.
                                     </p>
                                     <table role="presentation" cellpadding="0" cellspacing="0" align="right">
                                         <tr>
@@ -55,8 +61,8 @@
                 <tr>
                     <td style="padding:24px 40px;">
 
-                        <!-- 입금 안내 정보 섹션 -->
-                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+                        <!-- 입금 안내 정보 섹션 (무통장 입금만 표시) -->
+                        <table th:if="${isBankTransfer}" role="presentation" width="100%" cellpadding="0" cellspacing="0"
                                style="margin-bottom:20px;">
                             <tr>
                                 <td style="padding:0 12px 8px;">

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/email/event/EmailEventConsumerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/email/event/EmailEventConsumerTest.java
@@ -42,7 +42,7 @@ class EmailEventConsumerTest {
 		Map<String, Object> paymentContext = new HashMap<>();
 
 		given(emailDataQueryService.isOrderPaid(1L)).willReturn(true);
-		given(emailDataQueryService.buildBookingEmailContext(1L)).willReturn(Optional.of(bookingContext));
+		given(emailDataQueryService.buildBookingEmailContext(1L, event)).willReturn(Optional.of(bookingContext));
 		given(emailDataQueryService.buildPaymentEmailContext(1L, event)).willReturn(Optional.of(paymentContext));
 
 		consumer.handlePaymentCompleted(event);


### PR DESCRIPTION
## 🔧 작업 내용
- 토스페이/카카오페이 결제 시에도 예매 완료 메일에 **입금 안내 정보**(신한 110-123-456789 / 주식회사 구름공방)가 노출되던 문제 수정
- 결제 수단(BANK_TRANSFER / TOSS_PAY / KAKAO_PAY)에 따라 입금 안내 블록 및 헤더 안내 문구 분기 처리

## 🧩 구현 상세
- `EmailEventConsumer.handlePaymentCompleted`에서 `buildBookingEmailContext`로 `PaymentCompletedEvent` 전달
- `EmailDataQueryService.buildBookingEmailContext`에 `isBankTransfer` 플래그 추가, `paymentDeadline`은 무통장 입금일 때만 세팅
- `booking-confirmation.html`에서 `th:if="${isBankTransfer}"`로 입금 안내 블록 노출 제어
- 헤더 문구도 결제 수단에 따라 분기
  - 무통장: "예약된 티켓 확정을 위해 기한 내 결제를 완료해주세요"
  - 토스/카카오: "결제가 완료되어 티켓이 확정되었습니다"

### 📌 관련 Jira Issue
- (해당 없음 / 운영 중 발견)

## 🧪 테스트 방법
- 토스페이 결제 플로우 태운 뒤 주문 이메일 수신 → 입금 안내 블록 미노출, 헤더 "결제가 완료되어 티켓이 확정" 확인
- 무통장 입금 플로우 → 기존과 동일하게 입금 계좌/기한/예금주 노출, 헤더 "기한 내 결제를 완료해주세요" 확인