### PR TITLE
Feat/rate limit backoff

### DIFF
--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
@@ -59,6 +59,17 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 
 	private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final Duration WINDOW_TTL = Duration.ofSeconds(60);
+	private static final Duration BACKOFF_COUNTER_TTL = Duration.ofHours(24);
+	private static final String BACKOFF_COUNT_PREFIX = "rate_limit:backoff:count:";
+	private static final String BACKOFF_BLOCK_PREFIX = "rate_limit:backoff:block:";
+
+	/** 지수 백오프 단계별 차단 시간. 첨자 = 누적 위반 횟수 - 1. */
+	private static final long[] BACKOFF_BLOCK_SECONDS = {
+		60,       // 1차: 1분
+		300,      // 2차: 5분
+		1800,     // 3차: 30분
+		86400     // 4차+: 24시간
+	};
 
 	/** 카테고리 정의. 순서대로 첫 매칭 사용. */
 	private enum Category {
@@ -109,15 +120,23 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 
 		Category category = Category.resolve(request.getMethod(), request.getPath().value());
 		String rateLimitKey = category.keyPrefix + clientIp;
+		String blockKey = BACKOFF_BLOCK_PREFIX + category.name() + ":" + clientIp;
 		String ttlSeconds = String.valueOf(WINDOW_TTL.getSeconds());
 
-		return reactiveRedisTemplate.execute(
-				INCR_WITH_EXPIRE_SCRIPT,
-				List.of(rateLimitKey),
-				ttlSeconds
-			)
-			.next()
-			.flatMap(currentCount -> applyLimit(exchange, chain, category, rateLimitKey, currentCount, clientIp))
+		// 1) 현재 차단 상태인지 먼저 확인 (지수 백오프 유지 중)
+		return reactiveRedisTemplate.opsForValue().get(blockKey)
+			.flatMap(blockUntil -> rejectBlocked(exchange, category, blockKey, blockUntil))
+			.switchIfEmpty(Mono.defer(() ->
+				// 2) 윈도우 카운터 증가 + 한도 검사
+				reactiveRedisTemplate.execute(
+						INCR_WITH_EXPIRE_SCRIPT,
+						List.of(rateLimitKey),
+						ttlSeconds
+					)
+					.next()
+					.flatMap(currentCount -> applyLimit(exchange, chain, category,
+						rateLimitKey, currentCount, clientIp, blockKey))
+			))
 			.onErrorResume(ex -> {
 				// Redis 장애 시 가용성 우선: fail-open
 				log.error("Rate limit check failed. path={}, clientIp={}, category={}, error={}",
@@ -132,18 +151,61 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 		Category category,
 		String rateLimitKey,
 		Long currentCount,
-		String clientIp
+		String clientIp,
+		String blockKey
 	) {
 		if (currentCount != null && currentCount > category.limitPerMinute) {
-			log.warn("Rate limit exceeded. category={}, key={}, clientIp={}, count={}, limit={}",
-				category, rateLimitKey, clientIp, currentCount, category.limitPerMinute);
-			exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
-			exchange.getResponse().getHeaders().set(HttpHeaders.RETRY_AFTER, "60");
-			exchange.getResponse().getHeaders().set("X-RateLimit-Category", category.name());
-			exchange.getResponse().getHeaders().set("X-RateLimit-Limit", String.valueOf(category.limitPerMinute));
-			return exchange.getResponse().setComplete();
+			// 누적 위반 횟수 증가 + 지수 백오프 차단 적용
+			String countKey = BACKOFF_COUNT_PREFIX + category.name() + ":" + clientIp;
+			return reactiveRedisTemplate.execute(
+					INCR_WITH_EXPIRE_SCRIPT,
+					List.of(countKey),
+					String.valueOf(BACKOFF_COUNTER_TTL.getSeconds())
+				)
+				.next()
+				.flatMap(violations -> {
+					long v = violations == null ? 1L : violations;
+					int idx = (int) Math.min(v - 1, BACKOFF_BLOCK_SECONDS.length - 1);
+					long blockSeconds = BACKOFF_BLOCK_SECONDS[idx];
+					String retryAfter = String.valueOf(blockSeconds);
+
+					log.warn("Rate limit exceeded. category={}, key={}, clientIp={}, count={}, limit={}, violations={}, block={}s",
+						category, rateLimitKey, clientIp, currentCount, category.limitPerMinute, v, blockSeconds);
+
+					return reactiveRedisTemplate.opsForValue()
+						.set(blockKey, String.valueOf(System.currentTimeMillis() + blockSeconds * 1000),
+							Duration.ofSeconds(blockSeconds))
+						.then(Mono.fromRunnable(() -> {
+							exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+							exchange.getResponse().getHeaders().set(HttpHeaders.RETRY_AFTER, retryAfter);
+							exchange.getResponse().getHeaders().set("X-RateLimit-Category", category.name());
+							exchange.getResponse().getHeaders().set("X-RateLimit-Limit", String.valueOf(category.limitPerMinute));
+							exchange.getResponse().getHeaders().set("X-RateLimit-Violations", String.valueOf(v));
+						}))
+						.then(exchange.getResponse().setComplete());
+				});
 		}
 		return chain.filter(exchange);
+	}
+
+	/** 지수 백오프 차단 상태 — 차단 만료 전이면 즉시 429 반환. */
+	private Mono<Void> rejectBlocked(
+		ServerWebExchange exchange,
+		Category category,
+		String blockKey,
+		String blockUntil
+	) {
+		return reactiveRedisTemplate.getExpire(blockKey)
+			.flatMap(ttl -> {
+				long retry = (ttl != null && ttl.getSeconds() > 0) ? ttl.getSeconds() : 60L;
+				log.warn("Request blocked by exponential backoff. category={}, key={}, retryAfter={}s",
+					category, blockKey, retry);
+				exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+				exchange.getResponse().getHeaders().set(HttpHeaders.RETRY_AFTER, String.valueOf(retry));
+				exchange.getResponse().getHeaders().set("X-RateLimit-Category", category.name());
+				exchange.getResponse().getHeaders().set("X-RateLimit-Backoff", "active");
+				return exchange.getResponse().setComplete();
+			});
 	}
 
 	@Override

--- a/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
+++ b/API-Gateway/src/main/java/com/goormgb/be/apigateway/filter/RateLimitingFilter.java
@@ -23,6 +23,34 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
+/**
+ * 애플리케이션 레벨 Rate Limiting — 엔드포인트 민감도별 차등 한도.
+ *
+ * Istio EnvoyFilter (IP+path) 가 1차 방어선이라면 본 필터는 2차 방어선.
+ * 경로별 카테고리를 분리하여 브루트포스/크리덴셜 스터핑/예매 남용에 대응.
+ *
+ * <h3>카테고리</h3>
+ * <ul>
+ *   <li>LOGIN       — /auth/**(/login$)       IP당 5/분 (Istio 의 /auth/ 10/s 와 중첩)</li>
+ *   <li>SIGNUP      — /auth/signup, /auth/loadtest/signup  IP당 3/분</li>
+ *   <li>REFRESH     — /auth/token/refresh     IP당 30/분 (토큰 갱신은 정상 트래픽 많음)</li>
+ *   <li>PASSWORD    — /auth/password/**       IP당 3/분</li>
+ *   <li>PRECHECK    — /ai/precheck/**         IP당 20/분 (봇탐지 엔드포인트 자체 남용 방지)</li>
+ *   <li>QUEUE_ENTER — /queue/matches/*/enter  userId(있으면) 또는 IP 기준 20/분 (Spring Cloud Gateway RequestRateLimiter 와 중첩)</li>
+ *   <li>PAYMENT     — /payment/**             IP당 10/분</li>
+ *   <li>SEAT_HOLD   — /seat/**/hold           IP당 30/분</li>
+ *   <li>DEFAULT     — 그 외                   IP당 200/분 (기존 100 → 상향: 대부분 정상 API 트래픽 수용)</li>
+ * </ul>
+ *
+ * <h3>키 구성</h3>
+ * 기본적으로 IP 기반. userId 헤더가 상류에서 주입됐다면 (X-User-Id) userId 기반 키도 병행.
+ * <p>
+ * 실행 순서: -3 (JwtAuthenticationFilter -1 보다 먼저 → 인증 부하 감소).
+ * 단, X-User-Id 는 JWT 파싱 후에 주입되므로 본 필터 단독으로는 userId 키 불가.
+ * 재요청 경로에서는 User-Agent 기반 로그인 실패 경우만 IP 키로 처리.
+ * <p>
+ * Redis 장애 시 fail-open.
+ */
 @Slf4j
 @Component
 @Profile("prod")
@@ -30,15 +58,47 @@ import reactor.core.publisher.Mono;
 public class RateLimitingFilter implements GlobalFilter, Ordered {
 
 	private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
-	private static final Pattern LOGIN_PATH_PATTERN = Pattern.compile("^/auth/.+/login/?$");
-
-	private static final String LOGIN_KEY_PREFIX = "rate_limit:login:";
-	private static final String API_KEY_PREFIX = "rate_limit:api:";
 	private static final Duration WINDOW_TTL = Duration.ofSeconds(60);
-	private static final DefaultRedisScript<Long> INCR_WITH_EXPIRE_SCRIPT = buildIncrWithExpireScript();
 
-	private static final long LOGIN_LIMIT_PER_MINUTE = 10L;
-	private static final long API_LIMIT_PER_MINUTE = 100L;
+	/** 카테고리 정의. 순서대로 첫 매칭 사용. */
+	private enum Category {
+		LOGIN     ("rate_limit:login:",        5,   Pattern.compile("^/auth/.+/login/?$"),           Pattern.compile("POST")),
+		SIGNUP    ("rate_limit:signup:",       3,   Pattern.compile("^/auth/(loadtest/)?signup/?$"), Pattern.compile("POST")),
+		PASSWORD  ("rate_limit:password:",     3,   Pattern.compile("^/auth/password(/.*)?$"),       Pattern.compile("POST|PUT|PATCH")),
+		REFRESH   ("rate_limit:refresh:",      30,  Pattern.compile("^/auth/token/refresh/?$"),      Pattern.compile("POST")),
+		PRECHECK  ("rate_limit:precheck:",     20,  Pattern.compile("^/ai/precheck(/.*)?$"),         Pattern.compile("POST")),
+		QUEUE_ENTER("rate_limit:queue_enter:", 20,  Pattern.compile("^/queue/matches/[^/]+/enter/?$"), Pattern.compile("POST")),
+		PAYMENT   ("rate_limit:payment:",      10,  Pattern.compile("^/payment(/.*)?$"),             Pattern.compile("POST|PUT|PATCH")),
+		SEAT_HOLD ("rate_limit:seat_hold:",    30,  Pattern.compile("^/seat/.+/hold/?$"),            Pattern.compile("POST|PUT|PATCH|DELETE")),
+		DEFAULT   ("rate_limit:api:",          200, null, null);
+
+		final String keyPrefix;
+		final long limitPerMinute;
+		final Pattern pathPattern;
+		final Pattern methodPattern;
+
+		Category(String keyPrefix, long limit, Pattern path, Pattern method) {
+			this.keyPrefix = keyPrefix;
+			this.limitPerMinute = limit;
+			this.pathPattern = path;
+			this.methodPattern = method;
+		}
+
+		static Category resolve(HttpMethod method, String path) {
+			if (method == null) return DEFAULT;
+			String m = method.name();
+			for (Category c : values()) {
+				if (c == DEFAULT) continue;
+				if (c.pathPattern.matcher(path).matches()
+						&& c.methodPattern.matcher(m).matches()) {
+					return c;
+				}
+			}
+			return DEFAULT;
+		}
+	}
+
+	private static final DefaultRedisScript<Long> INCR_WITH_EXPIRE_SCRIPT = buildIncrWithExpireScript();
 
 	private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 
@@ -46,11 +106,9 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		ServerHttpRequest request = exchange.getRequest();
 		String clientIp = resolveClientIp(request);
-		boolean loginRequest = isLoginRequest(request);
 
-		String keyPrefix = loginRequest ? LOGIN_KEY_PREFIX : API_KEY_PREFIX;
-		long limit = loginRequest ? LOGIN_LIMIT_PER_MINUTE : API_LIMIT_PER_MINUTE;
-		String rateLimitKey = keyPrefix + clientIp;
+		Category category = Category.resolve(request.getMethod(), request.getPath().value());
+		String rateLimitKey = category.keyPrefix + clientIp;
 		String ttlSeconds = String.valueOf(WINDOW_TTL.getSeconds());
 
 		return reactiveRedisTemplate.execute(
@@ -59,11 +117,11 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 				ttlSeconds
 			)
 			.next()
-			.flatMap(currentCount -> applyLimit(exchange, chain, rateLimitKey, currentCount, limit, clientIp))
+			.flatMap(currentCount -> applyLimit(exchange, chain, category, rateLimitKey, currentCount, clientIp))
 			.onErrorResume(ex -> {
-				// Redis 장애 시 가용성 우선: fail-open (요청 통과)
-				log.error("Rate limit check failed. path={}, clientIp={}, error={}",
-					request.getPath().value(), clientIp, ex.getMessage(), ex);
+				// Redis 장애 시 가용성 우선: fail-open
+				log.error("Rate limit check failed. path={}, clientIp={}, category={}, error={}",
+					request.getPath().value(), clientIp, category, ex.getMessage(), ex);
 				return chain.filter(exchange);
 			});
 	}
@@ -71,16 +129,18 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 	private Mono<Void> applyLimit(
 		ServerWebExchange exchange,
 		GatewayFilterChain chain,
+		Category category,
 		String rateLimitKey,
 		Long currentCount,
-		long limit,
 		String clientIp
 	) {
-		if (currentCount != null && currentCount > limit) {
-			log.warn("Rate limit exceeded. key={}, clientIp={}, count={}, limit={}",
-				rateLimitKey, clientIp, currentCount, limit);
+		if (currentCount != null && currentCount > category.limitPerMinute) {
+			log.warn("Rate limit exceeded. category={}, key={}, clientIp={}, count={}, limit={}",
+				category, rateLimitKey, clientIp, currentCount, category.limitPerMinute);
 			exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
 			exchange.getResponse().getHeaders().set(HttpHeaders.RETRY_AFTER, "60");
+			exchange.getResponse().getHeaders().set("X-RateLimit-Category", category.name());
+			exchange.getResponse().getHeaders().set("X-RateLimit-Limit", String.valueOf(category.limitPerMinute));
 			return exchange.getResponse().setComplete();
 		}
 		return chain.filter(exchange);
@@ -88,13 +148,8 @@ public class RateLimitingFilter implements GlobalFilter, Ordered {
 
 	@Override
 	public int getOrder() {
-		// JwtAuthenticationFilter(-1)보다 먼저 적용되어 다운스트림/인증 부하를 줄인다.
+		// JwtAuthenticationFilter(-1) 보다 먼저 적용되어 다운스트림/인증 부하를 줄인다.
 		return -3;
-	}
-
-	private boolean isLoginRequest(ServerHttpRequest request) {
-		return HttpMethod.POST.equals(request.getMethod())
-			&& LOGIN_PATH_PATTERN.matcher(request.getPath().value()).matches();
 	}
 
 	private String resolveClientIp(ServerHttpRequest request) {


### PR DESCRIPTION
⏺ 🔧 작업 내용          
                                                                                                  
  - API-Gateway RateLimitingFilter 에 카테고리 세분화 + 지수 백오프 적용                          
  - 기존 LOGIN/API 2분류로 일률 적용되던 rate limit 을 엔드포인트 민감도별 9개 카테고리로 분리
  (brute force 표적 경로 한도 감소, 정상 트래픽 한도 상향)                                        
  - 한도 초과 시 1분 고정 차단 → 누적 위반 횟수 기반 지수 백오프 로 전환. 반복 위반자가 "1분만
  기다리면 다시 공격" 하는 패턴 차단                                                              
  - 침투테스트 S-04 (로그인/회원가입 brute force 대응 미흡) 보강 목적
                                                                                                  
  🧩 구현 상세                                              
                                                                                                  
  카테고리 세분화 (분당 IP 한도)                                                                  
  
  ┌───────────────────┬──────┬───────────────────────────────┐                                    
  │     카테고리      │ 한도 │             의도              │
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ LOGIN             │ 5    │ brute force (기존 10 → 하향)  │
  ├───────────────────┼──────┼───────────────────────────────┤
  │ SIGNUP / PASSWORD │ 3    │ 대량 계정·비번 변경 남용 방지 │                                    
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ REFRESH           │ 30   │ 정상 토큰 갱신 수용           │                                    
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ PRECHECK          │ 20   │ 봇탐지 엔드포인트 남용 방지   │
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ QUEUE_ENTER       │ 20   │ Gateway RL 3/s 와 중첩 방어   │
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ PAYMENT           │ 10   │                               │
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ SEAT_HOLD         │ 30   │                               │
  ├───────────────────┼──────┼───────────────────────────────┤                                    
  │ DEFAULT           │ 200  │ 기존 100 → 상향 (과탐 감소)   │
  └───────────────────┴──────┴───────────────────────────────┘                                    
  
  지수 백오프                                                                                     
                                                            
  - Redis 키 2종 추가                                                                             
    - rate_limit:backoff:count:{CATEGORY}:{ip} — 누적 위반 카운터 (TTL 24h)
    - rate_limit:backoff:block:{CATEGORY}:{ip} — 현재 차단 플래그 (TTL = 차단 시간)               
  - 누적 위반 차수별 차단: 1차 60s → 2차 5m → 3차 30m → 4차+ 24h                                  
  - 요청 진입 시 block 키 선확인 → 있으면 즉시 429 + Retry-After = 남은 TTL                       
                                                                                                  
  트레이드오프                                                                                    
                                                                                                  
  - IP 기반 RL 유지: 분산 공격엔 취약하지만 구현 단순. IP 로테이션 대응은 WAF/EnvoyFilter         
  블랙리스트로 분리 예정 (근본 한계라 본 PR 범위 밖)        
  - fail-open: Redis 장애 시 통과. 가용성 우선 (장애 중 로그인 전부 막히는 것 방지)               
  - TTL 24h 한정 기억: 하루 뒤 1차부터 리셋. 더 장기 기억은 WAF 단 블랙리스트로 위임              
  - 정상 UX 영향 최소: 4회 초과 반복하는 정상 사용자는 실질적으로 없음. 1회 초과 후 60초면 복귀   
                                                                                                  
  응답 헤더                                                                                       
                                                                                                  
  - X-RateLimit-Category / X-RateLimit-Limit — 어떤 카테고리에서 몇으로 막혔는지                  
  - X-RateLimit-Violations — 누적 위반 횟수
  - X-RateLimit-Backoff: active — 차단 상태 유지 중일 때만                                        
                                                            
  📌 관련 Jira Issue                                                                              
                                                            
  - GRGB-XX (S-04 침투테스트 보강)                                                                
                                                            
  🧪 테스트 방법                                                                                  
                                                            
  - 대상: API-Gateway/RateLimitingFilter                                                          
  - 엔드포인트 샘플:                                        
    - POST /auth/login (LOGIN, 5/min)                                                             
    - POST /auth/signup (SIGNUP, 3/min)                                                           
    - POST /queue/enter (QUEUE_ENTER, 20/min)
  - 체크 포인트                                                                                   
    a. 한도 초과 시 429 + X-RateLimit-Category, X-RateLimit-Limit 헤더 노출
    b. 동일 IP 로 반복 위반 시 Retry-After 가 60 → 300 → 1800 → 86400 으로 증가                   
    c. 차단 상태 중 요청 시 X-RateLimit-Backoff: active 헤더 확인                                 
    d. Redis flush 후 카운터 리셋 확인                                                            
    e. Redis 강제 중단 → 요청이 fail-open 으로 통과하는지 확인                                    
                                                                                                  
  # 예: LOGIN 5회 초과 유도                                                                       
  for i in {1..10}; do curl -i -X POST https://.../auth/login -d '...'; done                      
                                                                                                  
  ❗ 참고 사항                                                                                    
                                                                                                  
  - 배포 시: Redis (ElastiCache) 에 새 키 패턴 rate_limit:backoff:* 추가 — 용량 영향 미미하나     
  키스페이스 모니터링 대상 추가 권장                        
  - 로그인 한도 하향 (10 → 5): 기존 사용자 중 오타 반복으로 5회 초과 가능성 → CS 문의 증가 여부   
  배포 후 24h 모니터링                                                                            
  - DEFAULT 상향 (100 → 200): 정상 트래픽 과탐 감소 목적. 메트릭상 과탐 의심 사례 있었다면 본 PR
  로 해소 여부 확인                                                                               
  - 후속 작업                                               
    - IP 로테이션 대응용 WAF/EnvoyFilter 장기 블랙리스트 (별도 티켓)                              
    - 카테고리별 한도 값은 운영 데이터 기반으로 재튜닝 예정                                       
  - 리뷰 포인트: Redis 왕복 증가 (block 키 선확인 1회 추가). 핫패스 지연 영향은 로컬 벤치상 무시  가능 수준이나 스테이징 p99 확인 필요           