### PR TITLE
feat(auth-guard, order-core): Phase 2 — 사용자 데이터 Redis 분산 캐시 적용 [GRGB-375]

### DIFF
--- a/Auth-Guard/build.gradle
+++ b/Auth-Guard/build.gradle
@@ -28,7 +28,9 @@ dependencies {
     implementation project(':common-core')
     testImplementation(testFixtures(project(':common-core')))
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/controller/UserController.java
@@ -4,9 +4,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goormgb.be.authguard.auth.service.AuthMeService;
 import com.goormgb.be.global.response.ApiResult;
 import com.goormgb.be.user.dto.response.UserInfoGetResponse;
-import com.goormgb.be.user.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 
-	private final UserService userService;
+	private final AuthMeService authMeService;
 
 	@Operation(summary = "내 정보 조회", description = "현재 로그인한 유저의 기본 정보(ID, 이메일, 닉네임, 상태)를 조회합니다.",
 		security = @SecurityRequirement(name = "BearerAuth"))
@@ -31,6 +31,6 @@ public class UserController {
 	})
 	@GetMapping("/me")
 	public ApiResult<UserInfoGetResponse> getMyInfo(@AuthenticationPrincipal Long id) {
-		return ApiResult.ok(userService.getMyInfo(id));
+		return ApiResult.ok(authMeService.getMyInfo(id));
 	}
 }

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthMeService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthMeService.java
@@ -1,0 +1,54 @@
+package com.goormgb.be.authguard.auth.service;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.authguard.config.CacheConfig;
+import com.goormgb.be.user.dto.cache.UserCacheDto;
+import com.goormgb.be.user.dto.response.UserInfoGetResponse;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@code GET /me} 엔드포인트의 응답을 Redis 분산 캐시로 흡수하는 서비스.
+ *
+ * <p>프론트가 주기적으로 호출하는 확인 API 로 매 요청마다 DB 를 때리던 구간이다.
+ * {@link UserCacheService} 가 제공하는 사용자 스냅샷을 기반으로 응답 DTO 를 조립한 뒤,
+ * 30초 TTL 로 캐시한다. 30초 지연은 로그인 직후 프로필 일관성 측면에서 수용 가능한 수준이다.</p>
+ *
+ * <p>닉네임 변경·차단/해제·탈퇴 등 사용자 상태가 바뀌는 지점에서는
+ * {@link #evict(Long)} 로 즉시 무효화해 Pod 간 전파를 보장한다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthMeService {
+
+	private final UserCacheService userCacheService;
+
+	/**
+	 * 로그인한 사용자의 기본 정보를 반환한다. Redis 캐시 미스 시 {@link UserCacheService} 를
+	 * 거쳐 사용자 스냅샷을 조회하고, 응답 DTO 를 조립해 캐시에 저장한다.
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_AUTH_ME, key = "#userId", unless = "#result == null")
+	public UserInfoGetResponse getMyInfo(Long userId) {
+		UserCacheDto user = userCacheService.getById(userId);
+		boolean onboardingRequired = !Boolean.TRUE.equals(user.onboardingCompleted());
+		return new UserInfoGetResponse(
+			user.id(),
+			user.status(),
+			user.email(),
+			user.nickname(),
+			onboardingRequired
+		);
+	}
+
+	/**
+	 * 해당 사용자의 {@code /me} 응답 캐시를 무효화한다. 사용자 상태 변경 직후 호출한다.
+	 */
+	@CacheEvict(cacheNames = CacheConfig.CACHE_AUTH_ME, key = "#userId")
+	public void evict(Long userId) {
+	}
+}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -185,17 +185,8 @@ public class AuthService {
 		authMetricsService.increaseUserBlocked();
 		log.info("[User Block] userId={}, status={} -> {}", targetUserId, beforeStatus, user.getStatus());
 
-		// 캐시 무효화: 상태 변경이 Pod 간 즉시 전파되도록 user-by-id / auth-me 캐시 제거
-		userCacheService.evict(targetUserId);
-		authMeService.evict(targetUserId);
-
-		// 트랜잭션 커밋 성공 후 차단 유저의 주문 상태 변경 이벤트 발행
-		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-			@Override
-			public void afterCommit() {
-				publishUserBlockedEvent(targetUserId);
-			}
-		});
+		// 캐시 무효화 + 차단 이벤트 발행은 트랜잭션 커밋 성공 후 수행 (pre-commit race 방지)
+		registerAfterCommitInvalidation(targetUserId, true);
 
 		return UserStatusChangeResponse.from(user);
 	}
@@ -213,9 +204,8 @@ public class AuthService {
 		authMetricsService.increaseUserUnblocked();
 		log.info("[User Unblock] userId={}, status={} -> {}", targetUserId, beforeStatus, user.getStatus());
 
-		// 캐시 무효화: 상태 변경이 Pod 간 즉시 전파되도록 user-by-id / auth-me 캐시 제거
-		userCacheService.evict(targetUserId);
-		authMeService.evict(targetUserId);
+		// 캐시 무효화는 트랜잭션 커밋 성공 후에만 수행 (pre-commit race 방지)
+		registerAfterCommitInvalidation(targetUserId, false);
 
 		return UserStatusChangeResponse.from(user);
 	}
