### PR TITLE
feat(order): 내 주문 이외 요청 에러 (403, 404) 404로 통합 [GRGB-370]

### DIFF
--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/controller/MyPageController.java
@@ -185,8 +185,7 @@ public class MyPageController {
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "조회 성공"),
 			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음 또는 접근 불가", content = @Content)
 	})
 	@GetMapping("/tickets/{ticketId}")
 	@ResponseStatus(HttpStatus.OK)
@@ -206,8 +205,7 @@ public class MyPageController {
 			@ApiResponse(responseCode = "200", description = "QR 발급 성공"),
 			@ApiResponse(responseCode = "400", description = "발급 불가 상태", content = @Content),
 			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음 또는 접근 불가", content = @Content)
 	})
 	@GetMapping("/tickets/{ticketId}/qr")
 	@ResponseStatus(HttpStatus.OK)
@@ -227,8 +225,7 @@ public class MyPageController {
 			@ApiResponse(responseCode = "200", description = "취소 요청 완료"),
 			@ApiResponse(responseCode = "400", description = "취소 불가 상태", content = @Content),
 			@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-			@ApiResponse(responseCode = "403", description = "본인 소유 티켓 아님", content = @Content),
-			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음", content = @Content)
+			@ApiResponse(responseCode = "404", description = "티켓(주문) 없음 또는 접근 불가", content = @Content)
 	})
 	@PostMapping("/tickets/{ticketId}/cancel")
 	@ResponseStatus(HttpStatus.OK)

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/query/MyPageQueryService.java
@@ -127,7 +127,7 @@ public class MyPageQueryService {
 	/**
 	 * ticketId(orderId)에 해당하는 상세 기본 정보를 반환한다.
 	 */
-	public Optional<TicketDetailBaseRow> findTicketDetailBaseByOrderId(Long orderId) {
+	public Optional<TicketDetailBaseRow> findTicketDetailBaseByOrderIdAndUserId(Long orderId, Long userId) {
 		String sql = """
 				SELECT
 				    o.id             AS order_id,
@@ -163,10 +163,12 @@ public class MyPageQueryService {
 				LEFT JOIN payments p ON p.order_id = o.id
 				LEFT JOIN cash_receipts cr ON cr.payment_id = p.id
 				WHERE o.id = :orderId
+				  AND o.user_id = :userId
 				""";
 
 		var params = new MapSqlParameterSource()
-				.addValue("orderId", orderId);
+				.addValue("orderId", orderId)
+				.addValue("userId", userId);
 
 		List<TicketDetailBaseRow> rows = namedJdbc.query(sql, params, (rs, rowNum) -> {
 			String paymentMethod = rs.getString("payment_method");

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketService.java
@@ -188,9 +188,8 @@ public class MyPageTicketService {
 	}
 
 	public MyPageTicketDetailResponse getTicketDetail(Long userId, Long ticketId) {
-		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderId(ticketId)
+		TicketDetailBaseRow base = myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(base.userId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		List<TicketSeatDetailRow> seatRows = myPageQueryService.findTicketSeatRowsByOrderId(ticketId);
 
 		MyPageTicketDetailResponse.PaymentInfo payment = MyPageTicketDetailAssembler.toPaymentInfo(base);
@@ -214,9 +213,8 @@ public class MyPageTicketService {
 
 	@Transactional
 	public MyPageTicketQrResponse getTicketEntryQr(Long userId, Long ticketId) {
-		Order order = orderRepository.findByIdForUpdate(ticketId)
+		Order order = orderRepository.findByIdForUpdateAndUserId(ticketId, userId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		Instant now = Instant.now(clock);
@@ -232,9 +230,8 @@ public class MyPageTicketService {
 	@Transactional
 	public MyPageTicketCancelResponse requestTicketCancel(Long userId, Long ticketId) {
 		Instant now = Instant.now(clock);
-		Order order = orderRepository.findByIdForUpdate(ticketId)
+		Order order = orderRepository.findByIdForUpdateAndUserId(ticketId, userId)
 				.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.ORDER_ACCESS_DENIED);
 		Preconditions.validate(order.getStatus() == OrderStatus.PAID, ErrorCode.INVALID_ORDER_STATUS);
 
 		CancellationFeePolicy policy = MyPageTicketCancellationCalculator.findCancellationPolicy(

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -114,13 +114,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 	@Query("""
 		SELECT o
 		FROM Order o
-		JOIN FETCH o.user u
-		JOIN FETCH o.match m
-		JOIN FETCH m.homeClub hc
-		JOIN FETCH m.awayClub ac
-		JOIN FETCH m.stadium s
 		WHERE o.id = :orderId
-		  AND u.id = :userId
+		  AND o.user.id = :userId
 		""")
 	Optional<Order> findByIdForUpdateAndUserId(@Param("orderId") Long orderId, @Param("userId") Long userId);
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/order/repository/OrderRepository.java
@@ -17,6 +17,8 @@ import jakarta.persistence.LockModeType;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
+	Optional<Order> findByIdAndUserId(Long id, Long userId);
+
 	boolean existsByIdAndStatus(Long id, OrderStatus status);
 
 	long countByUserId(Long userId);
@@ -107,6 +109,20 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 		WHERE o.id = :orderId
 		""")
 	Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT o
+		FROM Order o
+		JOIN FETCH o.user u
+		JOIN FETCH o.match m
+		JOIN FETCH m.homeClub hc
+		JOIN FETCH m.awayClub ac
+		JOIN FETCH m.stadium s
+		WHERE o.id = :orderId
+		  AND u.id = :userId
+		""")
+	Optional<Order> findByIdForUpdateAndUserId(@Param("orderId") Long orderId, @Param("userId") Long userId);
 
 	@Query("""
 		SELECT o

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/controller/PaymentController.java
@@ -47,8 +47,7 @@ public class PaymentController {
 		@ApiResponse(responseCode = "200", description = "결제 처리 성공"),
 		@ApiResponse(responseCode = "400", description = "이미 결제 완료 또는 잘못된 요청", content = @Content),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
-		@ApiResponse(responseCode = "404", description = "주문 없음", content = @Content)
+		@ApiResponse(responseCode = "404", description = "주문 없음 또는 접근 불가", content = @Content)
 	})
 	@PostMapping("/{orderId}/payment")
 	@ResponseStatus(HttpStatus.OK)
@@ -70,7 +69,6 @@ public class PaymentController {
 		@ApiResponse(responseCode = "201", description = "현금영수증 신청 성공"),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
 		@ApiResponse(responseCode = "401", description = "인증 필요", content = @Content),
-		@ApiResponse(responseCode = "403", description = "주문 소유권 없음", content = @Content),
 		@ApiResponse(responseCode = "404", description = "주문 또는 결제 정보 없음", content = @Content),
 		@ApiResponse(responseCode = "409", description = "현금영수증 이미 신청됨", content = @Content)
 	})

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/payment/service/PaymentService.java
@@ -164,15 +164,8 @@ public class PaymentService {
 	}
 
 	private Order findOrderAndValidateOwnership(Long userId, Long orderId) {
-		Order order = orderRepository.findById(orderId)
+		return orderRepository.findByIdAndUserId(orderId, userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
-
-		Preconditions.validate(
-			order.getUser().getId().equals(userId),
-			ErrorCode.ORDER_ACCESS_DENIED
-		);
-
-		return order;
 	}
 
 	private Payment buildPayment(Order order, PaymentMethod method) {

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/controller/MyPageControllerTest.java
@@ -339,14 +339,14 @@ class MyPageControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("본인 소유가 아니면 403을 반환한다")
-		void getTicketDetail_권한없음_403() throws Exception {
+		@DisplayName("본인 소유가 아니면 404를 반환한다")
+		void getTicketDetail_권한없음_404() throws Exception {
 			given(myPageTicketService.getTicketDetail(1L, 101L))
-				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 			mockMvc.perform(get("/mypage/tickets/101"))
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
 		}
 	}
 
@@ -376,14 +376,14 @@ class MyPageControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("본인 소유가 아니면 403을 반환한다")
-		void getTicketEntryQr_권한없음_403() throws Exception {
+		@DisplayName("본인 소유가 아니면 404를 반환한다")
+		void getTicketEntryQr_권한없음_404() throws Exception {
 			given(myPageTicketService.getTicketEntryQr(1L, 101L))
-				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 			mockMvc.perform(get("/mypage/tickets/101/qr"))
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
 		}
 
 		@Test
@@ -436,14 +436,14 @@ class MyPageControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("본인 소유가 아니면 403을 반환한다")
-		void requestTicketCancel_권한없음_403() throws Exception {
+		@DisplayName("본인 소유가 아니면 404를 반환한다")
+		void requestTicketCancel_권한없음_404() throws Exception {
 			given(myPageTicketService.requestTicketCancel(1L, 101L))
-				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 			mockMvc.perform(post("/mypage/tickets/101/cancel"))
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageTicketServiceTest.java
@@ -263,7 +263,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(false)
 					.build();
 
-			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 
@@ -294,7 +294,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(true)
 					.build();
 
-			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
 					.willReturn(MyPageFixture.createTicketSeatDetailRows());
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -322,7 +322,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(false)
 					.build();
 
-			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)).willReturn(Optional.of(baseRow));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId))
 					.willReturn(MyPageFixture.createTicketSeatDetailRows());
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
@@ -337,24 +337,25 @@ class MyPageTicketServiceTest {
 		@Test
 		@DisplayName("존재하지 않는 티켓이면 ORDER_NOT_FOUND 예외가 발생한다")
 		void getTicketDetail_주문없음_예외() {
+			Long userId = 1L;
 			Long ticketId = 999L;
-			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.empty());
+			given(myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)).willReturn(Optional.empty());
 
-			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
+			assertThatThrownBy(() -> myPageService.getTicketDetail(userId, ticketId))
 					.isInstanceOf(CustomException.class)
 					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
-		@DisplayName("본인 소유가 아닌 티켓이면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("본인 소유가 아닌 티켓이면 ORDER_NOT_FOUND 예외가 발생한다")
 		void getTicketDetail_권한없음_예외() {
+			Long userId = 1L;
 			Long ticketId = 104L;
-			TicketDetailBaseRow baseRow = MyPageFixture.createTicketDetailBaseRow(2L, ticketId, OrderStatus.PAID);
-			given(myPageQueryService.findTicketDetailBaseByOrderId(ticketId)).willReturn(Optional.of(baseRow));
+			given(myPageQueryService.findTicketDetailBaseByOrderIdAndUserId(ticketId, userId)).willReturn(Optional.empty());
 
-			assertThatThrownBy(() -> myPageService.getTicketDetail(1L, ticketId))
+			assertThatThrownBy(() -> myPageService.getTicketDetail(userId, ticketId))
 					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 	}
 
@@ -395,7 +396,7 @@ class MyPageTicketServiceTest {
 					.expiresAt(Instant.now(clock).plus(2, ChronoUnit.MINUTES))
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(qrTokenRepository.findByOrderIdAndExpiresAtAfter(eq(ticketId), any())).willReturn(
 					Optional.of(existing));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
@@ -416,7 +417,7 @@ class MyPageTicketServiceTest {
 					Instant.now(clock).plus(10, ChronoUnit.MINUTES));
 			List<TicketSeatDetailRow> seatRows = MyPageFixture.createTicketSeatDetailRows();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(qrTokenRepository.findByOrderIdAndExpiresAtAfter(eq(ticketId), any())).willReturn(Optional.empty());
 			given(qrTokenRepository.save(any(QrToken.class))).willAnswer(invocation -> invocation.getArgument(0));
 			given(myPageQueryService.findTicketSeatRowsByOrderId(ticketId)).willReturn(seatRows);
@@ -435,7 +436,7 @@ class MyPageTicketServiceTest {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.PAYMENT_PENDING,
 					Instant.now(clock).plus(10, ChronoUnit.MINUTES));
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
 					.isInstanceOf(CustomException.class)
@@ -447,7 +448,7 @@ class MyPageTicketServiceTest {
 		void getTicketEntryQr_beforeEntryWindow_예외() {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now(clock).plus(5, ChronoUnit.HOURS));
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
 					.isInstanceOf(CustomException.class)
@@ -459,7 +460,7 @@ class MyPageTicketServiceTest {
 		void getTicketEntryQr_matchStarted_예외() {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.PAID, Instant.now(clock).minus(1, ChronoUnit.HOURS));
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.getTicketEntryQr(1L, ticketId))
 					.isInstanceOf(CustomException.class)
@@ -506,7 +507,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -538,7 +539,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(true)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -566,7 +567,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(true)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -590,7 +591,7 @@ class MyPageTicketServiceTest {
 					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -615,7 +616,7 @@ class MyPageTicketServiceTest {
 					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -640,7 +641,7 @@ class MyPageTicketServiceTest {
 					.cancellable(true).ticketFeeRate(new BigDecimal("0.100")).bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(List.of());
@@ -666,7 +667,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
@@ -679,7 +680,7 @@ class MyPageTicketServiceTest {
 		void requestTicketCancel_notPaid_예외() {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 1L, OrderStatus.CANCELLED, Instant.now(clock).plus(2, ChronoUnit.DAYS));
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
 					.isInstanceOf(CustomException.class)
@@ -687,15 +688,15 @@ class MyPageTicketServiceTest {
 		}
 
 		@Test
-		@DisplayName("본인 소유가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("본인 소유가 아니면 ORDER_NOT_FOUND 예외가 발생한다")
 		void requestTicketCancel_권한없음_예외() {
 			Long ticketId = 101L;
 			Order order = createOrder(ticketId, 2L, OrderStatus.PAID, Instant.now(clock).plus(2, ChronoUnit.DAYS));
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(() -> myPageService.requestTicketCancel(1L, ticketId))
 					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -714,7 +715,7 @@ class MyPageTicketServiceTest {
 					.bookingFeeRefundable(false)
 					.build();
 
-			given(orderRepository.findByIdForUpdate(ticketId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdForUpdateAndUserId(ticketId, 1L)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(ticketId)).willReturn(Optional.of(payment));
 			given(cancellationFeePolicyRepository.findByDaysLeft(anyInt())).willReturn(Optional.of(policy));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(ticketId)).willReturn(matchSeatIds);

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/controller/PaymentControllerTest.java
@@ -157,16 +157,16 @@ class PaymentControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("주문 소유권이 없으면 403을 반환한다")
-		void processPayment_소유권_없음_403() throws Exception {
+		@DisplayName("주문 소유권이 없으면 404를 반환한다")
+		void processPayment_소유권_없음_404() throws Exception {
 			given(paymentService.processPayment(any(), any(), any()))
-				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 			mockMvc.perform(post("/mypage/orders/1/payment")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(PaymentFixture.createTossPayRequest())))
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
 		}
 
 		@Test
@@ -277,16 +277,16 @@ class PaymentControllerTest extends WebMvcTestSupport {
 		}
 
 		@Test
-		@DisplayName("주문 소유권이 없으면 403을 반환한다")
-		void createCashReceipt_소유권_없음_403() throws Exception {
+		@DisplayName("주문 소유권이 없으면 404를 반환한다")
+		void createCashReceipt_소유권_없음_404() throws Exception {
 			given(paymentService.createCashReceipt(any(), any(), any()))
-				.willThrow(new CustomException(ErrorCode.ORDER_ACCESS_DENIED));
+				.willThrow(new CustomException(ErrorCode.ORDER_NOT_FOUND));
 
 			mockMvc.perform(post("/mypage/orders/1/cash-receipt")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(PaymentFixture.createPersonalDeductionRequest())))
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.message").value("해당 주문에 접근할 권한이 없습니다."));
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.message").value("주문을 찾을 수 없습니다."));
 		}
 
 		@Test

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/payment/service/PaymentServiceTest.java
@@ -90,7 +90,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(orderId, userId);
 			PaymentProcessRequest request = PaymentFixture.createTossPayRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(java.util.List.of());
@@ -112,7 +112,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(orderId, userId);
 			PaymentProcessRequest request = PaymentFixture.createKakaoPayRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(java.util.List.of());
@@ -133,7 +133,7 @@ class PaymentServiceTest {
 			ReflectionTestUtils.setField(order, "id", orderId);
 			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(List.of());
@@ -159,7 +159,7 @@ class PaymentServiceTest {
 			List<Long> matchSeatIds = List.of(101L, 102L);
 			PaymentProcessRequest request = PaymentFixture.createTossPayRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(matchSeatIds);
@@ -177,7 +177,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(orderId, userId);
 			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
 			given(orderSeatRepository.findMatchSeatIdsByOrderId(orderId)).willReturn(List.of(101L));
@@ -203,7 +203,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(orderId, userId);
 			PaymentProcessRequest request = PaymentFixture.createBankTransferRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
@@ -216,7 +216,7 @@ class PaymentServiceTest {
 		@Test
 		@DisplayName("주문이 없으면 ORDER_NOT_FOUND 예외가 발생한다")
 		void processPayment_주문_미발견_예외() {
-			given(orderRepository.findById(99L)).willReturn(Optional.empty());
+			given(orderRepository.findByIdAndUserId(99L, 1L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
 					() -> paymentService.processPayment(1L, 99L, PaymentFixture.createTossPayRequest())
@@ -226,19 +226,19 @@ class PaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("주문 소유자가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("주문 소유자가 아니면 ORDER_NOT_FOUND 예외가 발생한다")
 		void processPayment_소유권_없음_예외() {
 			Long actualOwnerId = 1L;
 			Long attackerId = 99L;
 			Order order = createOrderWithUser(1L, actualOwnerId);
 
-			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(1L, attackerId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
 					() -> paymentService.processPayment(attackerId, 1L, PaymentFixture.createTossPayRequest())
 			)
 					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
@@ -248,7 +248,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(1L, userId);
 			order.updateStatus(OrderStatus.PAID); // PAID 상태로 변경
 
-			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(order));
 
 			assertThatThrownBy(
 					() -> paymentService.processPayment(userId, 1L, PaymentFixture.createTossPayRequest())
@@ -265,7 +265,7 @@ class PaymentServiceTest {
 			Order order = createOrderWithUser(orderId, userId);
 			Payment existingPayment = PaymentFixture.createBankTransferPayment(order);
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(existingPayment));
 
 			assertThatThrownBy(
@@ -289,7 +289,7 @@ class PaymentServiceTest {
 			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
 			CashReceiptCreateRequest request = PaymentFixture.createPersonalDeductionRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.empty());
 			given(cashReceiptRepository.save(any(CashReceipt.class))).willAnswer(inv -> inv.getArgument(0));
@@ -310,7 +310,7 @@ class PaymentServiceTest {
 			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
 			CashReceiptCreateRequest request = PaymentFixture.createBusinessExpenseRequest();
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.empty());
 			given(cashReceiptRepository.save(any(CashReceipt.class))).willAnswer(inv -> inv.getArgument(0));
@@ -328,7 +328,7 @@ class PaymentServiceTest {
 			Long orderId = 1L;
 			Order order = createOrderWithUser(orderId, userId);
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
@@ -348,7 +348,7 @@ class PaymentServiceTest {
 			Payment payment = PaymentFixture.createCompletedTossPayPayment(order);
 			CashReceipt existing = PaymentFixture.createPersonalDeductionReceipt(payment);
 
-			given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(orderId, userId)).willReturn(Optional.of(order));
 			given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
 			given(cashReceiptRepository.findByPaymentId(payment.getId())).willReturn(Optional.of(existing));
 
@@ -361,26 +361,26 @@ class PaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("주문 소유자가 아니면 ORDER_ACCESS_DENIED 예외가 발생한다")
+		@DisplayName("주문 소유자가 아니면 ORDER_NOT_FOUND 예외가 발생한다")
 		void createCashReceipt_소유권_없음_예외() {
 			Long actualOwnerId = 1L;
 			Long attackerId = 99L;
 			Order order = createOrderWithUser(1L, actualOwnerId);
 
-			given(orderRepository.findById(1L)).willReturn(Optional.of(order));
+			given(orderRepository.findByIdAndUserId(1L, attackerId)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
 					() -> paymentService.createCashReceipt(attackerId, 1L,
 							PaymentFixture.createPersonalDeductionRequest())
 			)
 					.isInstanceOf(CustomException.class)
-					.hasMessage(ErrorCode.ORDER_ACCESS_DENIED.getMessage());
+					.hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
 		}
 
 		@Test
 		@DisplayName("주문이 없으면 ORDER_NOT_FOUND 예외가 발생한다")
 		void createCashReceipt_주문_미발견_예외() {
-			given(orderRepository.findById(99L)).willReturn(Optional.empty());
+			given(orderRepository.findByIdAndUserId(99L, 1L)).willReturn(Optional.empty());
 
 			assertThatThrownBy(
 					() -> paymentService.createCashReceipt(1L, 99L, PaymentFixture.createPersonalDeductionRequest())


### PR DESCRIPTION
## 🔧 작업 내용

- 주문 접근 검증을 `orderId + userId` 조건 조회로 변경하여 타인 주문 접근 시에도 `404`로 응답하도록 수정
- 결제/현금영수증/마이페이지 티켓 상세·QR·취소 API에 동일 정책 적용
- API 문서(Swagger) 응답 코드 설명을 `404(주문 없음 또는 접근 불가)` 정책에 맞게 정리

## 🧩 구현 상세 (선택)

- `OrderRepository`에 `findByIdAndUserId`, `findByIdForUpdateAndUserId` 추가
- `PaymentService`의 소유권 분기(`ORDER_ACCESS_DENIED`) 제거 후 owner-scoped 조회로 통일
- `MyPageQueryService` 상세 조회 SQL에 `o.user_id = :userId` 조건 추가
- `MyPageTicketService`의 상세/QR/취소 조회를 owner-scoped 조회로 변경

--- 

- `PESSIMISTIC_WRITE` 사용 이유 및 적용:
  - 적용 지점: `getTicketEntryQr`, `requestTicketCancel`
  - 이유: 동일 주문에 대한 동시 요청이 들어올 때 상태 변경/토큰 발급 로직의 경쟁 상태를 방지하고 트랜잭션을 직렬화하기 위해 사용
  - 필요성 판단:
    - `requestTicketCancel`: 주문/결제 상태 및 환불 처리의 중복 수행 방지를 위해 필요성이 높음
    - `getTicketEntryQr`: 중복 발급 방지 관점에서 안전성을 높이는 선택(대안 구현 가능하나 현 구조에서는 단순/안전)

---

- 코드리뷰 반영(락 범위 최소화):
  - 기존 `findByIdForUpdateAndUserId`의 `JOIN FETCH(match/homeClub/awayClub/stadium)` 제거
  - 현재는 `Order` 중심 잠금 조회(`WHERE o.id = :orderId AND o.user.id = :userId`)로 변경
  - 의도: 불필요한 연관 엔티티 잠금/경합 가능성 감소

### 📌 관련 Jira Issue

- GRGB-370

## 🧪 테스트 방법(선택)

- 테스트 대상:
  - `PaymentServiceTest`
  - `PaymentControllerTest`
  - `MyPageTicketServiceTest`
  - `MyPageControllerTest`
- 실행:
  - `./gradlew :Order-Core:test --tests "com.goormgb.be.ordercore.payment.service.PaymentServiceTest" --tests "com.goormgb.be.ordercore.payment.controller.PaymentControllerTest" --tests "com.goormgb.be.ordercore.mypage.service.MyPageTicketServiceTest" --tests "com.goormgb.be.ordercore.mypage.controller.MyPageControllerTest"`
- 체크 포인트:
  - 기존 `소유권 불일치 -> 403` 기대값이 `ORDER_NOT_FOUND -> 404`로 변경되었는지
  - owner-scoped 조회 메서드(`findByIdAndUserId`, `findByIdForUpdateAndUserId`, `findTicketDetailBaseByOrderIdAndUserId`) 기반으로 테스트 스텁이 갱신되었는지
  - 대상 테스트 클래스 실행 결과 `BUILD SUCCESSFUL`

## ❗ 참고 사항


