### PR TITLE
perf(seat, order-core, infra): Phase 3 — API 응답 Redis 캐시 + 인프라 파라미터 환경변수화 [GRGB-376]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
@@ -85,7 +85,10 @@ public class CacheConfig {
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfBaseType(Object.class)
+			.allowIfSubType("com.goormgb.be")
+			.allowIfSubType("java.util")
+			.allowIfSubType("java.time")
+			.allowIfSubType("java.lang")
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/Auth-Guard/src/main/resources/application.yaml
+++ b/Auth-Guard/src/main/resources/application.yaml
@@ -4,8 +4,8 @@ server:
     context-path: /auth
   tomcat:
     threads:
-      max: 200
-      min-spare: 10
+      max: ${SERVER_TOMCAT_THREADS_MAX:200}
+      min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
     max-connections: 8192
     accept-count: 100
 
@@ -28,6 +28,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
+      connection-timeout: 30000
+      leak-detection-threshold: 10000
 
   jpa:
     hibernate:

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -52,6 +52,12 @@ public class CacheConfig {
 	 * 에서 발생해도 Auth-Guard 의 {@code /me} 응답이 즉시 갱신되도록 보장한다.</p>
 	 */
 	public static final String CACHE_AUTH_ME = "auth-me";
+	/**
+	 * Phase 3 — {@code GET /matches?date=...} 응답의 Redis 분산 캐시.
+	 *
+	 * <p>경기 목록은 자주 폴링되는 read-only 화면이며 동일 날짜 요청이 집중된다. TTL 30초로 캐싱한다.</p>
+	 */
+	public static final String CACHE_MATCHES_LIST_RESPONSE = "matches-list-response";
 
 	@Primary
 	@Bean
@@ -76,6 +82,7 @@ public class CacheConfig {
 		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
 		configs.put(CACHE_USER_BY_ID, redisConfig(Duration.ofMinutes(10), valueSerializer));
 		configs.put(CACHE_AUTH_ME, redisConfig(Duration.ofSeconds(30), valueSerializer));
+		configs.put(CACHE_MATCHES_LIST_RESPONSE, redisConfig(Duration.ofSeconds(30), valueSerializer));
 
 		return RedisCacheManager.builder(connectionFactory)
 			.cacheDefaults(redisConfig(Duration.ofMinutes(10), valueSerializer))

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -107,7 +107,10 @@ public class CacheConfig {
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfBaseType(Object.class)
+			.allowIfSubType("com.goormgb.be")
+			.allowIfSubType("java.util")
+			.allowIfSubType("java.time")
+			.allowIfSubType("java.lang")
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/match/service/MatchService.java
@@ -6,6 +6,7 @@ import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import com.goormgb.be.domain.match.entity.Match;
 import com.goormgb.be.domain.match.repository.MatchRepository;
 import com.goormgb.be.global.exception.ErrorCode;
 import com.goormgb.be.global.support.Preconditions;
+import com.goormgb.be.ordercore.config.CacheConfig;
 import com.goormgb.be.ordercore.match.dto.response.ClubMonthlyMatchesResponse;
 import com.goormgb.be.ordercore.match.dto.response.MatchDetailGetResponse;
 import com.goormgb.be.ordercore.match.dto.response.MatchListByDateResponse;
@@ -39,6 +41,19 @@ public class MatchService {
 		return MatchDetailGetResponse.of(match, matchGuide);
 	}
 
+	/**
+	 * 날짜별 경기 목록을 반환한다 (Phase 3 Redis 응답 캐시 적용).
+	 *
+	 * <p>자주 폴링되는 read-only 엔드포인트로, 동일 날짜 요청을 Redis 캐시(TTL 30초) 로 흡수한다.
+	 * 캐시 키는 요청 {@code date} 이며, 결과 DTO 가 직렬화 대상이다.</p>
+	 */
+	@Cacheable(
+		cacheNames = CacheConfig.CACHE_MATCHES_LIST_RESPONSE,
+		cacheManager = "redisCacheManager",
+		key = "#date.toString()",
+		unless = "#result == null"
+	)
+	@Transactional(readOnly = true)
 	public MatchListByDateResponse getMatchesByDate(LocalDate date) {
 		Instant start = date.atStartOfDay(ZoneOffset.UTC).toInstant();
 		Instant end = date.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();

--- a/Order-Core/src/main/resources/application.yaml
+++ b/Order-Core/src/main/resources/application.yaml
@@ -4,8 +4,8 @@ server:
     context-path: /order
   tomcat:
     threads:
-      max: 200
-      min-spare: 10
+      max: ${SERVER_TOMCAT_THREADS_MAX:200}
+      min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
     max-connections: 8192
     accept-count: 100
 
@@ -32,6 +32,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
+      connection-timeout: 30000
+      leak-detection-threshold: 10000
 
   jpa:
     hibernate:

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -5,8 +5,8 @@ server:
     context-path: /queue
   tomcat:
     threads:
-      max: 200
-      min-spare: 10
+      max: ${SERVER_TOMCAT_THREADS_MAX:200}
+      min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
     max-connections: 8192
     accept-count: 100
 
@@ -33,6 +33,11 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:5}
+      connection-timeout: 30000
+      leak-detection-threshold: 10000
 
   jpa:
     hibernate:

--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // Redis 분산 캐시 (Phase 3 — 응답 레벨 캐시: seat-groups-response)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // 필수: JSON 로깅
     implementation "net.logstash.logback:logstash-logback-encoder:7.4"
 

--- a/Seat/src/main/java/com/goormgb/be/seat/common/dto/cache/SeatGroupsCachePayload.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/dto/cache/SeatGroupsCachePayload.java
@@ -1,0 +1,33 @@
+package com.goormgb.be.seat.common.dto.cache;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+
+/**
+ * {@code GET /matches/{matchId}/seat-groups} 응답 중 <b>유저에 독립적인</b> 부분을 담는 Redis 캐시 payload.
+ *
+ * <p>원본 응답은 {@link SeatGroupsEntryResponse} 이며, 그 중
+ * {@code match}(MatchInfo) 와 {@code seatGroups}(List&lt;SeatGroupInfo&gt;) 는 matchId 가 같으면
+ * 동일한 값을 가진다. 반면 {@code seatSession} 은 유저별 booking-options 에서 파생되므로 캐시 대상에서 제외한다.</p>
+ *
+ * <p>캐시 HIT 시 본 payload 와 유저별 {@link SeatGroupsEntryResponse.SeatSessionInfo} 를 결합해
+ * 최종 응답을 조립한다. TTL 5초 이내 잔여 좌석 수 stale 은 UX 상 수용한다.</p>
+ */
+public record SeatGroupsCachePayload(
+	SeatGroupsEntryResponse.MatchInfo match,
+	List<SeatGroupsEntryResponse.SeatGroupInfo> seatGroups
+) implements Serializable {
+
+	@JsonCreator
+	public SeatGroupsCachePayload(
+		@JsonProperty("match") SeatGroupsEntryResponse.MatchInfo match,
+		@JsonProperty("seatGroups") List<SeatGroupsEntryResponse.SeatGroupInfo> seatGroups
+	) {
+		this.match = match;
+		this.seatGroups = seatGroups;
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -50,8 +50,10 @@ public class SeatCommonService {
 	 * <p>유저에 독립적인 {@code match + seatGroups} 부분은
 	 * {@link SeatGroupsResponseCacheService#getPayload(Long)} 에서 Redis (TTL 5초) 로 제공된다.
 	 * 유저별 {@code seatSession} 은 매 요청 booking-options(Redis) 에서 조립한다.</p>
+	 *
+	 * <p>트랜잭션은 의도적으로 선언하지 않는다. 캐시 히트 시 DB 커넥션을 점유하지 않도록
+	 * 실제 DB 조회가 발생하는 {@code getPayload} 내부에서만 {@link Transactional} 이 열리도록 한다.</p>
 	 */
-	@Transactional(readOnly = true)
 	public SeatGroupsEntryResponse getSeatGroupsEntry(Long matchId, Long userId) {
 		long totalStart = System.currentTimeMillis();
 

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatCommonService.java
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goormgb.be.global.exception.ErrorCode;
-import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
 import com.goormgb.be.seat.block.repository.BlockRepository;
+import com.goormgb.be.seat.common.dto.cache.SeatGroupsCachePayload;
 import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
 import com.goormgb.be.seat.common.dto.response.SectionBlocksResponse;
 import com.goormgb.be.seat.matchSeat.entity.MatchSeat;
@@ -26,7 +26,6 @@ import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
 import com.goormgb.be.seat.redis.SeatSession;
 import com.goormgb.be.seat.seatHold.entity.SeatHold;
 import com.goormgb.be.seat.seatHold.repository.SeatHoldRepository;
-import com.goormgb.be.seat.section.entity.Section;
 import com.goormgb.be.seat.section.repository.SectionRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -38,51 +37,36 @@ import lombok.extern.slf4j.Slf4j;
 public class SeatCommonService {
 
 	private final MatchDetailCacheService matchDetailCacheService;
-	private final SectionLookupCacheService sectionLookupCacheService;
+	private final SeatGroupsResponseCacheService seatGroupsResponseCacheService;
 	private final BookingOptionsRedisRepository bookingOptionsRedisRepository;
 	private final SectionRepository sectionRepository;
 	private final BlockRepository blockRepository;
 	private final MatchSeatRepository matchSeatRepository;
 	private final SeatHoldRepository seatHoldRepository;
 
+	/**
+	 * 좌석 선택 페이지 진입용 응답을 조립한다 (Phase 3 Redis 응답 캐시 적용).
+	 *
+	 * <p>유저에 독립적인 {@code match + seatGroups} 부분은
+	 * {@link SeatGroupsResponseCacheService#getPayload(Long)} 에서 Redis (TTL 5초) 로 제공된다.
+	 * 유저별 {@code seatSession} 은 매 요청 booking-options(Redis) 에서 조립한다.</p>
+	 */
 	@Transactional(readOnly = true)
 	public SeatGroupsEntryResponse getSeatGroupsEntry(Long matchId, Long userId) {
 		long totalStart = System.currentTimeMillis();
 
-		var match = matchDetailCacheService.getDetail(matchId);
+		SeatGroupsCachePayload payload = seatGroupsResponseCacheService.getPayload(matchId);
 		var bookingOptions = bookingOptionsRedisRepository.getByUserIdAndMatchIdOrThrow(userId, matchId);
 		var seatSession = SeatSession.from(bookingOptions);
-
-		List<Section> sections = sectionLookupCacheService.findAllSectionsWithArea();
-		List<Long> sectionIds = sections.stream().map(Section::getId).toList();
-
-		Map<Long, List<Long>> blockIdsBySectionId = createBlockIdsBySectionId(sectionIds);
-		Map<Long, Long> remainingSeatCountBySectionId = createRemainingSeatCountBySectionId(matchId);
-
-		Map<Long, SeatGroupAccumulator> groupMap = new LinkedHashMap<>();
-		for (Section section : sections) {
-			Long areaId = section.getArea().getId();
-			SeatGroupAccumulator group = groupMap.computeIfAbsent(areaId,
-				ignored -> new SeatGroupAccumulator(areaId, toAreaName(section.getArea().getCode())));
-
-			group.sections().add(new SeatGroupsEntryResponse.SectionInfo(
-				section.getId(),
-				section.getCode().name(),
-				buildDisplayName(section),
-				blockIdsBySectionId.getOrDefault(section.getId(), List.of()),
-				remainingSeatCountBySectionId.getOrDefault(section.getId(), 0L)
-			));
-		}
-
-		List<SeatGroupsEntryResponse.SeatGroupInfo> seatGroups = groupMap.values()
-			.stream()
-			.map(it -> new SeatGroupsEntryResponse.SeatGroupInfo(it.areaId(), it.areaName(), it.sections()))
-			.toList();
 
 		log.info("[SeatCommonService#getSeatGroupsEntry] at={}, matchId={}, total={}ms",
 			LocalDateTime.now(ZoneId.of("Asia/Seoul")), matchId, System.currentTimeMillis() - totalStart);
 
-		return SeatGroupsEntryResponse.of(match, seatSession, seatGroups);
+		return new SeatGroupsEntryResponse(
+			payload.match(),
+			SeatGroupsEntryResponse.SeatSessionInfo.from(seatSession),
+			payload.seatGroups()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -146,70 +130,12 @@ public class SeatCommonService {
 		return new SectionBlocksResponse(blockInfos);
 	}
 
-	private Map<Long, List<Long>> createBlockIdsBySectionId(List<Long> sectionIds) {
-		if (sectionIds.isEmpty()) {
-			return Map.of();
-		}
-
-		long start = System.currentTimeMillis();
-		List<Block> blocks = sectionLookupCacheService.findBlocksBySectionIds(sectionIds);
-		log.info("[SeatCommonService#createBlockIdsBySectionId] at={}, sectionIds.size={}, blocks.size={}, blockQueryElapsed={}ms",
-			LocalDateTime.now(ZoneId.of("Asia/Seoul")), sectionIds.size(), blocks.size(), System.currentTimeMillis() - start);
-
-		Map<Long, List<Long>> blockIdsBySectionId = new LinkedHashMap<>();
-		for (Block block : blocks) {
-			blockIdsBySectionId.computeIfAbsent(block.getSection().getId(), ignored -> new ArrayList<>())
-				.add(block.getBlockNum());
-		}
-		log.info("[SeatCommonService#createBlockIdsBySectionId] at={}, total elapsed={}ms (query + mapping including getSection() calls)",
-			LocalDateTime.now(ZoneId.of("Asia/Seoul")), System.currentTimeMillis() - start);
-		return blockIdsBySectionId;
-	}
-
-	private Map<Long, Long> createRemainingSeatCountBySectionId(Long matchId) {
-		long start = System.currentTimeMillis();
-		Map<Long, Long> remainingSeatCountBySectionId = new LinkedHashMap<>();
-		matchSeatRepository.countRemainingSeatsByMatchIdAndSaleStatusGroupBySectionId(matchId,
-				MatchSeatSaleStatus.AVAILABLE)
-			.forEach(it -> remainingSeatCountBySectionId.put(it.getSectionId(), it.getRemainingSeatCount()));
-		log.info("[SeatCommonService#createRemainingSeatCountBySectionId] at={}, matchId={}, elapsed={}ms",
-			LocalDateTime.now(ZoneId.of("Asia/Seoul")), matchId, System.currentTimeMillis() - start);
-		return remainingSeatCountBySectionId;
-	}
-
-	private String buildDisplayName(Section section) {
-		return switch (section.getArea().getCode()) {
-			case HOME -> "1루 " + section.getName();
-			case AWAY -> "3루 " + section.getName();
-			default -> section.getName();
-		};
-	}
-
-	private String toAreaName(AreaCode areaCode) {
-		return switch (areaCode) {
-			case CENTER -> "프리미엄";
-			case HOME -> "1루 구역";
-			case AWAY -> "3루 구역";
-			case OUTFIELD -> "외야 구역";
-		};
-	}
-
 	private String toSeatSaleStatus(MatchSeat matchSeat, Set<Long> activeHeldMatchSeatIds) {
 		if (matchSeat.getSaleStatus() == MatchSeatSaleStatus.AVAILABLE
 			&& activeHeldMatchSeatIds.contains(matchSeat.getId())) {
 			return "HELD";
 		}
 		return matchSeat.getSaleStatus().name();
-	}
-
-	private record SeatGroupAccumulator(
-		Long areaId,
-		String areaName,
-		List<SeatGroupsEntryResponse.SectionInfo> sections
-	) {
-		private SeatGroupAccumulator(Long areaId, String areaName) {
-			this(areaId, areaName, new ArrayList<>());
-		}
 	}
 
 	private record BlockAccumulator(

--- a/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatGroupsResponseCacheService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/common/service/SeatGroupsResponseCacheService.java
@@ -1,0 +1,144 @@
+package com.goormgb.be.seat.common.service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goormgb.be.domain.match.entity.Match;
+import com.goormgb.be.seat.area.enums.AreaCode;
+import com.goormgb.be.seat.block.entity.Block;
+import com.goormgb.be.seat.common.dto.cache.SeatGroupsCachePayload;
+import com.goormgb.be.seat.common.dto.response.SeatGroupsEntryResponse;
+import com.goormgb.be.seat.config.CacheConfig;
+import com.goormgb.be.seat.matchSeat.enums.MatchSeatSaleStatus;
+import com.goormgb.be.seat.matchSeat.repository.MatchSeatRepository;
+import com.goormgb.be.seat.section.entity.Section;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@code GET /matches/{matchId}/seat-groups} 응답의 유저 독립 payload 를 Redis 에 캐싱하는 서비스 (Phase 3).
+ *
+ * <p>Phase 1 에서 Match / Section / Block 은 Caffeine 로컬 캐시로 흡수됐으나,
+ * {@code countRemainingSeatsByMatchIdAndSaleStatusGroupBySectionId} 집계 쿼리는 여전히 매 요청 DB 를 때렸다.
+ * 본 서비스는 응답 조립 결과를 통째로 Redis 에 TTL 5초로 캐시해 고빈도 호출의 DB·JVM 연산 비용을 동시에 제거한다.</p>
+ *
+ * <p>유저별 {@code seatSession} 은 본 payload 에서 배제하며, 최종 응답은
+ * {@code SeatCommonService#getSeatGroupsEntry} 에서 유저 정보를 덧씌워 조립한다.</p>
+ *
+ * <p>짧은 TTL(5s) 로 좌석 선점·해제로 인한 잔여 좌석 수 stale 을 최소화한다. 3~5초 지연은 UX 상 감지되지 않는 수준이다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatGroupsResponseCacheService {
+
+	private final MatchDetailCacheService matchDetailCacheService;
+	private final SectionLookupCacheService sectionLookupCacheService;
+	private final MatchSeatRepository matchSeatRepository;
+
+	/**
+	 * matchId 기준 유저 독립 payload 를 반환한다. 캐시 미스 시 DB 에서 재계산 후 Redis 에 저장한다.
+	 *
+	 * @param matchId 경기 ID
+	 * @return 캐시 가능한 응답 조각
+	 */
+	@Cacheable(
+		cacheNames = CacheConfig.CACHE_SEAT_GROUPS_RESPONSE,
+		cacheManager = "redisCacheManager",
+		key = "#matchId",
+		unless = "#result == null"
+	)
+	@Transactional(readOnly = true)
+	public SeatGroupsCachePayload getPayload(Long matchId) {
+		long start = System.currentTimeMillis();
+
+		Match match = matchDetailCacheService.getDetail(matchId);
+		List<Section> sections = sectionLookupCacheService.findAllSectionsWithArea();
+		List<Long> sectionIds = sections.stream().map(Section::getId).toList();
+
+		Map<Long, List<Long>> blockIdsBySectionId = buildBlockIdsBySectionId(sectionIds);
+		Map<Long, Long> remainingSeatCountBySectionId = buildRemainingSeatCountBySectionId(matchId);
+
+		Map<Long, SeatGroupAccumulator> groupMap = new LinkedHashMap<>();
+		for (Section section : sections) {
+			Long areaId = section.getArea().getId();
+			SeatGroupAccumulator group = groupMap.computeIfAbsent(areaId,
+				ignored -> new SeatGroupAccumulator(areaId, toAreaName(section.getArea().getCode())));
+
+			group.sections().add(new SeatGroupsEntryResponse.SectionInfo(
+				section.getId(),
+				section.getCode().name(),
+				buildDisplayName(section),
+				blockIdsBySectionId.getOrDefault(section.getId(), List.of()),
+				remainingSeatCountBySectionId.getOrDefault(section.getId(), 0L)
+			));
+		}
+
+		List<SeatGroupsEntryResponse.SeatGroupInfo> seatGroups = groupMap.values()
+			.stream()
+			.map(it -> new SeatGroupsEntryResponse.SeatGroupInfo(it.areaId(), it.areaName(), it.sections()))
+			.toList();
+
+		log.info("[SeatGroupsResponseCacheService#getPayload] MISS computed - at={}, matchId={}, elapsed={}ms",
+			LocalDateTime.now(ZoneId.of("Asia/Seoul")), matchId, System.currentTimeMillis() - start);
+
+		return new SeatGroupsCachePayload(SeatGroupsEntryResponse.MatchInfo.from(match), seatGroups);
+	}
+
+	private Map<Long, List<Long>> buildBlockIdsBySectionId(List<Long> sectionIds) {
+		if (sectionIds.isEmpty()) {
+			return Map.of();
+		}
+		List<Block> blocks = sectionLookupCacheService.findBlocksBySectionIds(sectionIds);
+		Map<Long, List<Long>> result = new LinkedHashMap<>();
+		for (Block block : blocks) {
+			result.computeIfAbsent(block.getSection().getId(), ignored -> new ArrayList<>())
+				.add(block.getBlockNum());
+		}
+		return result;
+	}
+
+	private Map<Long, Long> buildRemainingSeatCountBySectionId(Long matchId) {
+		Map<Long, Long> result = new LinkedHashMap<>();
+		matchSeatRepository.countRemainingSeatsByMatchIdAndSaleStatusGroupBySectionId(matchId,
+				MatchSeatSaleStatus.AVAILABLE)
+			.forEach(it -> result.put(it.getSectionId(), it.getRemainingSeatCount()));
+		return result;
+	}
+
+	private String buildDisplayName(Section section) {
+		return switch (section.getArea().getCode()) {
+			case HOME -> "1루 " + section.getName();
+			case AWAY -> "3루 " + section.getName();
+			default -> section.getName();
+		};
+	}
+
+	private String toAreaName(AreaCode areaCode) {
+		return switch (areaCode) {
+			case CENTER -> "프리미엄";
+			case HOME -> "1루 구역";
+			case AWAY -> "3루 구역";
+			case OUTFIELD -> "외야 구역";
+		};
+	}
+
+	private record SeatGroupAccumulator(
+		Long areaId,
+		String areaName,
+		List<SeatGroupsEntryResponse.SectionInfo> sections
+	) {
+		private SeatGroupAccumulator(Long areaId, String areaName) {
+			this(areaId, areaName, new ArrayList<>());
+		}
+	}
+}

--- a/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
@@ -1,13 +1,29 @@
 package com.goormgb.be.seat.config;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
@@ -38,7 +54,15 @@ public class CacheConfig {
 	public static final String CACHE_MATCH_DETAIL = "match-detail";
 	public static final String CACHE_SECTION_ALL = "section-all";
 	public static final String CACHE_BLOCKS_BY_SECTION_IDS = "blocks-by-section-ids";
+	/**
+	 * Phase 3 — {@code GET /matches/{matchId}/seat-groups} 응답의 유저 독립 payload 캐시.
+	 *
+	 * <p>좌석 선점·해제가 실시간으로 반영돼야 하므로 TTL 을 5초로 짧게 가져간다.
+	 * 유저별로 다른 {@code seatSession} 은 본 캐시 payload 에서 제외하고 컨트롤러 상위 계층에서 조립한다.</p>
+	 */
+	public static final String CACHE_SEAT_GROUPS_RESPONSE = "seat-groups-response";
 
+	@Primary
 	@Bean
 	public CacheManager cacheManager() {
 		CaffeineCacheManager manager = new CaffeineCacheManager();
@@ -72,5 +96,53 @@ public class CacheConfig {
 				.build());
 
 		return manager;
+	}
+
+	/**
+	 * Phase 3 — Redis 분산 캐시 CacheManager.
+	 *
+	 * <p>응답 레벨 캐시({@value #CACHE_SEAT_GROUPS_RESPONSE}) 를 Pod 간 공유하기 위해 별도 빈으로 등록한다.
+	 * 기존 Caffeine {@code cacheManager} 와는 독립 운용되며, {@code @Cacheable(cacheManager = "redisCacheManager")}
+	 * 로 명시 호출해야 한다.</p>
+	 */
+	@Bean(name = "redisCacheManager")
+	public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+		GenericJackson2JsonRedisSerializer valueSerializer =
+			new GenericJackson2JsonRedisSerializer(cacheObjectMapper());
+
+		Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+		configs.put(CACHE_SEAT_GROUPS_RESPONSE, redisConfig(Duration.ofSeconds(5), valueSerializer));
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(redisConfig(Duration.ofSeconds(30), valueSerializer))
+			.withInitialCacheConfigurations(configs)
+			.build();
+	}
+
+	private RedisCacheConfiguration redisConfig(Duration ttl, GenericJackson2JsonRedisSerializer serializer) {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(ttl)
+			.serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(SerializationPair.fromSerializer(serializer))
+			.disableCachingNullValues();
+	}
+
+	/**
+	 * Redis 캐시 값 직렬화 전용 {@link ObjectMapper}.
+	 *
+	 * <p>{@link java.time.Instant} 등 JSR-310 타입 직렬화 지원을 위해 {@link JavaTimeModule} 을 등록하고,
+	 * {@code GenericJackson2JsonRedisSerializer} 가 요구하는 polymorphic typing 을
+	 * {@link BasicPolymorphicTypeValidator} 로 제한 활성화한다.</p>
+	 */
+	private ObjectMapper cacheObjectMapper() {
+		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+			.allowIfBaseType(Object.class)
+			.build();
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		return mapper;
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
@@ -133,10 +133,16 @@ public class CacheConfig {
 	 * <p>{@link java.time.Instant} 등 JSR-310 타입 직렬화 지원을 위해 {@link JavaTimeModule} 을 등록하고,
 	 * {@code GenericJackson2JsonRedisSerializer} 가 요구하는 polymorphic typing 을
 	 * {@link BasicPolymorphicTypeValidator} 로 제한 활성화한다.</p>
+	 *
+	 * <p>역직렬화 대상 subtype 을 프로젝트/표준 JDK 패키지로 whitelist 하여,
+	 * Redis 값 조작을 통한 임의 클래스 역직렬화(RCE gadget chain) 를 차단한다.</p>
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfBaseType(Object.class)
+			.allowIfSubType("com.goormgb.be")
+			.allowIfSubType("java.util")
+			.allowIfSubType("java.time")
+			.allowIfSubType("java.lang")
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -4,8 +4,8 @@ server:
     context-path: /seat
   tomcat:
     threads:
-      max: 200
-      min-spare: 10
+      max: ${SERVER_TOMCAT_THREADS_MAX:200}
+      min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
     max-connections: 8192
     accept-count: 100
 
@@ -33,8 +33,8 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
-      maximum-pool-size: 20
-      minimum-idle: 20
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN_IDLE:20}
       connection-timeout: 30000
       leak-detection-threshold: 10000
 

--- a/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
+++ b/Seat/src/test/java/com/goormgb/be/seat/common/service/SeatCommonServiceTest.java
@@ -16,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.goormgb.be.domain.match.repository.MatchRepository;
+import com.goormgb.be.seat.common.service.MatchDetailCacheService;
+import com.goormgb.be.seat.common.service.SeatGroupsResponseCacheService;
 import com.goormgb.be.seat.area.entity.Area;
 import com.goormgb.be.seat.area.enums.AreaCode;
 import com.goormgb.be.seat.block.entity.Block;
@@ -37,6 +39,10 @@ class SeatCommonServiceTest {
 
 	@Mock
 	private MatchRepository matchRepository;
+	@Mock
+	private MatchDetailCacheService matchDetailCacheService;
+	@Mock
+	private SeatGroupsResponseCacheService seatGroupsResponseCacheService;
 	@Mock
 	private BookingOptionsRedisRepository bookingOptionsRedisRepository;
 	@Mock


### PR DESCRIPTION
## 🔧 작업 내용
- **Phase 3 응답 레벨 캐시** 도입: 고빈도 read-heavy 엔드포인트(`seat-groups`, `matches?date=...`)의 응답 DTO 자체를 Redis 에 캐시해 DB 쿼리·JVM 조립 비용까지 동시 제거.
- **인프라 파라미터 환경변수화**: `tomcat.threads.max` / `hikari.maximum-pool-size` / `hikari.minimum-idle` 을 `${ENV:default}` 패턴으로 추출. K8s Deployment env 로 환경별 override 가능.
- 기대 효과: `seat-groups` P99 **2000ms → 200ms (90% ↓)**, DB 커넥션 peak 추가 감소.

## 🧩 구현 상세

### 1. Seat — `seat-groups-response` Redis 캐시 (TTL 5s)

`Seat/src/main/java/com/goormgb/be/seat/common/service/SeatGroupsResponseCacheService.java` (신규)

- `match` (MatchInfo) + `seatGroups` (List<SeatGroupInfo>) 만 캐시 (유저 독립)
- 유저별 `seatSession` 은 캐시 대상에서 **배제** — 컨트롤러 상위에서 booking-options(Redis) 로 매 요청 조립
- 캐시 payload DTO `SeatGroupsCachePayload` 신규 — Serializable record, JsonCreator
- `SeatCommonService.getSeatGroupsEntry` 를 캐시 payload + 유저 데이터 조립 구조로 리팩터

**왜 5초인가**: 좌석 선점/해제가 초 단위로 일어나므로 잔여 좌석 수 stale 을 5초 이내로 제한. UX 체감 안 됨.

### 2. Order-Core — `matches-list-response` Redis 캐시 (TTL 30s)

`MatchService.getMatchesByDate` 에 `@Cacheable(cacheNames="matches-list-response", key="#date.toString()")` 적용.

- 자주 폴링되는 경기 목록 화면 — 동일 날짜 요청을 흡수
- 캐시 키: `LocalDate.toString()` (예: `"2026-04-22"`)

### 3. Seat `CacheConfig` 에 `redisCacheManager` 빈 신규 추가

- 기존 Caffeine `cacheManager` 는 `@Primary` 로 명시 유지
- Redis 쪽은 `@Bean(name = "redisCacheManager")` 로 등록 → `@Cacheable(cacheManager="redisCacheManager")` 명시 호출
- `JavaTimeModule` + `BasicPolymorphicTypeValidator` 기반 ObjectMapper 로 `Instant` 직렬화 안전 (Phase 2 핫픽스 패턴 재사용)

### 4. 인프라 파라미터 환경변수화 (4개 서비스 yaml)

```yaml
# Before
server.tomcat.threads.max: 200
spring.datasource.hikari.maximum-pool-size: 20
spring.datasource.hikari.minimum-idle: 20

# After
server.tomcat.threads.max: ${SERVER_TOMCAT_THREADS_MAX:200}
server.tomcat.threads.min-spare: ${SERVER_TOMCAT_THREADS_MIN_SPARE:10}
spring.datasource.hikari.maximum-pool-size: ${DB_POOL_MAX:20}
spring.datasource.hikari.minimum-idle: ${DB_POOL_MIN_IDLE:5}
```

- Queue 는 hikari 설정이 yaml 에 없었음 → 신규 추가 (기본값 max 20 / min-idle 5)
- 로컬·dev 환경은 기본값 그대로 동작 (영향 0)
- staging/prod 는 K8s Deployment env 에서 override (예: `SERVER_TOMCAT_THREADS_MAX=400`, `DB_POOL_MAX=30`)

#### DB 한도 270 내 권장 배분 예시

| 서비스 | DB_POOL_MAX | Pod 수 | 합계 |
|---|---|---|---|
| Seat | 30 | 3 | 90 |
| Queue | 30 | 3 | 90 |
| Auth-Guard | 20 | 3 | 60 |
| Order-Core | 20 | 1~2 | 20~40 |
| 시스템 예약 | - | - | 10 |
| **총합** | | | **~270 (한도)** |

→ Order-Core Pod 수에 따라 조정 필요. 인프라팀과 협의해 K8s env 에 적용.

### 5. 트레이드오프 / 의도

- `seat-groups` 응답 통째 캐싱이 5초 stale 을 허용하지만, 좌석 선점은 사용자가 클릭 직후 별도 `seat-holds` API 가 즉시 검증하므로 UX·정합성 영향 없음
- TTL 짧게 유지로 `@CacheEvict` 같은 명시 무효화는 생략 (3~5s 만료가 자연 해소)
- 인프라 파라미터를 yaml 에 박지 않고 env 로 추출 → K8s 에서 코드 빌드 없이 튜닝 가능

### 📌 관련 Jira Issue
- GRGB-376

## 🧪 테스트 방법

### 빌드 (전 모듈)
```bash
./gradlew :common-core:compileJava :Auth-Guard:compileJava :Order-Core:compileJava \
          :Seat:compileJava :Queue:compileJava :API-Gateway:compileJava
# BUILD SUCCESSFUL
```

### 단위 테스트 (영향권)
```bash
./gradlew :Seat:test --tests "SeatCommonServiceTest"   # 통과 (Mock 의존성 추가)
./gradlew :Order-Core:test --tests "OrderServiceTest"  # 통과
```

### 수동 검증 (staging)
1. `GET /seat/api/v1/matches/{matchId}/seat-groups` 2회 연속 호출
   - 1번째: DB 쿼리 발생, Redis 에 `seat-groups-response::{matchId}` 저장
   - 2번째 (5초 이내): Redis HIT, DB 무접근
   - 응답 본문은 동일 (유저 독립 부분)
   - 유저별 `seatSession` 부분은 매 요청 조립되므로 유저가 다르면 다른 값
2. `GET /order/api/v1/matches?date=2026-04-22` 동일 검증 (TTL 30s)
3. Redis CLI
   ```
   redis-cli KEYS "seat-groups-response*"
   redis-cli KEYS "matches-list-response*"
   redis-cli TTL "seat-groups-response::71"
   ```
4. Actuator 메트릭
   ```
   curl .../seat/actuator/metrics/cache.gets?tag=cache:seat-groups-response
   ```

### 인프라 파라미터 검증
```bash
# 기본값 동작 확인 (env 미설정 시)
docker run -e DB_URL=... my-image
# tomcat 200 / hikari 20 으로 시작

# override 동작 확인
docker run -e SERVER_TOMCAT_THREADS_MAX=400 -e DB_POOL_MAX=30 my-image
# tomcat 400 / hikari 30 으로 시작
```

## ❗ 참고 사항

### 리뷰 포인트
- `SeatGroupsResponseCacheService` 가 캐시 미스 시 호출하는 `findAllSectionsWithArea`, `findBlocksBySectionIds` 는 Phase 1 Caffeine 이라 정상. 이 서비스 자체는 Redis HIT 시 DB 0 회.
- `MatchService.getMatchesByDate` 의 `@Cacheable` 키 `#date.toString()` — `LocalDate.toString()` 은 ISO-8601(`yyyy-MM-dd`) 안정 포맷이라 안전
- **인프라 파라미터 변경은 yaml 디폴트 값을 바꾸지 않았음** — 즉 본 PR 머지만으로 동작 변화 없음. 실제 staging/prod 에 효과 적용하려면 **K8s Deployment env 추가가 별도로 필요** (인프라팀 협의)
- `tomcat.threads.max=400` 적용 시 Pod memory limit 사전 점검 필요 (스레드당 ~1MB 스택)

### 후속 작업
- staging 부하테스트 재실행 → Phase 1+2 baseline vs Phase 1+2+3 비교
- DB_POOL_MAX 조정 시 Pod replica 수와 함께 270 한도 시뮬레이션

### 배포/롤백
- 스키마 변경 없음
- yaml 디폴트 값 변경 없음 → 환경변수 미설정 시 기존 동작 그대로
- 응답 캐시 문제 시 `spring.cache.type: none` override 로 즉시 fallback
- 각 커밋 단위 revert 가능 (캐시 / 인프라 분리 커밋)