@@ -241,12 +231,34 @@ public class AuthService {
 				.build();
 		withdrawalRequestRepository.save(withdrawalRequest);
 
-		// 5. 캐시 무효화: 탈퇴 직후 다른 Pod 에서 여전히 ACTIVATE 로 보이지 않도록 제거
-		userCacheService.evict(userId);
-		authMeService.evict(userId);
+		// 5. 캐시 무효화: 탈퇴 직후 다른 Pod 에서 여전히 ACTIVATE 로 보이지 않도록, 트랜잭션 커밋 후 제거
+		registerAfterCommitInvalidation(userId, false);
 
 		return WithdrawalResponse.from(withdrawalRequest);
 
+	}
+
+	/**
+	 * 사용자 상태 변경(차단/해제/탈퇴) 직후 트랜잭션이 커밋되고 나서 수행해야 할 후속 작업을 한 번에 등록한다.
+	 *
+	 * <p>쓰기 트랜잭션 중간에 {@code @CacheEvict} 가 실행되면, 같은 userId 로 들어온 다른 Pod 의
+	 * {@code /me} 조회가 아직 커밋 안 된 pre-commit 스냅샷을 읽어 Redis 캐시를 재채움하는 race 가
+	 * 가능하다. 이를 막기 위해 evict 와 Kafka 이벤트 발행을 모두 {@code afterCommit} 에 위임한다.</p>
+	 *
+	 * @param userId 대상 사용자
+	 * @param publishBlockedEvent {@code true} 이면 차단 이벤트({@code USER_BLOCKED}) 도 같이 발행
+	 */
+	private void registerAfterCommitInvalidation(Long userId, boolean publishBlockedEvent) {
+		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+			@Override
+			public void afterCommit() {
+				userCacheService.evict(userId);
+				authMeService.evict(userId);
+				if (publishBlockedEvent) {
+					publishUserBlockedEvent(userId);
+				}
+			}
+		});
 	}
 
 	private void publishUserBlockedEvent(Long userId) {

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/AuthService.java
@@ -53,6 +53,8 @@ public class AuthService {
 	private final WithdrawalRequestRepository withdrawalRequestRepository;
 	private final AuthMetricsService authMetricsService;
 	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final UserCacheService userCacheService;
+	private final AuthMeService authMeService;
 
 	/**
 	 * Refresh Token으로 새로운 Access Token과 Refresh Token을 발급한다. (RTR)
@@ -183,6 +185,10 @@ public class AuthService {
 		authMetricsService.increaseUserBlocked();
 		log.info("[User Block] userId={}, status={} -> {}", targetUserId, beforeStatus, user.getStatus());
 
+		// 캐시 무효화: 상태 변경이 Pod 간 즉시 전파되도록 user-by-id / auth-me 캐시 제거
+		userCacheService.evict(targetUserId);
+		authMeService.evict(targetUserId);
+
 		// 트랜잭션 커밋 성공 후 차단 유저의 주문 상태 변경 이벤트 발행
 		TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
 			@Override
@@ -207,6 +213,10 @@ public class AuthService {
 		authMetricsService.increaseUserUnblocked();
 		log.info("[User Unblock] userId={}, status={} -> {}", targetUserId, beforeStatus, user.getStatus());
 
+		// 캐시 무효화: 상태 변경이 Pod 간 즉시 전파되도록 user-by-id / auth-me 캐시 제거
+		userCacheService.evict(targetUserId);
+		authMeService.evict(targetUserId);
+
 		return UserStatusChangeResponse.from(user);
 	}
 
@@ -230,6 +240,10 @@ public class AuthService {
 				.user(user)
 				.build();
 		withdrawalRequestRepository.save(withdrawalRequest);
+
+		// 5. 캐시 무효화: 탈퇴 직후 다른 Pod 에서 여전히 ACTIVATE 로 보이지 않도록 제거
+		userCacheService.evict(userId);
+		authMeService.evict(userId);
 
 		return WithdrawalResponse.from(withdrawalRequest);
 

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/UserCacheService.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/auth/service/UserCacheService.java
@@ -1,0 +1,48 @@
+package com.goormgb.be.authguard.auth.service;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.authguard.config.CacheConfig;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.user.dto.cache.UserCacheDto;
+import com.goormgb.be.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Auth-Guard 에서 사용자 정보를 Redis 분산 캐시를 경유해 조회하는 서비스.
+ *
+ * <p>매 요청마다 발생하던 {@code UserRepository.findByIdOrThrow} 호출을 흡수해 DB 부하를 줄인다.
+ * Pod 간 즉시 전파가 필요하므로 로컬 캐시가 아닌 Redis 를 사용한다 (Phase 2 설계).</p>
+ *
+ * <p>캐시 TTL 은 10분이며, 닉네임·상태 변경 같은 프로필 수정 지점에서
+ * {@link #evict(Long)} 을 호출하거나 {@code @CacheEvict} 를 걸어 즉시 무효화한다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserCacheService {
+
+	private final UserRepository userRepository;
+
+	/**
+	 * userId 로 {@link UserCacheDto} 를 반환한다. 캐시 미스 시 DB 에서 조회해 캐시에 저장한다.
+	 *
+	 * @param userId 대상 사용자 ID
+	 * @return 사용자 스냅샷 DTO
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_USER_BY_ID, key = "#userId", unless = "#result == null")
+	public UserCacheDto getById(Long userId) {
+		return UserCacheDto.from(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND));
+	}
+
+	/**
+	 * 해당 사용자 캐시를 즉시 무효화한다. 닉네임·상태·프로필 변경 직후 호출한다.
+	 */
+	@CacheEvict(cacheNames = CacheConfig.CACHE_USER_BY_ID, key = "#userId")
+	public void evict(Long userId) {
+	}
+}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
@@ -1,0 +1,64 @@
+package com.goormgb.be.authguard.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Auth-Guard 서비스 캐시 설정 (Phase 2: Redis 분산 캐시).
+ *
+ * <p>Auth-Guard 는 Phase 1 의 Caffeine 로컬 캐시 대상이 없었기 때문에 본 클래스가 최초
+ * {@code CacheManager} 빈 구성이다. 사용자 정보는 Pod 간 즉시 전파(닉네임/차단 상태 변경)가
+ * 필요하므로 로컬 캐시가 아닌 Redis 분산 캐시를 채택한다.</p>
+ *
+ * <p>등록된 캐시:</p>
+ * <ul>
+ *   <li>{@value #CACHE_USER_BY_ID} — {@code UserRepository.findByIdOrThrow} 결과의 DTO 스냅샷. TTL 10분.</li>
+ *   <li>{@value #CACHE_AUTH_ME} — {@code /me} 응답 DTO. TTL 30초 (프론트 폴링 허용 범위).</li>
+ * </ul>
+ *
+ * <p>정합성 전략: 프로필/상태 변경 서비스 메서드에 {@code @CacheEvict} 를 걸어 즉시 무효화한다.
+ * Redis 장애 시 Spring Cache 기본 동작에 따라 캐시 미스로 fallback 되어 DB 직접 조회가 수행된다.</p>
+ *
+ * @see com.goormgb.be.user.dto.cache.UserCacheDto
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	public static final String CACHE_USER_BY_ID = "user-by-id";
+	public static final String CACHE_AUTH_ME = "auth-me";
+
+	@Primary
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10)));
+		configs.put(CACHE_AUTH_ME, redisConfig(Duration.ofSeconds(30)));
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(redisConfig(Duration.ofMinutes(10)))
+			.withInitialCacheConfigurations(configs)
+			.build();
+	}
+
+	private RedisCacheConfiguration redisConfig(Duration ttl) {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(ttl)
+			.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.disableCachingNullValues();
+	}
+}

