### PR TITLE
feat(match): PAYMENT_COMPLETED시 전석 SOLD 경기 SOLD_OUT 전환 [GRGB-378]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -6,6 +6,8 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.enums.SaleStatus;
+import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.PaymentCompletedEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentCompletedEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final MatchRepository matchRepository;
 
 	@KafkaListener(topics = EventTopic.PAYMENT_COMPLETED, groupId = "seat-service")
 	@Transactional
@@ -61,5 +64,26 @@ public class PaymentCompletedEventConsumer {
 				unexpectedStateCount,
 				missingSeatCount
 		);
+
+		updateMatchToSoldOutIfAllSeatsSold(event.getMatchId(), event.getOrderId());
+	}
+
+	private void updateMatchToSoldOutIfAllSeatsSold(Long matchId, Long orderId) {
+		boolean hasNonSoldSeat = matchSeatRepository.existsByMatchIdAndSaleStatusNot(matchId, MatchSeatSaleStatus.SOLD);
+		if (hasNonSoldSeat) {
+			return;
+		}
+
+		matchRepository.findById(matchId).ifPresent(match -> {
+			if (match.getSaleStatus() == SaleStatus.ON_SALE) {
+				match.updateSaleStatus(SaleStatus.SOLD_OUT);
+				log.info("[Kafka] 경기 상태 전환 - orderId={}, matchId={}, action=update, from=ON_SALE, to=SOLD_OUT",
+					orderId, matchId);
+				return;
+			}
+
+			log.debug("[Kafka] 경기 상태 전환 스킵 - orderId={}, matchId={}, action=skip, currentStatus={}",
+				orderId, matchId, match.getSaleStatus());
+		});
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -6,7 +6,6 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.goormgb.be.domain.match.enums.SaleStatus;
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.PaymentCompletedEvent;
@@ -69,21 +68,14 @@ public class PaymentCompletedEventConsumer {
 	}
 
 	private void updateMatchToSoldOutIfAllSeatsSold(Long matchId, Long orderId) {
-		boolean hasNonSoldSeat = matchSeatRepository.existsByMatchIdAndSaleStatusNot(matchId, MatchSeatSaleStatus.SOLD);
-		if (hasNonSoldSeat) {
+		int updated = matchRepository.updateSoldOutIfAllSeatsSold(matchId);
+		if (updated > 0) {
+			log.info("[Kafka] 경기 상태 전환 - orderId={}, matchId={}, action=update, from=ON_SALE, to=SOLD_OUT",
+				orderId, matchId);
 			return;
 		}
 
-		matchRepository.findById(matchId).ifPresent(match -> {
-			if (match.getSaleStatus() == SaleStatus.ON_SALE) {
-				match.updateSaleStatus(SaleStatus.SOLD_OUT);
-				log.info("[Kafka] 경기 상태 전환 - orderId={}, matchId={}, action=update, from=ON_SALE, to=SOLD_OUT",
-					orderId, matchId);
-				return;
-			}
-
-			log.debug("[Kafka] 경기 상태 전환 스킵 - orderId={}, matchId={}, action=skip, currentStatus={}",
-				orderId, matchId, match.getSaleStatus());
-		});
+		log.debug("[Kafka] 경기 상태 전환 스킵 - orderId={}, matchId={}, action=skip, reason=not_all_sold_or_not_on_sale",
+			orderId, matchId);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -50,6 +50,7 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 	);
 
 	List<MatchSeat> findAllByMatchIdAndSeatIdIn(Long matchId, List<Long> seatIds);
+	boolean existsByMatchIdAndSaleStatusNot(Long matchId, MatchSeatSaleStatus saleStatus);
 
 	/**
 	 * 좌석이 AVAILABLE 상태일 때만 BLOCKED로 변경한다.

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/repository/MatchSeatRepository.java
@@ -50,7 +50,6 @@ public interface MatchSeatRepository extends JpaRepository<MatchSeat, Long> {
 	);
 
 	List<MatchSeat> findAllByMatchIdAndSeatIdIn(Long matchId, List<Long> seatIds);
-	boolean existsByMatchIdAndSaleStatusNot(Long matchId, MatchSeatSaleStatus saleStatus);
 
 	/**
 	 * 좌석이 AVAILABLE 상태일 때만 BLOCKED로 변경한다.

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -85,4 +85,25 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		@Param("onSale") SaleStatus onSale,
 		@Param("soldOut") SaleStatus soldOut
 	);
+
+	/**
+	 * 경기의 모든 좌석이 SOLD 상태일 때만 ON_SALE -> SOLD_OUT으로 원자적 전환한다.
+	 */
+	@Modifying
+	@Query(
+		value = """
+			UPDATE matches m
+			SET sale_status = 'SOLD_OUT'
+			WHERE m.id = :matchId
+			  AND m.sale_status = 'ON_SALE'
+			  AND NOT EXISTS (
+					SELECT 1
+					FROM match_seats ms
+					WHERE ms.match_id = :matchId
+					  AND ms.sale_status <> 'SOLD'
+				)
+			""",
+		nativeQuery = true
+	)
+	int updateSoldOutIfAllSeatsSold(@Param("matchId") Long matchId);
 }


### PR DESCRIPTION
## 🔧 작업 내용

- `PaymentCompletedEventConsumer`에서 좌석 `BLOCKED -> SOLD` 처리 후 경기 단위 후처리 추가
- 해당 경기(`matchId`)의 좌석이 모두 `SOLD`이면 `matches.sale_status`를 `ON_SALE -> SOLD_OUT`으로 변경
- 판별용 레포지토리 메서드 `existsByMatchIdAndSaleStatusNot(...)` 추가

## 🧩 구현 상세 (선택)

- 결제수단과 무관하게 `PAYMENT_COMPLETED` 이벤트 기반으로 동일 로직을 적용
- 경기 상태는 `ON_SALE`일 때만 `SOLD_OUT`으로 전환하여 불필요한 상태 변경을 방지
- 상태 전환/스킵 로그를 추가하여 운영 중 추적 가능하도록 구성

## 🔒 락 vs 원자 쿼리 비교
- 락 방식: 순차성 보장은 강하지만 경합 시 대기/타임아웃/데드락 관리 비용이 커짐
- DB 원자 쿼리 1회 방식: 조건 판정과 갱신을 DB가 원자적으로 처리해 왕복과 경합 비용이 낮음
- 본 변경 선택 이유: 이번 요구사항은 조건이 단순(`전석 SOLD && ON_SALE`)해서 원자 쿼리가 더 단순하고 효율적

구현 예시(비교):

```java
// 1) 락 방식 (개념 예시)
@Transactional
public void updateSoldOutWithLock(Long matchId) {
    Match match = matchRepository.findByIdForUpdate(matchId); // PESSIMISTIC_WRITE
    boolean hasNonSold = matchSeatRepository.existsByMatchIdAndSaleStatusNot(matchId, SOLD);
    if (!hasNonSold && match.getSaleStatus() == ON_SALE) {
        match.updateSaleStatus(SOLD_OUT);
    }
}
```

```sql
-- 2) DB 원자 쿼리 방식 (이번 PR 적용)
UPDATE matches m
SET sale_status = 'SOLD_OUT'
WHERE m.id = :matchId
  AND m.sale_status = 'ON_SALE'
  AND NOT EXISTS (
        SELECT 1
        FROM match_seats ms
        WHERE ms.match_id = :matchId
          AND ms.sale_status <> 'SOLD'
  );
```

### 📌 관련 Jira Issue

- GRGB-378

## 🧪 테스트 방법(선택)

- dev에 올리가면 테스트 해보겠습니다!

## ❗ 참고 사항

- 다음 브랜치에서 취소 표 나올 경우에 다시 `ON_SALE`로 변환하는 로직 구현하겠습니당
