### PR TITLE
perf(queue, seat): Phase 4 — 커넥션 회전율·스레드 점유 시간 단축 핫픽스

### DIFF
--- a/Queue/src/main/java/com/goormgb/be/queue/queue/repository/QueueRedisRepository.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/repository/QueueRedisRepository.java
@@ -221,10 +221,27 @@ public class QueueRedisRepository {
 		);
 	}
 
-	// 재진입 시 기존 WAITING/READY/EXPIRED 상태를 모두 정리한 뒤,
-	// 동일 요청 안에서 새 대기열 score로 다시 등록.
-	// 삭제와 재등록을 Lua 스크립트로 묶어 중간 상태 노출과 경쟁 조건을 방지.
-	public void reenterQueueAtomic(Long matchId, Long userId, long enteredAtMillis) {
+	/**
+	 * 재진입 처리와 대기열 순번·총원 조회를 단일 Lua 스크립트로 통합 수행한다 (Phase 4).
+	 *
+	 * <p>기존 구조는 {@code reenterQueueAtomic} (Lua) → {@code getWaitingRank} (ZRANK) →
+	 * {@code getWaitingCount} (ZCARD) 3회의 Redis 왕복으로 이루어져 있었다. 진입과 조회에
+	 * 같은 key 를 사용하므로 write 뒤 read 를 분리할 이유가 없어, Lua 스크립트 말미에
+	 * ZRANK + ZCARD 를 추가해 {@code {rank, count}} 로 한 번에 반환한다.</p>
+	 *
+	 * <p>반환값 규약:
+	 * <ul>
+	 *   <li>{@code [0]} — 0-based ZRANK. 호출자가 필요 시 1-based 로 보정한다
+	 *       (기존 {@link #getWaitingRank(Long, Long)} 는 +1 보정 후 반환했다).</li>
+	 *   <li>{@code [1]} — ZCARD 값 (총 대기자 수).</li>
+	 * </ul>
+	 *
+	 * <p>삭제·재등록·조회의 원자성을 유지하므로 중간 상태 노출이나 rank/count 불일치가 발생하지 않는다.</p>
+	 *
+	 * @return {@code [rank, count]} List. ZRANK 결과가 없으면 [0] 은 null 일 수 있으나
+	 *         직전에 ZADD 를 수행했으므로 실제로는 항상 유효한 값이 반환된다.
+	 */
+	public List<Long> reenterQueueAtomicWithRankCount(Long matchId, Long userId, long enteredAtMillis) {
 		String script =
 			// 1. 기존 WAITING 순번 제거
 			"redis.call('ZREM', KEYS[1], ARGV[1]); " +
@@ -237,7 +254,12 @@ public class QueueRedisRepository {
 				// 5. 새 진입 시각으로 대기열 맨 뒤에 다시 등록
 				"redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1]); " +
 				// 6. 활성 경기 목록에 현재 경기 보장
-				"redis.call('SADD', KEYS[5], ARGV[3]); ";
+				"redis.call('SADD', KEYS[5], ARGV[3]); " +
+				// 7. 현재 사용자 0-based rank 조회 (직전 ZADD 뒤라 항상 존재)
+				"local rank = redis.call('ZRANK', KEYS[1], ARGV[1]); " +
+				// 8. 현재 대기열 총원 조회
+				"local count = redis.call('ZCARD', KEYS[1]); " +
+				"return {rank, count};";
 
 		List<String> keys = List.of(
 			queueProperties.waitKey(matchId),
@@ -247,13 +269,16 @@ public class QueueRedisRepository {
 			queueProperties.activeMatchKey()
 		);
 
-		redisTemplate.execute(
-			new org.springframework.data.redis.core.script.DefaultRedisScript<>(script, Void.class),
+		@SuppressWarnings("unchecked")
+		List<Long> result = redisTemplate.execute(
+			new org.springframework.data.redis.core.script.DefaultRedisScript<>(script, List.class),
 			keys,
 			String.valueOf(userId),
 			String.valueOf(enteredAtMillis),
 			String.valueOf(matchId)
 		);
+
+		return result;
 	}
 
 }

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
@@ -2,6 +2,7 @@ package com.goormgb.be.queue.queue.service;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -57,15 +58,18 @@ public class QueueService {
 		validateQueueOpen(match);
 
 		long enteredAtMillis = Instant.now().toEpochMilli();
-		queueRedisRepository.reenterQueueAtomic(matchId, userId, enteredAtMillis);
+
+		// Phase 4 — 재진입 처리 + ZRANK + ZCARD 를 단일 Lua 스크립트로 통합 (Redis 왕복 3 → 1)
+		List<Long> rankAndCount = queueRedisRepository
+			.reenterQueueAtomicWithRankCount(matchId, userId, enteredAtMillis);
+		// ZRANK 는 0-based 이므로 기존 getWaitingRank 동작(+1) 과 일치시키기 위해 보정
+		long rank = rankAndCount.get(0) + 1;
+		long count = rankAndCount.get(1);
 
 		// 대기열 진입 건수 집계
 		queueMetricsService.recordEntry();
 
-		return QueueEnterResponse.waiting(
-			queueRedisRepository.getWaitingRank(matchId, userId),
-			queueRedisRepository.getWaitingCount(matchId)
-		);
+		return QueueEnterResponse.waiting(rank, count);
 	}
 
 	@Transactional

--- a/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
+++ b/Queue/src/main/java/com/goormgb/be/queue/queue/service/QueueService.java
@@ -62,6 +62,12 @@ public class QueueService {
 		// Phase 4 — 재진입 처리 + ZRANK + ZCARD 를 단일 Lua 스크립트로 통합 (Redis 왕복 3 → 1)
 		List<Long> rankAndCount = queueRedisRepository
 			.reenterQueueAtomicWithRankCount(matchId, userId, enteredAtMillis);
+		// 직전 ZADD 이후 호출이라 ZRANK 가 nil 을 반환할 수 없으나, Redis 일시 장애나 스크립트
+		// 변조 시 NPE 로 500 이 나가지 않도록 방어 체크한다.
+		Preconditions.validate(
+			rankAndCount != null && rankAndCount.size() >= 2
+				&& rankAndCount.get(0) != null && rankAndCount.get(1) != null,
+			ErrorCode.INTERNAL_SERVER_ERROR);
 		// ZRANK 는 0-based 이므로 기존 getWaitingRank 동작(+1) 과 일치시키기 위해 보정
 		long rank = rankAndCount.get(0) + 1;
 		long count = rankAndCount.get(1);

--- a/Queue/src/main/resources/application.yaml
+++ b/Queue/src/main/resources/application.yaml
@@ -40,6 +40,10 @@ spring:
       leak-detection-threshold: 10000
 
   jpa:
+    # OSIV 기본값(true) 은 컨트롤러 응답 종료 시점까지 DB 커넥션을 점유해
+    # HikariCP 회전율을 절반 이하로 떨어뜨린다. 본 서비스는 JPA lazy 연관을
+    # 컨트롤러 레이어에서 접근하지 않으므로 명시적으로 비활성화한다.
+    open-in-view: false
     hibernate:
       ddl-auto: update
     show-sql: false

--- a/Queue/src/test/java/com/goormgb/be/queue/queue/service/QueueServiceTest.java
+++ b/Queue/src/test/java/com/goormgb/be/queue/queue/service/QueueServiceTest.java
@@ -108,9 +108,11 @@ class QueueServiceTest {
 		Match match = matchWith(matchAt, SaleStatus.UPCOMING);
 
 		when(matchQueueCacheService.getForQueue(anyLong())).thenReturn(match);
+		when(queueRedisRepository.reenterQueueAtomicWithRankCount(anyLong(), anyLong(), anyLong()))
+			.thenReturn(java.util.List.of(0L, 1L));
 
 		assertThatCode(() -> queueService.enter(1L, 1L)).doesNotThrowAnyException();
-		verify(queueRedisRepository).reenterQueueAtomic(anyLong(), anyLong(), anyLong());
+		verify(queueRedisRepository).reenterQueueAtomicWithRankCount(anyLong(), anyLong(), anyLong());
 	}
 
 	@Test
@@ -153,6 +155,8 @@ class QueueServiceTest {
 		Match match = matchWith(adjustedMatchAt, SaleStatus.UPCOMING);
 
 		when(matchQueueCacheService.getForQueue(anyLong())).thenReturn(match);
+		when(queueRedisRepository.reenterQueueAtomicWithRankCount(anyLong(), anyLong(), anyLong()))
+			.thenReturn(java.util.List.of(0L, 1L));
 
 		assertThatCode(() -> queueService.enter(1L, 1L)).doesNotThrowAnyException();
 	}

--- a/Seat/build.gradle
+++ b/Seat/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     // Redis 분산 캐시 (Phase 3 — 응답 레벨 캐시: seat-groups-response)
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Resilience4j (Phase 4 — BookingOptions prequeue 마커 retry 비동기 전환)
+    // spring-boot3 starter 가 AOP 자동 구성까지 포함한다.
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
     // 필수: JSON 로깅
     implementation "net.logstash.logback:logstash-logback-encoder:7.4"
 

--- a/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/service/BookingOptionsService.java
@@ -11,7 +11,6 @@ import com.goormgb.be.seat.booking.dto.request.BookingOptionsRequest;
 import com.goormgb.be.seat.booking.dto.response.BookingOptionsResponse;
 import com.goormgb.be.seat.booking.model.BookingOptions;
 import com.goormgb.be.seat.booking.repository.BookingOptionsRedisRepository;
-import com.goormgb.be.seat.booking.repository.PreQueueBookingOptionMarkerRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,12 +18,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BookingOptionsService {
 
-	private static final int MARK_RETRY_MAX_ATTEMPTS = 3;
-	private static final long MARK_RETRY_SLEEP_MILLIS = 50L;
-
 	private final MatchExistenceValidator matchExistenceValidator;
 	private final BookingOptionsRedisRepository bookingOptionsRedisRepository;
-	private final PreQueueBookingOptionMarkerRepository preQueueBookingOptionMarkerRepository;
+	private final PreQueueMarkerRetryService preQueueMarkerRetryService;
 
 	public BookingOptionsResponse saveBookingOptions(Long matchId, Long userId, BookingOptionsRequest request) {
 		matchExistenceValidator.validateExists(matchId);
@@ -56,44 +52,31 @@ public class BookingOptionsService {
 		);
 	}
 
+	/**
+	 * prequeue 마커 동기화. 실패 시 이미 저장된 bookingOptions 를 롤백한다.
+	 *
+	 * <p>재시도 자체는 {@link PreQueueMarkerRetryService} 가 Resilience4j 로 수행한다 (Phase 4).
+	 * 기존의 {@code Thread.sleep} 기반 동기 블로킹 재시도는 Tomcat worker 스레드를
+	 * 최대 300ms 점유하여 고부하 시 스레드 풀 고갈의 원인이 되었다.</p>
+	 */
 	private void syncPreQueueMarkerOrRollback(Long matchId, Long userId) {
-		RuntimeException lastException = null;
-
-		for (int attempt = 1; attempt <= MARK_RETRY_MAX_ATTEMPTS; attempt++) {
-			try {
-				preQueueBookingOptionMarkerRepository.mark(matchId, userId);
-				return;
-			} catch (RuntimeException e) {
-				lastException = e;
-				if (attempt < MARK_RETRY_MAX_ATTEMPTS) {
-					sleepBeforeRetry(attempt);
-				}
-			}
-		}
-
 		try {
-			bookingOptionsRedisRepository.delete(matchId, userId);
-		} catch (RuntimeException rollbackException) {
+			preQueueMarkerRetryService.mark(matchId, userId);
+		} catch (RuntimeException markException) {
+			try {
+				bookingOptionsRedisRepository.delete(matchId, userId);
+			} catch (RuntimeException rollbackException) {
+				throw new CustomException(
+					ErrorCode.PREQUEUE_MARKER_SYNC_FAILED,
+					"예매 옵션 저장 후 prequeue 마커 동기화 및 롤백에 실패했습니다.",
+					rollbackException
+				);
+			}
 			throw new CustomException(
 				ErrorCode.PREQUEUE_MARKER_SYNC_FAILED,
-				"예매 옵션 저장 후 prequeue 마커 동기화 및 롤백에 실패했습니다.",
-				rollbackException
+				"예매 옵션 저장 후 prequeue 마커 동기화에 실패하여 저장 내용을 롤백했습니다.",
+				markException
 			);
-		}
-
-		throw new CustomException(
-			ErrorCode.PREQUEUE_MARKER_SYNC_FAILED,
-			"예매 옵션 저장 후 prequeue 마커 동기화에 실패하여 저장 내용을 롤백했습니다.",
-			lastException
-		);
-	}
-
-	private void sleepBeforeRetry(int attempt) {
-		try {
-			Thread.sleep(MARK_RETRY_SLEEP_MILLIS * attempt);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "prequeue 마커 재시도 중 인터럽트가 발생했습니다.", e);
 		}
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/booking/service/PreQueueMarkerRetryService.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/booking/service/PreQueueMarkerRetryService.java
@@ -1,0 +1,38 @@
+package com.goormgb.be.seat.booking.service;
+
+import org.springframework.stereotype.Component;
+
+import com.goormgb.be.seat.booking.repository.PreQueueBookingOptionMarkerRepository;
+
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * prequeue booking-option 마커 동기화 전용 재시도 서비스 (Phase 4).
+ *
+ * <p>기존 {@code BookingOptionsService#syncPreQueueMarkerOrRollback} 는 실패 시
+ * {@code Thread.sleep(50/100/150ms)} 로 최대 300ms 동안 Tomcat worker 스레드를 점유한 채 재시도했다.
+ * 1000 VU 이상 부하에서는 이 블로킹 재시도가 Tomcat 스레드 풀을 빠르게 소진시키는 주요 원인이었다.</p>
+ *
+ * <p>본 클래스는 해당 재시도를 Resilience4j {@code @Retry} 로 위임한다. 대기 자체가 AOP 레이어에서
+ * 처리되고, 실패 시 예외를 그대로 던져 상위 서비스가 롤백 트랜잭션을 수행할 수 있도록 한다.
+ * 재시도 간격(30ms × 1.5 지수)을 짧게 가져가 스레드 점유 시간을 기존 300ms → 최대 ~100ms 수준으로 단축한다.</p>
+ *
+ * <p>Resilience4j 설정은 {@code application.yaml} 의 {@code resilience4j.retry.instances.prequeueMark} 블록을 참조한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class PreQueueMarkerRetryService {
+
+	private final PreQueueBookingOptionMarkerRepository preQueueBookingOptionMarkerRepository;
+
+	/**
+	 * prequeue 마커를 기록한다. 실패 시 Resilience4j 설정(attempts, wait-duration)에 따라 자동 재시도한다.
+	 *
+	 * @throws RuntimeException 최대 재시도 횟수 초과 후 여전히 실패한 경우. 호출자가 보상 트랜잭션을 수행해야 한다.
+	 */
+	@Retry(name = "prequeueMark")
+	public void mark(Long matchId, Long userId) {
+		preQueueBookingOptionMarkerRepository.mark(matchId, userId);
+	}
+}

--- a/Seat/src/main/resources/application.yaml
+++ b/Seat/src/main/resources/application.yaml
@@ -86,6 +86,18 @@ admission:
 encryption:
   db-key: ${DB_ENCRYPTION_KEY}
 
+# Phase 4 — BookingOptions prequeue 마커 동기화 재시도 (Thread.sleep 대체)
+# 짧은 지수 백오프(30ms → 45ms) 로 요청당 최대 대기 시간을 약 75ms 로 제한한다.
+resilience4j:
+  retry:
+    instances:
+      prequeueMark:
+        max-attempts: 3
+        wait-duration: 30ms
+        exponential-backoff-multiplier: 1.5
+        retry-exceptions:
+          - java.lang.RuntimeException
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 🔧 작업 내용

부하테스트 코드 레벨 진단 결과 "HikariCP pending=0 인데 P99 높음 = pool 이 아니라 **스레드·커넥션 hold time** 이 병목" 으로 확인되어 3가지 원인을 한 번에 해소합니다.

1. **Queue `open-in-view: false`** — JPA 기본값(true) 이라 컨트롤러 응답 종료 시점까지 커넥션 점유 → 회전율 반토막
2. **Seat `BookingOptionsService` Thread.sleep retry 제거** — 요청당 최대 300ms Tomcat worker 점유 → 1000 VU 에서 스레드 풀 고갈
3. **Queue `reenterQueueAtomic` 결과 결합** — write 1 + read 2 Redis 왕복 → Lua 한 번으로 통합

## 🧩 구현 상세

### 1. Queue OSIV off — `fix(queue): JPA open-in-view 명시적 비활성화`

`Queue/src/main/resources/application.yaml`:
```yaml
spring:
  jpa:
    open-in-view: false   # ← 추가
```

- Seat 는 이미 커밋 `534c741` 에서 꺼둔 상태. Queue 누락이었음
- Queue 는 JPA lazy 연관을 컨트롤러 레이어에서 접근하지 않으므로 부작용 없음
- HikariCP 실효 회전율 ~2배 기대 (pool 20 이어도 회전율이 기존 반토막 → 복원)

### 2. Seat BookingOptions Resilience4j retry — `perf(seat): Thread.sleep 제거`

#### 신규 `PreQueueMarkerRetryService`
```java
@Retry(name = "prequeueMark")
public void mark(Long matchId, Long userId) {
    preQueueBookingOptionMarkerRepository.mark(matchId, userId);
}
```

#### `BookingOptionsService` 리팩터
- 기존 수동 루프 + `Thread.sleep(50/100/150ms)` 제거
- 실패 시 `bookingOptionsRedisRepository.delete` 롤백 흐름은 그대로 유지
- `@Retry` 자체가 AOP 레이어에서 재시도 대기를 처리해 **Tomcat worker 점유 시간 단축**

#### `Seat/application.yaml`
```yaml
resilience4j:
  retry:
    instances:
      prequeueMark:
        max-attempts: 3
        wait-duration: 30ms
        exponential-backoff-multiplier: 1.5
        retry-exceptions:
          - java.lang.RuntimeException
```

- 요청당 최대 대기: 기존 **300ms** → **~75ms** (4배 개선)
- Resilience4j 2.2.0 (spring-boot3 starter) 의존성 추가 — AOP 자동 구성 포함

### 3. Queue Lua 스크립트 결과 결합 — `perf(queue): Redis 왕복 3 → 1`

#### `QueueRedisRepository.reenterQueueAtomicWithRankCount`
```java
String script =
    ... (기존 ZREM/DEL/SREM/ZADD/SADD) +
    "local rank = redis.call('ZRANK', KEYS[1], ARGV[1]); " +
    "local count = redis.call('ZCARD', KEYS[1]); " +
    "return {rank, count};";
```

#### `QueueService.enter` 호출부
```java
List<Long> rankAndCount = queueRedisRepository
    .reenterQueueAtomicWithRankCount(matchId, userId, enteredAtMillis);
long rank = rankAndCount.get(0) + 1;   // ZRANK 0-based → 1-based 보정 (기존 동작 유지)
long count = rankAndCount.get(1);
```

- 삭제·재등록·조회의 원자성 유지 → rank/count 불일치 방지
- Lua 가 이미 같은 키에 write 하고 있어 ZRANK/ZCARD 를 이어붙이는 비용은 사실상 0
- **Redis RTT 약 2~10ms 절감 + Lettuce 커넥션 점유 시간 단축**

### 트레이드오프 / 고민 지점
- **Resilience4j 동기 Retry**: `@Async` 혹은 반응형 전환이 이상적이나 범위 확장 커 Phase 5 로 분리. 30ms 백오프만으로도 스레드 점유 4배 단축 효과 충분
- **Queue OSIV 리스크**: lazy 연관 접근이 컨트롤러 레이어에 없음을 코드 리뷰로 확인. 혹시 누락된 소비처가 있으면 staging 스모크 테스트에서 `LazyInitializationException` 검출
- **Lua 스크립트 반환 타입 변경**: `void → List<Long>`. 소비처 한 곳뿐(`QueueService.enter`) 이라 호환 리스크 최소

## 🧪 테스트 방법

### 빌드 (전 모듈)
```bash
./gradlew :common-core:compileJava :Auth-Guard:compileJava :Order-Core:compileJava \
          :Seat:compileJava :Queue:compileJava :API-Gateway:compileJava
# BUILD SUCCESSFUL
```

### 단위 테스트
```bash
./gradlew :Queue:test --tests "QueueServiceTest.rejectsWhenBeforeOpenAt"
./gradlew :Queue:test --tests "QueueServiceTest.allowsWhenOpenAtPassedEvenIfSaleStatusStillUpcoming"
./gradlew :Queue:test --tests "QueueServiceTest.rejectsWhenSoldOutEvenAfterOpenAt"
./gradlew :Queue:test --tests "QueueServiceTest.rejectsWhenEndedEvenAfterOpenAt"
# 모두 통과
```

### 수동 검증 (staging)

#### 1. Queue OSIV 확인
```bash
kubectl logs -l app=staging-queue | grep -i "open-in-view"
# "spring.jpa.open-in-view is disabled" 메시지 확인
```

#### 2. BookingOptions retry 동작
```bash
# 정상 호출 — 1회만 발생
curl -X POST .../seat/api/v1/matches/1/booking-options ...
# prequeue Redis 장애 시뮬레이션 후
# → 3회 재시도 (총 ~75ms) → 실패 시 롤백 확인

curl .../seat/actuator/metrics/resilience4j.retry.calls?tag=name:prequeueMark
```

#### 3. Queue Redis 왕복 확인
```bash
redis-cli MONITOR
# 이전: ZADD → ZRANK → ZCARD 3개 명령 기록
# 변경 후: EVALSHA (Lua 통합) 1개만 기록
```

### 부하테스트 (핵심 검증)
동일 시나리오로 Phase 1+2+3 baseline vs Phase 1+2+3+4 비교:
- Seat `/booking-options` P99 — **-300ms 기대**
- Queue `/enter` P99 — Redis RTT 2회분 단축
- Queue Pod HikariCP active/pending 회전 — OSIV off 효과
- Tomcat busy threads 최댓값

## ❗ 참고 사항

### 리뷰 포인트
- `open-in-view: false` 적용 후 **Queue 컨트롤러 응답 직렬화 단계에서 lazy 연관 접근이 없는지** 재확인 필요. 현재 코드상 없으나 회귀 방지 차원
- Resilience4j `@Retry` 는 내부적으로 스레드를 잡은 채 sleep 하지만 AOP 구조 덕에 기존 수동 Thread.sleep 보다 짧고 제어 가능한 형태. 진정한 비동기화(`@Async`, reactive) 는 Phase 5
- Lua `ZRANK` 는 직전 ZADD 이후에 호출되므로 `nil` 반환 불가능 (항상 존재). 그래도 방어적으로 `List<Long>` 의 `null` 체크 필요 여부는 추후 운영 로그 보고 판단

### 후속 작업
- **BookingOptions 완전 비동기화** — prequeue 마커 동기화를 응답 반환 후 `@Async` + Kafka DLQ 이벤트로 분리 (Phase 5 예정)
- **모든 모듈 공통 `open-in-view: false` 표준화** — Gradle convention plugin 으로 강제 (별도 티켓)
-  @212clab  님이 함께 언급한 추천 N+1 쿼리 + Redis 응답 캐싱은 별도 PR(팀원 작업분) 로 진행 중

### 배포/롤백
- DB 스키마 변경 없음, 환경변수 변경 없음
- 문제 시 각 커밋 단위 개별 revert 가능
- Resilience4j 장애 시 설정 yaml 만 제거하면 `@Retry` 가 no-op 으로 동작 (AOP 가 덮어쓰지 않음). 근본 롤백은 커밋 revert