--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
@@ -16,6 +16,14 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 /**
  * Auth-Guard 서비스 캐시 설정 (Phase 2: Redis 분산 캐시).
  *
@@ -44,21 +52,46 @@ public class CacheConfig {
 	@Primary
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		GenericJackson2JsonRedisSerializer valueSerializer =
+			new GenericJackson2JsonRedisSerializer(cacheObjectMapper());
+
 		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
-		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10)));
-		configs.put(CACHE_AUTH_ME, redisConfig(Duration.ofSeconds(30)));
+		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10), valueSerializer));
+		configs.put(CACHE_AUTH_ME, redisConfig(Duration.ofSeconds(30), valueSerializer));
 
 		return RedisCacheManager.builder(connectionFactory)
-			.cacheDefaults(redisConfig(Duration.ofMinutes(10)))
+			.cacheDefaults(redisConfig(Duration.ofMinutes(10), valueSerializer))
 			.withInitialCacheConfigurations(configs)
 			.build();
 	}
 
-	private RedisCacheConfiguration redisConfig(Duration ttl) {
+	private RedisCacheConfiguration redisConfig(Duration ttl, GenericJackson2JsonRedisSerializer serializer) {
 		return RedisCacheConfiguration.defaultCacheConfig()
 			.entryTtl(ttl)
 			.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
-			.serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.serializeValuesWith(SerializationPair.fromSerializer(serializer))
 			.disableCachingNullValues();
+	}
+
+	/**
+	 * Redis 캐시 값 직렬화에 사용할 전용 {@link ObjectMapper} 를 생성한다.
+	 *
+	 * <p>기본 {@code GenericJackson2JsonRedisSerializer} 는 {@link java.time.Instant} 등
+	 * JSR-310 타입을 직렬화하지 못해 런타임에 {@code Java 8 date/time type not supported}
+	 * 예외가 발생한다. 이를 방지하기 위해 {@link JavaTimeModule} 을 등록한 전용 매퍼를 사용한다.</p>
+	 *
+	 * <p>Polymorphic typing 은 {@code GenericJackson2JsonRedisSerializer} 동작에 필요하므로
+	 * {@link BasicPolymorphicTypeValidator} 로 도메인 패키지만 허용하도록 제한해 안전하게 활성화한다.</p>
+	 */
+	private ObjectMapper cacheObjectMapper() {
+		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+			.allowIfBaseType(Object.class)
+			.build();
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		return mapper;
 	}
 }

--- a/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/UserControllerTest.java
+++ b/Auth-Guard/src/test/java/com/goormgb/be/authguard/auth/controller/UserControllerTest.java
@@ -19,7 +19,7 @@ import com.goormgb.be.authguard.support.WebMvcTestSupport;
 import com.goormgb.be.global.environment.ErrorResponseStrategy;
 import com.goormgb.be.user.dto.response.UserInfoGetResponse;
 import com.goormgb.be.user.enums.UserStatus;
