### PR TITLE
fix(auth-guard, order-core, seat): Redis 캐시 PolymorphicTypeValidator 범위 원복 [GRGB-376]

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
@@ -85,10 +85,7 @@ public class CacheConfig {
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfSubType("com.goormgb.be")
-			.allowIfSubType("java.util")
-			.allowIfSubType("java.time")
-			.allowIfSubType("java.lang")
+			.allowIfBaseType(Object.class)
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -107,10 +107,7 @@ public class CacheConfig {
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfSubType("com.goormgb.be")
-			.allowIfSubType("java.util")
-			.allowIfSubType("java.time")
-			.allowIfSubType("java.lang")
+			.allowIfBaseType(Object.class)
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
@@ -139,10 +139,7 @@ public class CacheConfig {
 	 */
 	private ObjectMapper cacheObjectMapper() {
 		PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
-			.allowIfSubType("com.goormgb.be")
-			.allowIfSubType("java.util")
-			.allowIfSubType("java.time")
-			.allowIfSubType("java.lang")
+			.allowIfBaseType(Object.class)
 			.build();
 
 		ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
- 3개 모듈 CacheConfig 의 Jackson PolymorphicTypeValidator 를 allowIfSubType 기반 패키지 whitelist → allowIfBaseType(Object.class) 로 원복
- dev 환경에서 Phase 3 배포(75b2e3c) 이후 /auth/me, /matches?date=, /seat-groups 응답에서 GenericJackson2JsonRedisSerializer 역직렬화가 "missing type id property '@class'" 로 실패하던 문제 해소
- record 기반 응답 DTO + NON_FINAL default typing 조합에서 좁혀진 whitelist 가 nested 필드의 @class 힌트 누락을 유발하던 것을 확인
- RCE gadget chain 방어 목적의 whitelist 좁히기는 별도 티켓으로 재설계 예정

refs: GRGB-376