### PR TITLE
feat(match): 취소 표 생겼을 때 AVAILABLE 좌석이 있으면 경기 상태 ON_SALE 전환 [GRGB-379]

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -1,11 +1,13 @@
 package com.goormgb.be.seat.matchSeat.event;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.BankTransferExpiredEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class BankTransferExpiredEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final MatchRepository matchRepository;
 
 	@KafkaListener(topics = EventTopic.BANK_TRANSFER_EXPIRED, groupId = "seat-service")
 	@Transactional
@@ -62,5 +65,19 @@ public class BankTransferExpiredEventConsumer {
 			unexpectedStateCount,
 			missingSeatCount
 		);
+
+		updateMatchToOnSaleIfAnyAvailable(event.getMatchId(), event.getOrderId(), event.getPaymentId());
+	}
+
+	private void updateMatchToOnSaleIfAnyAvailable(Long matchId, Long orderId, Long paymentId) {
+		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(matchId, Instant.now());
+		if (updated > 0) {
+			log.info("[Kafka] 경기 상태 복귀 - orderId={}, paymentId={}, matchId={}, action=update, from=SOLD_OUT, to=ON_SALE",
+				orderId, paymentId, matchId);
+			return;
+		}
+
+		log.debug("[Kafka] 경기 상태 복귀 스킵 - orderId={}, paymentId={}, matchId={}, action=skip, reason=no_available_or_not_sold_out_or_started",
+			orderId, paymentId, matchId);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/BankTransferExpiredEventConsumer.java
@@ -7,6 +7,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.enums.SaleStatus;
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.BankTransferExpiredEvent;
@@ -70,7 +71,13 @@ public class BankTransferExpiredEventConsumer {
 	}
 
 	private void updateMatchToOnSaleIfAnyAvailable(Long matchId, Long orderId, Long paymentId) {
-		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(matchId, Instant.now());
+		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(
+			matchId,
+			Instant.now(),
+			SaleStatus.SOLD_OUT.name(),
+			SaleStatus.ON_SALE.name(),
+			MatchSeatSaleStatus.AVAILABLE.name()
+		);
 		if (updated > 0) {
 			log.info("[Kafka] 경기 상태 복귀 - orderId={}, paymentId={}, matchId={}, action=update, from=SOLD_OUT, to=ON_SALE",
 				orderId, paymentId, matchId);

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
@@ -7,6 +7,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.enums.SaleStatus;
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.OrderCancelledEvent;
@@ -69,7 +70,13 @@ public class OrderCancelledEventConsumer {
 	}
 
 	private void updateMatchToOnSaleIfAnyAvailable(Long matchId, Long orderId) {
-		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(matchId, Instant.now());
+		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(
+			matchId,
+			Instant.now(),
+			SaleStatus.SOLD_OUT.name(),
+			SaleStatus.ON_SALE.name(),
+			MatchSeatSaleStatus.AVAILABLE.name()
+		);
 		if (updated > 0) {
 			log.info("[Kafka] 경기 상태 복귀 - orderId={}, matchId={}, action=update, from=SOLD_OUT, to=ON_SALE",
 				orderId, matchId);

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/OrderCancelledEventConsumer.java
@@ -1,11 +1,13 @@
 package com.goormgb.be.seat.matchSeat.event;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.OrderCancelledEvent;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderCancelledEventConsumer {
 
 	private final MatchSeatRepository matchSeatRepository;
+	private final MatchRepository matchRepository;
 
 	@KafkaListener(topics = EventTopic.ORDER_CANCELLED, groupId = "seat-service")
 	@Transactional
@@ -61,5 +64,19 @@ public class OrderCancelledEventConsumer {
 				unexpectedStateCount,
 				missingSeatCount
 		);
+
+		updateMatchToOnSaleIfAnyAvailable(event.getMatchId(), event.getOrderId());
+	}
+
+	private void updateMatchToOnSaleIfAnyAvailable(Long matchId, Long orderId) {
+		int updated = matchRepository.updateOnSaleIfAnyAvailableSeat(matchId, Instant.now());
+		if (updated > 0) {
+			log.info("[Kafka] 경기 상태 복귀 - orderId={}, matchId={}, action=update, from=SOLD_OUT, to=ON_SALE",
+				orderId, matchId);
+			return;
+		}
+
+		log.debug("[Kafka] 경기 상태 복귀 스킵 - orderId={}, matchId={}, action=skip, reason=no_available_or_not_sold_out_or_started",
+			orderId, matchId);
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/matchSeat/event/PaymentCompletedEventConsumer.java
@@ -6,6 +6,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goormgb.be.domain.match.enums.SaleStatus;
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.kafka.EventTopic;
 import com.goormgb.be.kafka.event.PaymentCompletedEvent;
@@ -68,7 +69,12 @@ public class PaymentCompletedEventConsumer {
 	}
 
 	private void updateMatchToSoldOutIfAllSeatsSold(Long matchId, Long orderId) {
-		int updated = matchRepository.updateSoldOutIfAllSeatsSold(matchId);
+		int updated = matchRepository.updateSoldOutIfAllSeatsSold(
+			matchId,
+			SaleStatus.ON_SALE.name(),
+			SaleStatus.SOLD_OUT.name(),
+			MatchSeatSaleStatus.SOLD.name()
+		);
 		if (updated > 0) {
 			log.info("[Kafka] 경기 상태 전환 - orderId={}, matchId={}, action=update, from=ON_SALE, to=SOLD_OUT",
 				orderId, matchId);

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -106,4 +106,27 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		nativeQuery = true
 	)
 	int updateSoldOutIfAllSeatsSold(@Param("matchId") Long matchId);
+
+	/**
+	 * 경기 상태가 SOLD_OUT이고, 경기 시작 전이며, AVAILABLE 좌석이 1개 이상 존재할 때
+	 * SOLD_OUT -> ON_SALE로 원자적 복귀한다.
+	 */
+	@Modifying
+	@Query(
+		value = """
+			UPDATE matches m
+			SET sale_status = 'ON_SALE'
+			WHERE m.id = :matchId
+			  AND m.sale_status = 'SOLD_OUT'
+			  AND m.match_at > :now
+			  AND EXISTS (
+					SELECT 1
+					FROM match_seats ms
+					WHERE ms.match_id = :matchId
+					  AND ms.sale_status = 'AVAILABLE'
+				)
+			""",
+		nativeQuery = true
+	)
+	int updateOnSaleIfAnyAvailableSeat(@Param("matchId") Long matchId, @Param("now") Instant now);
 }

--- a/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
+++ b/common-core/src/main/java/com/goormgb/be/domain/match/repository/MatchRepository.java
@@ -93,19 +93,24 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 	@Query(
 		value = """
 			UPDATE matches m
-			SET sale_status = 'SOLD_OUT'
+			SET sale_status = :soldOutStatus
 			WHERE m.id = :matchId
-			  AND m.sale_status = 'ON_SALE'
+			  AND m.sale_status = :onSaleStatus
 			  AND NOT EXISTS (
 					SELECT 1
 					FROM match_seats ms
 					WHERE ms.match_id = :matchId
-					  AND ms.sale_status <> 'SOLD'
+					  AND ms.sale_status <> :soldSeatStatus
 				)
 			""",
 		nativeQuery = true
 	)
-	int updateSoldOutIfAllSeatsSold(@Param("matchId") Long matchId);
+	int updateSoldOutIfAllSeatsSold(
+		@Param("matchId") Long matchId,
+		@Param("onSaleStatus") String onSaleStatus,
+		@Param("soldOutStatus") String soldOutStatus,
+		@Param("soldSeatStatus") String soldSeatStatus
+	);
 
 	/**
 	 * 경기 상태가 SOLD_OUT이고, 경기 시작 전이며, AVAILABLE 좌석이 1개 이상 존재할 때
@@ -115,18 +120,24 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 	@Query(
 		value = """
 			UPDATE matches m
-			SET sale_status = 'ON_SALE'
+			SET sale_status = :onSaleStatus
 			WHERE m.id = :matchId
-			  AND m.sale_status = 'SOLD_OUT'
+			  AND m.sale_status = :soldOutStatus
 			  AND m.match_at > :now
 			  AND EXISTS (
 					SELECT 1
 					FROM match_seats ms
 					WHERE ms.match_id = :matchId
-					  AND ms.sale_status = 'AVAILABLE'
+					  AND ms.sale_status = :availableSeatStatus
 				)
 			""",
 		nativeQuery = true
 	)
-	int updateOnSaleIfAnyAvailableSeat(@Param("matchId") Long matchId, @Param("now") Instant now);
+	int updateOnSaleIfAnyAvailableSeat(
+		@Param("matchId") Long matchId,
+		@Param("now") Instant now,
+		@Param("soldOutStatus") String soldOutStatus,
+		@Param("onSaleStatus") String onSaleStatus,
+		@Param("availableSeatStatus") String availableSeatStatus
+	);
 }


### PR DESCRIPTION
## 🔧 작업 내용

- `OrderCancelledEventConsumer`에 경기 상태 복귀 후처리 추가
- `BankTransferExpiredEventConsumer`에 경기 상태 복귀 후처리 추가
- `MatchRepository.updateOnSaleIfAnyAvailableSeat(matchId, now)` 원자 쿼리 추가

## 🧩 구현 상세 (선택)

- 좌석 복원(`SOLD -> AVAILABLE`) 이후 동일 트랜잭션에서 경기 상태 복귀를 시도
- 아래 조건을 모두 만족할 때만 `SOLD_OUT -> ON_SALE` 전환:
- `matches.sale_status = SOLD_OUT`
- `matches.match_at > now` (경기 시작 전)
- `EXISTS (match_seats.sale_status = AVAILABLE)`
- 원자 쿼리 1회로 조건 판정과 상태 변경을 동시에 수행해 동시성/재처리 상황에서 멱등적으로 동작

### 📌 관련 Jira Issue

- GRGB-379

## 🧪 테스트 방법(선택)

- dev에서 테스트 해보겠슴다!

## ❗ 참고 사항