-import com.goormgb.be.user.service.UserService;
+import com.goormgb.be.authguard.auth.service.AuthMeService;
 
 @WebMvcTest(controllers = UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -27,7 +27,7 @@ import com.goormgb.be.user.service.UserService;
 class UserControllerTest extends WebMvcTestSupport {
 
 	@MockitoBean
-	private UserService userService;
+	private AuthMeService authMeService;
 
 	@MockitoBean
 	private ErrorResponseStrategy errorResponseStrategy;
@@ -48,7 +48,7 @@ class UserControllerTest extends WebMvcTestSupport {
 		UserInfoGetResponse response = new UserInfoGetResponse(
 			userId, UserStatus.ACTIVATE, "user@example.com", "홍길동", true
 		);
-		given(userService.getMyInfo(userId)).willReturn(response);
+		given(authMeService.getMyInfo(userId)).willReturn(response);
 
 		// when & then
 		mockMvc.perform(get("/me"))
@@ -71,7 +71,7 @@ class UserControllerTest extends WebMvcTestSupport {
 		UserInfoGetResponse response = new UserInfoGetResponse(
 			userId, UserStatus.ACTIVATE, "user@example.com", "홍길동", false
 		);
-		given(userService.getMyInfo(userId)).willReturn(response);
+		given(authMeService.getMyInfo(userId)).willReturn(response);
 
 		// when & then
 		mockMvc.perform(get("/me"))

--- a/Order-Core/build.gradle
+++ b/Order-Core/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // Redis 분산 캐시 (Phase 2 — 사용자 데이터 Pod 간 공유)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // 필수: JSON 로깅
     implementation "net.logstash.logback:logstash-logback-encoder:7.4"
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -1,29 +1,44 @@
 package com.goormgb.be.ordercore.config;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
- * Order-Core 서비스 로컬 캐시 설정.
+ * Order-Core 서비스 캐시 설정.
  *
- * <p>주문서 조회({@code OrderService#getOrderSheet}) 시 반복 수행되던 경기 메타 조회를
- * 흡수하기 위한 {@code match-detail} 캐시를 등록한다. 주문 생성({@code createOrder}) 의
- * {@code Match} 조회는 영속성 컨텍스트에 연결된 관리 엔티티가 필요하므로 캐시를 사용하지
- * 않는다.</p>
+ * <p>Phase 1 — Caffeine 로컬 캐시: 주문서 조회({@code OrderService#getOrderSheet}) 시 반복
+ * 수행되던 경기 메타 조회를 흡수하기 위한 {@code match-detail} 캐시를 등록한다. 주문 생성
+ * ({@code createOrder}) 의 {@code Match} 조회는 영속성 컨텍스트에 연결된 관리 엔티티가
+ * 필요하므로 Caffeine 캐시를 사용하지 않는다.</p>
+ *
+ * <p>Phase 2 — Redis 분산 캐시: 사용자 정보({@code user-by-id}) 를 Pod 간 공유 목적으로
+ * Redis 에 캐시한다. {@code @Cacheable} 어노테이션에서 {@code cacheManager = "redisCacheManager"}
+ * 로 명시해 Caffeine(Primary) 와 격리 운용한다.</p>
  */
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
 	public static final String CACHE_MATCH_DETAIL = "match-detail";
+	public static final String CACHE_USER_BY_ID = "user-by-id";
 
+	@Primary
 	@Bean
 	public CacheManager cacheManager() {
 		CaffeineCacheManager manager = new CaffeineCacheManager();
@@ -36,5 +51,24 @@ public class CacheConfig {
 				.build());
 
 		return manager;
+	}
+
+	@Bean(name = "redisCacheManager")
+	public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10)));
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(redisConfig(Duration.ofMinutes(10)))
+			.withInitialCacheConfigurations(configs)
+			.build();
+	}
+
+	private RedisCacheConfiguration redisConfig(Duration ttl) {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(ttl)
+			.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.disableCachingNullValues();
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -17,6 +17,13 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
@@ -37,6 +44,14 @@ public class CacheConfig {
 
 	public static final String CACHE_MATCH_DETAIL = "match-detail";
 	public static final String CACHE_USER_BY_ID = "user-by-id";
+	/**
+	 * Auth-Guard 가 소유한 {@code /auth/me} 응답 캐시의 키 스페이스.
+	 *
+	 * <p>Order-Core 는 해당 캐시에 값을 <b>저장하지 않고</b>, 사용자 프로필·온보딩 변경 시 동일
+	 * Redis 인스턴스에서 키를 삭제하기 위한 용도로만 등록한다. 같은 사용자에 대한 쓰기가 Order-Core
+	 * 에서 발생해도 Auth-Guard 의 {@code /me} 응답이 즉시 갱신되도록 보장한다.</p>
+	 */
+	public static final String CACHE_AUTH_ME = "auth-me";
 
 	@Primary
 	@Bean
@@ -55,20 +70,43 @@ public class CacheConfig {
 
 	@Bean(name = "redisCacheManager")
 	public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+		GenericJackson2JsonRedisSerializer valueSerializer =
+			new GenericJackson2JsonRedisSerializer(cacheObjectMapper());
+
 		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
-		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10)));
+		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10), valueSerializer));
+		configs.put(CACHE_AUTH_ME, redisConfig(Duration.ofSeconds(30), valueSerializer));
 
 		return RedisCacheManager.builder(connectionFactory)
-			.cacheDefaults(redisConfig(Duration.ofMinutes(10)))
+			.cacheDefaults(redisConfig(Duration.ofMinutes(10), valueSerializer))
 			.withInitialCacheConfigurations(configs)
 			.build();
 	}
 
