### PR TITLE
fix(auth-guard, order-core, seat): Redis 캐시 DefaultTyping 을 EVERYTHING 으로 전환

### DIFF
--- a/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
+++ b/Auth-Guard/src/main/java/com/goormgb/be/authguard/config/CacheConfig.java
@@ -91,7 +91,7 @@ public class CacheConfig {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(new JavaTimeModule());
 		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.EVERYTHING, JsonTypeInfo.As.PROPERTY);
 		return mapper;
 	}
 }

--- a/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
+++ b/Order-Core/src/main/java/com/goormgb/be/ordercore/config/CacheConfig.java
@@ -113,7 +113,7 @@ public class CacheConfig {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(new JavaTimeModule());
 		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.EVERYTHING, JsonTypeInfo.As.PROPERTY);
 		return mapper;
 	}
 }

--- a/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
+++ b/Seat/src/main/java/com/goormgb/be/seat/config/CacheConfig.java
@@ -145,7 +145,7 @@ public class CacheConfig {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModule(new JavaTimeModule());
 		mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+		mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.EVERYTHING, JsonTypeInfo.As.PROPERTY);
 		return mapper;
 	}
 }


### PR DESCRIPTION
- 3개 모듈 CacheConfig.cacheObjectMapper 의 activateDefaultTyping 을 NON_FINAL → EVERYTHING 으로 변경
- 응답/캐시 DTO 가 Java record(implicit final) 기반이라 NON_FINAL 에서는 nested 위치의 @class 힌트가 누락돼 GenericJackson2JsonRedisSerializer 역직렬화가 "missing type id property '@class'" 로 실패하던 문제 해소
- EVERYTHING 은 final 타입에도 @class 를 기록해 record 구조와 무관하게 read/write 포맷이 일관되게 유지됨
- /auth/me, /matches?date=, /seat-groups 500 에러 복구