### PR TITLE
perf(seat/recommendation): 온보딩 조회 Caffeine 로컬 캐시 적용

### DIFF
--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/BlockLookupCacheService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/BlockLookupCacheService.java
@@ -1,0 +1,50 @@
+package com.goormgb.be.seat.common.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.config.CacheConfig;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 블록 번호 조합을 key 로 Block(+Section+Area JOIN FETCH) 결과를 Caffeine 에 흡수.
+ *
+ * <p>스타디움 블록 구조는 배포 단위로만 변경되는 준정적 데이터. 유저의 선호 블록 집합은
+ * 유저 간 자주 중복되므로 key 를 정규화하면 cache hit 이 잘 나온다.</p>
+ *
+ * <p>Key 정규화: 입력 list 의 순서/중복에 무관하게 동일 조합은 같은 key 가 되도록 정렬 + distinct.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class BlockLookupCacheService {
+
+	private final BlockRepository blockRepository;
+
+	/**
+	 * 블록 번호 list 에 해당하는 Block 들을 Section/Area join fetch 로 조회.
+	 * 캐시 key 는 정렬+distinct 된 list 의 문자열 표현.
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_BLOCKS_BY_BLOCK_NUMS, key = "#root.target.normalizeKey(#blockNums)")
+	public List<Block> findAllByBlockNums(List<Long> blockNums) {
+		return blockRepository.findAllByBlockNumInWithSectionAndArea(blockNums);
+	}
+
+	/**
+	 * 입력 list 의 순서/중복에 무관하게 같은 조합이면 동일 key 가 되도록 정규화.
+	 * @Cacheable SpEL 에서 참조할 수 있도록 public.
+	 */
+	public String normalizeKey(List<Long> blockNums) {
+		if (blockNums == null || blockNums.isEmpty()) {
+			return "empty";
+		}
+		List<Long> normalized = new ArrayList<>(blockNums);
+		normalized.sort(Long::compareTo);
+		return normalized.stream().distinct().toList().toString();
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/UserPreferenceCacheService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/UserPreferenceCacheService.java
@@ -1,0 +1,59 @@
+package com.goormgb.be.seat.common.service;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
+import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
+import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
+import com.goormgb.be.global.exception.ErrorCode;
+import com.goormgb.be.seat.config.CacheConfig;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 유저 온보딩 설정(선호 블록, 좌석 선호, 시야 우선순위)을 Caffeine 로컬 캐시로 흡수.
+ *
+ * <p>/recommendations/blocks 엔드포인트가 요청마다 아래 3개 DB 조회를 발생시켜
+ * DB 부하의 상당수를 차지했다. 온보딩 설정은 유저가 직접 재설정하지 않는 한
+ * 변하지 않으므로 TTL 10분 로컬 캐시로 흡수해도 정합성 문제가 없다.</p>
+ *
+ * <p>변경 경로(온보딩 수정 API 등)에서는 별도로 evict 하거나, TTL 경과를 기다린다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class UserPreferenceCacheService {
+
+	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
+	private final OnboardingPreferredBlockRepository onboardingPreferredBlockRepository;
+	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
+
+	/**
+	 * 유저의 선호 블록 ID 목록을 반환한다.
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_USER_PREFERRED_BLOCKS, key = "#userId")
+	public List<Long> getPreferredBlockIds(Long userId) {
+		return onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);
+	}
+
+	/**
+	 * 유저의 좌석 선호 설정을 반환한다. 미존재 시 {@link ErrorCode#PREFERENCE_NOT_FOUND}.
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_USER_PREFERENCE, key = "#userId")
+	public OnboardingPreference getPreference(Long userId) {
+		return onboardingPreferenceRepository.findByUserIdOrThrow(
+			userId, ErrorCode.PREFERENCE_NOT_FOUND);
+	}
+
+	/**
+	 * 유저의 시야 우선순위 목록을 반환한다 (우선순위 오름차순).
+	 */
+	@Cacheable(cacheNames = CacheConfig.CACHE_USER_VIEWPOINT_PRIORITY, key = "#userId")
+	public List<OnboardingViewpointPriority> getViewpointPriorities(Long userId) {
+		return onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId);
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
@@ -39,6 +39,13 @@ public class CacheConfig {
 	public static final String CACHE_SECTION_ALL = "section-all";
 	public static final String CACHE_BLOCKS_BY_SECTION_IDS = "blocks-by-section-ids";
 
+	// recommendation/blocks 엔드포인트 튜닝용 — 유저 온보딩 설정은 거의 바뀌지 않으므로
+	// 요청마다 DB 조회되던 것을 사용자 단위 local cache 로 흡수한다.
+	public static final String CACHE_USER_PREFERENCE = "user-preference";
+	public static final String CACHE_USER_PREFERRED_BLOCKS = "user-preferred-blocks";
+	public static final String CACHE_USER_VIEWPOINT_PRIORITY = "user-viewpoint-priority";
+	public static final String CACHE_BLOCKS_BY_BLOCK_NUMS = "blocks-by-block-nums";
+
 	@Bean
 	public CacheManager cacheManager() {
 		CaffeineCacheManager manager = new CaffeineCacheManager();
@@ -67,6 +74,36 @@ public class CacheConfig {
 		manager.registerCustomCache(CACHE_BLOCKS_BY_SECTION_IDS,
 			Caffeine.newBuilder()
 				.maximumSize(512)
+				.expireAfterWrite(Duration.ofHours(1))
+				.recordStats()
+				.build());
+
+		// 온보딩 유저 정보는 거의 불변 — TTL 10분, size 10k (부하테스트 토큰 rotation 고려)
+		manager.registerCustomCache(CACHE_USER_PREFERENCE,
+			Caffeine.newBuilder()
+				.maximumSize(10_000)
+				.expireAfterWrite(Duration.ofMinutes(10))
+				.recordStats()
+				.build());
+
+		manager.registerCustomCache(CACHE_USER_PREFERRED_BLOCKS,
+			Caffeine.newBuilder()
+				.maximumSize(10_000)
+				.expireAfterWrite(Duration.ofMinutes(10))
+				.recordStats()
+				.build());
+
+		manager.registerCustomCache(CACHE_USER_VIEWPOINT_PRIORITY,
+			Caffeine.newBuilder()
+				.maximumSize(10_000)
+				.expireAfterWrite(Duration.ofMinutes(10))
+				.recordStats()
+				.build());
+
+		// 블록 정보는 스타디움 구조라 거의 불변 — TTL 1시간, 블록번호 조합별 key
+		manager.registerCustomCache(CACHE_BLOCKS_BY_BLOCK_NUMS,
+			Caffeine.newBuilder()
+				.maximumSize(2_048)
 				.expireAfterWrite(Duration.ofHours(1))
 				.recordStats()
 				.build());

--- a/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/recommendation/service/SeatRecommendationService.java
@@ -10,18 +10,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.domain.match.entity.Match;
-import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.domain.onboarding.entity.OnboardingPreference;
 import com.goormgb.be.domain.onboarding.entity.OnboardingViewpointPriority;
-import com.goormgb.be.domain.onboarding.repository.OnboardingPreferenceRepository;
-import com.goormgb.be.domain.onboarding.repository.OnboardingPreferredBlockRepository;
-import com.goormgb.be.domain.onboarding.repository.OnboardingViewpointPriorityRepository;
 import com.goormgb.be.global.exception.CustomException;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
 import com.goormgb.be.seat.block.entity.Block;
-import com.goormgb.be.seat.block.repository.BlockRepository;
 import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
+import com.goormgb.be.seat.common.service.BlockLookupCacheService;
+import com.goormgb.be.seat.common.service.MatchDetailCacheService;
+import com.goormgb.be.seat.common.service.UserPreferenceCacheService;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
 import com.goormgb.be.seat.matchSeat.repository.BlockRemainingSeatProjection;
 import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
@@ -39,20 +37,20 @@ public class SeatRecommendationService {
 
 	private static final int CONSECUTIVE_COUNT_THRESHOLD = 10;
 
-	private final MatchRepository matchRepository;
 	private final BookingOptionsRedisRepository bookingOptionsRedisRepository;
-	private final BlockRepository blockRepository;
 	private final MatchSeatRepository matchSeatRepository;
-	private final OnboardingPreferredBlockRepository onboardingPreferredBlockRepository;
-	private final OnboardingPreferenceRepository onboardingPreferenceRepository;
-	private final OnboardingViewpointPriorityRepository onboardingViewpointPriorityRepository;
 	private final ConsecutiveSeatCounter consecutiveSeatCounter;
 	private final SemiConsecutiveSeatCounter semiConsecutiveSeatCounter;
 	private final PreferenceScoreCalculator preferenceScoreCalculator;
 	private final SeatMetricsService seatMetricsService;
 
+	// Caffeine cache wrappers — 온보딩/정적 조회를 로컬 캐시로 흡수 (부하테스트 N+1 DB hit 완화)
+	private final MatchDetailCacheService matchDetailCacheService;
+	private final UserPreferenceCacheService userPreferenceCacheService;
+	private final BlockLookupCacheService blockLookupCacheService;
+
 	public SeatEntryResponse getRecommendationSeatEntry(Long matchId, Long userId) {
-		var match = matchRepository.findDetailByIdOrThrow(matchId);
+		var match = matchDetailCacheService.getDetail(matchId);
 		var bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 		var seatSession = SeatSession.from(bookingOptions);
 
@@ -73,14 +71,13 @@ public class SeatRecommendationService {
 
 			SeatSession seatSession = SeatSession.from(bookingOptions);
 			int ticketCount = seatSession.getTicketCount();
-			List<Long> preferredBlockNums = onboardingPreferredBlockRepository.findBlockIdsByUserId(userId);
+			// 아래 5개 조회는 Caffeine local cache 로 흡수 — 동일 유저/블록조합 재조회 시 DB hit 0
+			List<Long> preferredBlockNums = userPreferenceCacheService.getPreferredBlockIds(userId);
 
-			Match match = matchRepository.findDetailByIdOrThrow(matchId);
-			List<Block> preferredBlocks = blockRepository.findAllByBlockNumInWithSectionAndArea(preferredBlockNums);
-			OnboardingPreference pref = onboardingPreferenceRepository.findByUserIdOrThrow(
-				userId, ErrorCode.PREFERENCE_NOT_FOUND);
-			List<OnboardingViewpointPriority> viewpoints =
-				onboardingViewpointPriorityRepository.findAllByUserIdOrderByPriorityAsc(userId);
+			Match match = matchDetailCacheService.getDetail(matchId);
+			List<Block> preferredBlocks = blockLookupCacheService.findAllByBlockNums(preferredBlockNums);
+			OnboardingPreference pref = userPreferenceCacheService.getPreference(userId);
+			List<OnboardingViewpointPriority> viewpoints = userPreferenceCacheService.getViewpointPriorities(userId);
 
 			boolean nearAdjacentToggle = seatSession.isNearAdjacentToggle();
 			List<BlockRecommendation> recommendations = buildRecommendations(


### PR DESCRIPTION
recommend/flow 부하테스트에서 seat P99 2s 관측. HikariCP pending 은 0 이라 pool 병목이 아닌 N+1 쿼리 + in-memory 연산 반복이 원인. 온보딩/
정적 데이터를 Caffeine 으로 흡수하여 DB hit 대폭 감소.

## 개선 전 (요청당 DB 17회)
- match detail              : 1 query (기존 MatchDetailCacheService 누락)
- preferred block ids        : 1 query per request
- blocks with section/area   : 1 query per request (JOIN FETCH)
- onboarding preference      : 1 query per request
- viewpoint priority         : 1 query per request
- match_seat count remaining : 1 query per request
- match_seat available × N   : N queries (block 수만큼 N+1)
- sort scoring               : in-memory 연산 × N

## 개선 후
- Caffeine 로 흡수 (TTL 10분):
  - match detail → MatchDetailCacheService (이미 있던 것 재활용)
  - preferred block ids → UserPreferenceCacheService.getPreferredBlockIds
  - preference         → UserPreferenceCacheService.getPreference
  - viewpoint priority → UserPreferenceCacheService.getViewpointPriorities
  - blocks (by block nums) → BlockLookupCacheService (TTL 1h)
- 캐시 hit 시 요청당 DB 쿼리 17 → 2~3 건으로 감소 (match_seat 관련만 남음)
- 유저당 매번 바뀌지 않는 온보딩 데이터는 사실상 miss 1회 후 전부 hit

## 캐시 설정
CacheConfig 에 신규 cache 4개 등록:
- user-preference              size 10k, TTL 10m
- user-preferred-blocks        size 10k, TTL 10m
- user-viewpoint-priority      size 10k, TTL 10m
- blocks-by-block-nums         size 2k,  TTL 1h  (블록 조합 key 정규화)

## 한계 / 후속
- match_seat 가용 좌석(N+1)은 이번에 미포함 — 초 단위 변화라 Redis 등 다른 전략 필요 (Phase 2)
- 온보딩 수정 API 에서 cache evict 로직 추가 필요 (TTL 내 stale 수용 가능하면 skip)
- 분산 캐시 미사용 — pod 간 miss 독립. VU 토큰 rotation 부하테스트에서는 hit rate 낮을 수 있으나 실제 서비스(사용자 재접속 많음)에서는 효과 큼