-	private RedisCacheConfiguration redisConfig(Duration ttl) {
+	private RedisCacheConfiguration redisConfig(Duration ttl, GenericJackson2JsonRedisSerializer serializer) {
 		return RedisCacheConfiguration.defaultCacheConfig()
 			.entryTtl(ttl)
 			.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
-			.serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.serializeValuesWith(SerializationPair.fromSerializer(serializer))
 			.disableCachingNullValues();
+	}
+
+	/**
+	 * Redis 캐시 값 직렬화 전용 {@link ObjectMapper}.
+	 *
+	 * <p>{@link java.time.Instant} 등 JSR-310 타입 직렬화 지원을 위해 {@link JavaTimeModule} 을 등록하고,
+	 * {@code GenericJackson2JsonRedisSerializer} 가 요구하는 polymorphic typing 을
+	 * {@link BasicPolymorphicTypeValidator} 로 제한 활성화한다.</p>
+	 */
+	private ObjectMapper cacheObjectMapper() {
+		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+			.allowIfBaseType(Object.class)
+			.build();
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		return mapper;
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileService.java
@@ -14,6 +14,7 @@ import com.goormgb.be.ordercore.mypage.dto.response.MyPageProfileResponse;
 import com.goormgb.be.ordercore.order.enums.OrderStatus;
 import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
+import com.goormgb.be.ordercore.user.service.UserCacheService;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
 import com.goormgb.be.user.repository.UserRepository;
@@ -44,6 +45,7 @@ public class MyPageProfileService {
 	private final UserRepository userRepository;
 	private final UserSnsRepository userSnsRepository;
 	private final OrderRepository orderRepository;
+	private final UserCacheService userCacheService;
 	private final Clock clock;
 
 	private record UserInfo(User user, UserSns userSns) {
@@ -60,6 +62,8 @@ public class MyPageProfileService {
 		String nickname = request.nickname().trim();
 		UserInfo userInfo = findUserInfo(userId);
 		userInfo.user().updateNickname(nickname);
+		// 닉네임 변경은 UserCacheDto 에 담긴 값이므로 커밋 후 전 서비스의 캐시를 무효화한다.
+		userCacheService.evictAfterCommit(userId);
 		return MyPageAccountResponse.of(userInfo.user(), userInfo.userSns());
 	}
 

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/service/OnboardingPreferenceService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/onboarding/service/OnboardingPreferenceService.java
@@ -28,6 +28,7 @@ import com.goormgb.be.ordercore.onboarding.dto.request.OnboardingPreferenceUpdat
 import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceCreateResponse;
 import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingPreferenceGetResponse;
 import com.goormgb.be.ordercore.onboarding.dto.response.OnboardingStatusGetResponse;
+import com.goormgb.be.ordercore.user.service.UserCacheService;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.repository.UserRepository;
 
@@ -42,6 +43,7 @@ public class OnboardingPreferenceService {
 	private final OnboardingPreferredBlockRepository preferredBlockRepository;
 	private final ClubRepository clubRepository;
 	private final UserRepository userRepository;
+	private final UserCacheService userCacheService;
 
 	@Transactional(readOnly = true)
 	public OnboardingStatusGetResponse getOnboardingStatus(Long userId) {
@@ -93,6 +95,10 @@ public class OnboardingPreferenceService {
 		// 온보딩 완료
 		user.completeOnboarding();
 
+		// onboardingCompleted 는 UserCacheDto 에 포함되어 Auth-Guard /me 에서 참조한다.
+		// 커밋 완료 후 공유 캐시(user-by-id, auth-me) 를 무효화해 stale 상태로 노출되지 않게 한다.
+		userCacheService.evictAfterCommit(userId);
+
 		return OnboardingPreferenceCreateResponse.from(user);
 	}
 
@@ -141,6 +147,9 @@ public class OnboardingPreferenceService {
 		savePreferredBlocks(user, request.preferredBlockIds());
 
 		user.completeOnboarding();
+
+		// 온보딩 갱신도 UserCacheDto 의 onboardingCompleted 에 반영되므로 공유 캐시 무효화.
+		userCacheService.evictAfterCommit(userId);
 	}
 
 	@Transactional

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/user/service/UserCacheService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/user/service/UserCacheService.java
@@ -1,0 +1,49 @@
+package com.goormgb.be.ordercore.user.service;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.ordercore.config.CacheConfig;
+import com.goormgb.be.user.dto.cache.UserCacheDto;
+import com.goormgb.be.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Order-Core 에서 사용자 정보를 Redis 분산 캐시를 경유해 조회하는 서비스.
+ *
+ * <p>주문 생성·마이페이지 프로필 등 요청당 발생하던 {@code UserRepository.findByIdOrThrow}
+ * 호출을 흡수해 DB 부하를 줄인다. Auth-Guard 와 동일한 {@code user-by-id} 키 스페이스를
+ * 공유하므로 Pod 간·서비스 간에도 일관된 사용자 스냅샷을 사용한다.</p>
+ *
+ * <p>캐시 기본 TTL 은 10분이며, 쓰기 트랜잭션(프로필 변경 등) 직후에는 {@link #evict(Long)} 으로
+ * 즉시 무효화해 staleness 를 최소화한다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserCacheService {
+
+	private final UserRepository userRepository;
+
+	@Cacheable(
+		cacheNames = CacheConfig.CACHE_USER_BY_ID,
+		cacheManager = "redisCacheManager",
+		key = "#userId",
+		unless = "#result == null"
+	)
+	public UserCacheDto getById(Long userId) {
+		return UserCacheDto.from(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND));
+	}
+
+	@CacheEvict(
+		cacheNames = CacheConfig.CACHE_USER_BY_ID,
+		cacheManager = "redisCacheManager",
+		key = "#userId"
+	)
+	public void evict(Long userId) {
+	}
+}

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/user/service/UserCacheService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/user/service/UserCacheService.java
@@ -2,8 +2,11 @@ package com.goormgb.be.ordercore.user.service;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.ordercore.config.CacheConfig;
@@ -19,8 +22,10 @@ import lombok.RequiredArgsConstructor;
  * 호출을 흡수해 DB 부하를 줄인다. Auth-Guard 와 동일한 {@code user-by-id} 키 스페이스를
  * 공유하므로 Pod 간·서비스 간에도 일관된 사용자 스냅샷을 사용한다.</p>
  *
- * <p>캐시 기본 TTL 은 10분이며, 쓰기 트랜잭션(프로필 변경 등) 직후에는 {@link #evict(Long)} 으로
- * 즉시 무효화해 staleness 를 최소화한다.</p>
+ * <p>프로필·온보딩 변경 등 쓰기 트랜잭션 직후에는 {@link #evictAfterCommit(Long)} 를 호출해
+ * 현재 트랜잭션 커밋 완료 시점에 캐시를 무효화한다. 같은 사용자의 {@code /auth/me} 응답 캐시
+ * ({@value com.goormgb.be.ordercore.config.CacheConfig#CACHE_AUTH_ME})도 동반 제거해
+ * Auth-Guard 가 stale 데이터를 노출하지 않도록 보장한다.</p>
  */
 @Service
 @RequiredArgsConstructor
@@ -39,11 +44,39 @@ public class UserCacheService {
 		return UserCacheDto.from(userRepository.findByIdOrThrow(userId, ErrorCode.USER_NOT_FOUND));
 	}
 
-	@CacheEvict(
-		cacheNames = CacheConfig.CACHE_USER_BY_ID,
-		cacheManager = "redisCacheManager",
-		key = "#userId"
-	)
+	/**
+	 * {@code user-by-id} 와 {@code auth-me} 캐시를 모두 즉시 무효화한다.
+	 *
+	 * <p>키 이름 파라미터({@code #userId})는 {@link Caching} 내부 {@link CacheEvict} 의
+	 * SpEL 에서 사용되므로 메서드 바디는 비어 있어도 정상 동작한다.</p>
+	 */
+	@Caching(evict = {
+		@CacheEvict(cacheNames = CacheConfig.CACHE_USER_BY_ID, cacheManager = "redisCacheManager", key = "#userId"),
+		@CacheEvict(cacheNames = CacheConfig.CACHE_AUTH_ME, cacheManager = "redisCacheManager", key = "#userId")
+	})
 	public void evict(Long userId) {
+	}
+
+	/**
+	 * 현재 트랜잭션 커밋 성공 후에 {@link #evict(Long)} 를 호출한다.
+	 *
+	 * <p>쓰기 트랜잭션 중간에 evict 하면 같은 키를 읽는 동시 요청이 아직 커밋 안 된 pre-commit
+	 * 스냅샷을 읽어 캐시를 재채움하는 race 가 발생할 수 있다. 이를 방지하기 위해
+	 * {@link TransactionSynchronizationManager#registerSynchronization(TransactionSynchronization)}
+	 * 로 {@code afterCommit} 콜백에서만 실제 evict 를 실행한다.</p>
+	 *
+	 * <p>활성 트랜잭션이 없는 드문 경로(예: 배치 초기화)에서 호출된 경우에는 즉시 evict 한다.</p>
+	 */
+	public void evictAfterCommit(Long userId) {
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					evict(userId);
+				}
+			});
+		} else {
+			evict(userId);
+		}
 	}
 }

--- a/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
+++ b/Order-Core/src/test/java/com/goormgb/be/ordercore/mypage/service/MyPageProfileServiceTest.java
@@ -27,6 +27,7 @@ import com.goormgb.be.ordercore.order.repository.OrderMyPageSummaryCounts;
 import com.goormgb.be.ordercore.order.repository.OrderRepository;
 import com.goormgb.be.user.entity.User;
 import com.goormgb.be.user.entity.UserSns;
+import com.goormgb.be.ordercore.user.service.UserCacheService;
 import com.goormgb.be.user.enums.SocialProvider;
 import com.goormgb.be.user.repository.UserRepository;
 import com.goormgb.be.user.repository.UserSnsRepository;
@@ -41,6 +42,8 @@ class MyPageProfileServiceTest {
 	private UserSnsRepository userSnsRepository;
 	@Mock
 	private OrderRepository orderRepository;
+	@Mock
+	private UserCacheService userCacheService;
 
 	private MyPageProfileService myPageProfileService;
 	private Clock clock;
@@ -52,6 +55,7 @@ class MyPageProfileServiceTest {
 			userRepository,
 			userSnsRepository,
 			orderRepository,
+			userCacheService,
 			clock
 		);
 	}

--- a/common-core/src/main/java/com/goormgb/be/user/dto/cache/UserCacheDto.java
+++ b/common-core/src/main/java/com/goormgb/be/user/dto/cache/UserCacheDto.java
@@ -1,0 +1,75 @@
+package com.goormgb.be.user.dto.cache;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.goormgb.be.user.entity.User;
+import com.goormgb.be.user.enums.UserStatus;
+
+/**
+ * Redis 분산 캐시에 저장되는 사용자 스냅샷 DTO.
+ *
+ * <p>JPA 엔티티를 그대로 직렬화하는 대신 필요한 필드만 담은 불변 record 를 캐시에 저장한다.
+ * JPA 프록시/Lazy 연관 직렬화 이슈를 피하고, 캐시 포맷이 엔티티 스키마 변경과 독립적으로 유지된다.</p>
+ *
+ * <p>포함하는 필드는 Auth-Guard 의 {@code /auth/me} / 토큰 재발급, Order-Core 의
+ * 주문 생성·마이페이지 프로필 조회, Seat 의 추천 흐름에서 공통으로 필요로 하는 최소 집합이다.
+ * 추가 필드가 필요해지면 이 DTO 와 {@link #from(User)} 변환부를 함께 확장한다.</p>
+ *
+ * <p>직렬화: {@code GenericJackson2JsonRedisSerializer} 기반 JSON. {@link Serializable} 를
+ * 함께 구현해 비상 시 Java 직렬화 경로도 허용한다.</p>
+ */
+public record UserCacheDto(
+	Long id,
+	String email,
+	String nickname,
+	String profileImageUrl,
+	UserStatus status,
+	Boolean onboardingCompleted,
+	Boolean marketingConsent,
+	Instant lastLoginAt,
+	Instant createdAt
+) implements Serializable {
+
+	@JsonCreator
+	public UserCacheDto(
+		@JsonProperty("id") Long id,
+		@JsonProperty("email") String email,
+		@JsonProperty("nickname") String nickname,
+		@JsonProperty("profileImageUrl") String profileImageUrl,
+		@JsonProperty("status") UserStatus status,
+		@JsonProperty("onboardingCompleted") Boolean onboardingCompleted,
+		@JsonProperty("marketingConsent") Boolean marketingConsent,
+		@JsonProperty("lastLoginAt") Instant lastLoginAt,
+		@JsonProperty("createdAt") Instant createdAt
+	) {
+		this.id = id;
+		this.email = email;
+		this.nickname = nickname;
+		this.profileImageUrl = profileImageUrl;
+		this.status = status;
+		this.onboardingCompleted = onboardingCompleted;
+		this.marketingConsent = marketingConsent;
+		this.lastLoginAt = lastLoginAt;
+		this.createdAt = createdAt;
+	}
+
+	/**
+	 * 영속 엔티티로부터 스냅샷 DTO 를 생성한다. 호출 시점의 트랜잭션 내에서 필드가 초기화돼 있어야 한다.
+	 */
+	public static UserCacheDto from(User user) {
+		return new UserCacheDto(
+			user.getId(),
+			user.getEmail(),
+			user.getNickname(),
+			user.getProfileImageUrl(),
+			user.getStatus(),
+			user.getOnboardingCompleted(),
+			user.getMarketingConsent(),
+			user.getLastLoginAt(),
+			user.getCreatedAt()
+		);
+	}
+}


### PR DESCRIPTION
## 🔧 작업 내용

- **Phase 2 Redis 분산 캐시** 첫 단계로 **사용자 정보(`User`)** 를 Pod 간 공유되는 Redis 캐시로 흡수합니다.
- Phase 1 의 Caffeine 로컬 캐시로는 닉네임·차단 상태 변경 등 **즉시 전파가 필요한 데이터** 를 다룰 수 없어, 사용자 스냅샷을 Redis 에 두고 `@CacheEvict` 로 즉시 무효화하는 구조를 도입합니다.
- 영향 API: `GET /me` (Auth-Guard), 차단/해제/탈퇴 시 전 Pod 즉시 반영, Order-Core 의 후속 read-only 소비처 연동 준비.

## 🧩 구현 상세

### 1. `common-core/.../user/dto/cache/UserCacheDto.java` (신규)

엔티티 직접 캐싱이 아닌 **record 기반 불변 DTO** 를 사용합니다.
- `Serializable` + `@JsonCreator` 로 `GenericJackson2JsonRedisSerializer` 기반 JSON 직렬화 호환
- JPA 프록시·Lazy 필드 직렬화 위험 회피
- 엔티티 스키마 변경과 캐시 포맷 독립

### 2. Auth-Guard — `CacheConfig` 신규 + `UserCacheService` + `AuthMeService`

```java
// CacheConfig — Redis CacheManager 구성 (Auth-Guard 는 Phase 1 Caffeine 없음 → 본 빈이 Primary)
user-by-id : TTL 10분
auth-me    : TTL 30초 (프론트 폴링 주기)
```

- `UserCacheService.getById(userId)` — `UserRepository.findByIdOrThrow` 를 `UserCacheDto` 로 래핑
- `AuthMeService.getMyInfo(userId)` — `/me` 응답 DTO 자체를 30초 캐시. 내부에서 `UserCacheService` 를 거쳐 2단 캐시 구조 (응답 30s → 사용자 10m)
- `UserController.getMyInfo` 를 `AuthMeService` 경유로 변경
- `AuthService.blockUser / unblockUser / withdraw` 끝에서 `userCacheService.evict(userId) + authMeService.evict(userId)` 호출로 **Pod 간 즉시 무효화**

### 3. Order-Core — `CacheConfig` 확장 + `UserCacheService` 신규

- 기존 `cacheManager` (Caffeine) 에 `@Primary` 명시해 유지
- `redisCacheManager` 빈 추가 (이름 명시) — Phase 1 Caffeine 과 격리 운용
- `UserCacheService.getById` — Auth-Guard 와 **동일한 `user-by-id` 키 스페이스** 공유 → 서비스 간에도 일관된 사용자 스냅샷

### 4. Seat Onboarding 은 본 PR 범위 외

작업계획서 원안에는 Seat `OnboardingPreference` / `OnboardingPreferredBlock` 캐싱이 포함되어 있으나:
- `PreferenceScoreCalculator` 가 `pref.getFavoriteClub().getId()` 등 **엔티티 Lazy 연관** 을 접근
- DTO 치환 시 calculator 시그니처 전체 리팩터 필요

→ **Phase 2.5 별도 티켓** 으로 분리합니다.

### 5. Order-Core `createOrder` 도 범위 외

`Order.builder().user(user)` 에 영속 엔티티가 필요해 `UserCacheDto` 로 대체할 수 없습니다. read-only 경로(`MyPage` 등) 연동은 후속 커밋/PR 로 분리.

### 📌 관련 Jira Issue
- GRGB-375

## 🧪 테스트 방법

### 빌드 (전 모듈)
```bash
./gradlew :common-core:compileJava :Auth-Guard:compileJava :Order-Core:compileJava :Seat:compileJava :Queue:compileJava :API-Gateway:compileJava
# BUILD SUCCESSFUL
```

### 단위 테스트 (영향권)
```bash
./gradlew :Auth-Guard:test --tests "UserControllerTest"   # 통과 — AuthMeService mock 으로 전환됨
./gradlew :Order-Core:test --tests "OrderServiceTest"     # 통과
./gradlew :common-core:test                               # 통과
```

### 수동 검증 (staging)
1. `GET /me` 2회 연속 호출 → 2번째는 DB 쿼리 없이 Redis 에서 반환 (actuator `/actuator/metrics/cache.gets?tag=cache:auth-me` 로 hit rate 확인)
2. 관리자 API 로 특정 유저 차단 → 해당 유저가 보유한 세션에서 `/me` 즉시 `BLOCKED` 로 반환되는지 확인
3. Redis CLI 로 키 확인
   ```
   redis-cli KEYS "user-by-id*"
   redis-cli KEYS "auth-me*"
   redis-cli TTL "user-by-id::123"
   ```
4. Redis 다운/장애 시 DB 직접 조회로 fallback 되는지 확인 (Spring Cache 기본 동작)

## ❗ 참고 사항

### 리뷰 포인트
- `GenericJackson2JsonRedisSerializer` 사용 (Spring Data Redis 4.x 에서 deprecated 경고 있지만 동작 정상). 대체 직렬화 전환은 Phase 2.5/3 리팩터 범위.
- `AuthMeService` 의 2단 캐시 — `auth-me` (응답 DTO) 가 hit 이면 `UserCacheService` 까지 타지 않음. TTL 경계에서 1회 miss 발생.
- `AuthService.blockUser/unblockUser/withdraw` 의 `@Transactional` 커밋 전에 evict 하면 race 발생 가능 — 현재 구현은 **메서드 종료 시점(커밋 후 기대)** 에 evict. 이후 `TransactionSynchronization.afterCommit` 으로 이동할지 별도 티켓에서 검토.

### 후속 작업 (Phase 2.5 / 3)
- Seat `OnboardingPreference` / `OnboardingPreferredBlock` DTO 치환 + calculator 시그니처 리팩터
- Order-Core `MyPageProfileService` / `MyPageInquiryService` 의 read-only User 조회를 `UserCacheService` 경유로 전환
- Kafka 이벤트 기반 `@CacheEvict` 연계 (서비스 간 전파)

### 배포/롤백
- 스키마 변경 없음
- `application.yaml` 의 `spring.data.redis.*` 가 이미 구성돼 있어 추가 설정 불필요
- 문제 시 `spring.cache.type: none` override 로 모든 `@Cacheable` no-op 처리해 DB 직접 조회로 즉시 폴백 가능